### PR TITLE
error formatting suggestions

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -118,7 +118,11 @@ fn write_path<C: fmt::Display>(
         if num_errors == 0 {
             Cow::Borrowed("")
         } else {
-            Cow::Owned(format!("\t<{} IO Error(s)>", num_errors))
+            Cow::Owned(format!(
+                "  <{} IO Error{}>",
+                num_errors,
+                if num_errors > 1 { "s" } else { "" }
+            ))
         },
         byte_color = options.color.display(color::Fg(color::Green)),
         byte_color_reset = options.color.display(color::Fg(color::Reset)),


### PR DESCRIPTION
We can avoid the `(s)` by inspecting the number. And using spaces instead of tabs makes the output more consistent in a terminal, no longer depending on the length of the preceding filename.