### PR TITLE
Changed sync stdin to async stdin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn run() -> Result<(), Error> {
                     .with_context(|_| "Interactive mode requires a connected terminal")?
             };
             let mut app = TerminalApp::initialize(&mut terminal, walk_options, paths_from(input)?)?;
-            app.process_events(&mut terminal, io::stdin().keys())?
+            app.process_events(&mut terminal, termion::async_stdin().keys())?
         }
         Some(Aggregate {
             input,


### PR DESCRIPTION
This simple fix should allow readying user input while traversing the filesystem. I haven't tested it though!