### PR TITLE
Fix color scheme for light terminals

### DIFF
--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -160,15 +160,14 @@ impl TerminalApp {
     }
 
     pub fn mark_entry(&mut self, advance_cursor: bool) {
-        match (self.state.selected, self.window.mark_pane.take()) {
-            (Some(index), Some(pane)) => {
-                self.window.mark_pane = pane.toggle_index(index, &self.traversal.tree);
-            }
-            (Some(index), None) => {
+        if let Some(index) = self.state.selected {
+            let is_dir = self.state.entries.iter().find(|e| e.index == index).unwrap().is_dir;
+            if let Some(pane) = self.window.mark_pane.take() {
+                self.window.mark_pane = pane.toggle_index(index, &self.traversal.tree, is_dir);
+            } else {
                 self.window.mark_pane =
-                    MarkPane::default().toggle_index(index, &self.traversal.tree)
+                    MarkPane::default().toggle_index(index, &self.traversal.tree, is_dir)
             }
-            _ => {}
         };
         if advance_cursor {
             self.change_entry_selection(CursorDirection::Down)

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -161,7 +161,13 @@ impl TerminalApp {
 
     pub fn mark_entry(&mut self, advance_cursor: bool) {
         if let Some(index) = self.state.selected {
-            let is_dir = self.state.entries.iter().find(|e| e.index == index).unwrap().is_dir;
+            let is_dir = self
+                .state
+                .entries
+                .iter()
+                .find(|e| e.index == index)
+                .unwrap()
+                .is_dir;
             if let Some(pane) = self.window.mark_pane.take() {
                 self.window.mark_pane = pane.toggle_index(index, &self.traversal.tree, is_dir);
             } else {

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -1,8 +1,6 @@
 use crate::interactive::{
     path_of,
-    widgets::{
-        get_name_color, EntryMarkMap,
-    },
+    widgets::{entry_color, EntryMarkMap},
     DisplayOptions, EntryDataBundle,
 };
 use dua::traverse::{Tree, TreeIndex};
@@ -11,7 +9,7 @@ use std::{borrow::Borrow, path::Path};
 use tui::{
     buffer::Buffer,
     layout::Rect,
-    style::{Color, Style, Modifier},
+    style::{Color, Modifier, Style},
     widgets::{Block, Borders, Text},
 };
 use tui_react::{fill_background_to_right, List, ListProps};
@@ -147,10 +145,10 @@ impl Entries {
                             // non-existing - always red!
                             Color::Red
                         } else {
-                            get_name_color(style.fg, !is_dir, is_marked)
+                            entry_color(style.fg, !is_dir, is_marked)
                         };
                         Style { fg, ..style }
-                    }
+                    },
                 );
                 vec![bytes, percentage, name]
             },

--- a/src/interactive/widgets/footer.rs
+++ b/src/interactive/widgets/footer.rs
@@ -26,8 +26,6 @@ impl Footer {
             message,
         } = props.borrow();
 
-        let bg_color = Color::White;
-        let text_color = Color::Black;
         let lines = [
             Text::Raw(
                 format!(
@@ -46,7 +44,7 @@ impl Footer {
                     m.into(),
                     Style {
                         fg: Color::Red,
-                        bg: bg_color,
+                        bg: Color::Reset,
                         modifier: Modifier::BOLD | Modifier::RAPID_BLINK,
                     },
                 )
@@ -54,8 +52,7 @@ impl Footer {
         ];
         Paragraph::new(lines.iter().filter_map(|x| x.as_ref()))
             .style(Style {
-                fg: text_color,
-                bg: bg_color,
+                modifier: Modifier::REVERSED,
                 ..Default::default()
             })
             .draw(area, buf);

--- a/src/interactive/widgets/header.rs
+++ b/src/interactive/widgets/header.rs
@@ -9,12 +9,12 @@ pub struct Header;
 
 impl Header {
     pub fn render(&self, bg_color: Color, area: Rect, buf: &mut Buffer) {
-        let standard = Style{
+        let standard = Style {
             fg: Color::Black,
             bg: bg_color,
             ..Default::default()
         };
-        assert_ne!(standard.bg, standard.fg);
+        debug_assert_ne!(standard.bg, standard.fg);
         let modified = |text: &'static str, modifier| {
             Text::Styled(
                 text.into(),

--- a/src/interactive/widgets/header.rs
+++ b/src/interactive/widgets/header.rs
@@ -9,12 +9,12 @@ pub struct Header;
 
 impl Header {
     pub fn render(&self, bg_color: Color, area: Rect, buf: &mut Buffer) {
-        let text_color = Color::Black;
-        let standard = Style {
-            fg: text_color,
+        let standard = Style{
+            fg: Color::Black,
             bg: bg_color,
             ..Default::default()
         };
+        assert_ne!(standard.bg, standard.fg);
         let modified = |text: &'static str, modifier| {
             Text::Styled(
                 text.into(),
@@ -43,7 +43,6 @@ impl Header {
         ];
         Paragraph::new(lines.iter())
             .style(Style {
-                fg: text_color,
                 bg: bg_color,
                 ..Default::default()
             })

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -1,7 +1,7 @@
 use crate::interactive::{
     widgets::{
         Entries, EntriesProps, Footer, FooterProps, Header, HelpPane, HelpPaneProps, MarkPane,
-        MarkPaneProps, COLOR_MARKED_LIGHT,
+        MarkPaneProps, COLOR_MARKED,
     },
     AppState, DisplayOptions, FocussedPane,
 };
@@ -54,14 +54,14 @@ impl MainWindow {
                 bg: Color::Reset,
                 modifier: Modifier::empty(),
             };
-            let white = Style {
-                fg: Color::White,
+            let bold = Style {
+                modifier: Modifier::BOLD,
                 ..grey
             };
             match state.focussed {
-                Main => (white, grey, grey),
-                Help => (grey, white, grey),
-                Mark => (grey, grey, white),
+                Main => (bold, grey, grey),
+                Help => (grey, bold, grey),
+                Mark => (grey, grey, bold),
             }
         };
 
@@ -76,7 +76,7 @@ impl MainWindow {
             let marked = self.mark_pane.as_ref().map(|p| p.marked());
             let bg_color = match (marked.map_or(true, |m| m.is_empty()), state.focussed) {
                 (false, FocussedPane::Mark) => Color::LightRed,
-                (false, _) => COLOR_MARKED_LIGHT,
+                (false, _) => COLOR_MARKED,
                 (_, _) => Color::White,
             };
             Header.render(bg_color, header_area, buf);

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -1,7 +1,5 @@
 use crate::interactive::{
-    fit_string_graphemes_with_ellipsis, path_of,
-    widgets::get_name_color,
-    CursorDirection,
+    fit_string_graphemes_with_ellipsis, path_of, widgets::entry_color, CursorDirection,
 };
 use dua::{
     traverse::{Tree, TreeIndex},
@@ -234,7 +232,7 @@ impl MarkPane {
                             modifier,
                             ..Default::default()
                         }
-                    },
+                    }
                     _ => Style::default(),
                 };
                 let (path, path_len) = {
@@ -260,7 +258,7 @@ impl MarkPane {
                         _ => (path, num_path_graphemes),
                     }
                 };
-                let fg_path = get_name_color(Color::Reset, !v.is_dir, true);
+                let fg_path = entry_color(Color::Reset, !v.is_dir, true);
                 let path = Text::Styled(
                     path.into(),
                     Style {

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -33,6 +33,7 @@ pub struct EntryMark {
     pub path: PathBuf,
     pub index: usize,
     pub num_errors_during_deletion: usize,
+    pub is_dir: bool,
 }
 
 #[derive(Default)]
@@ -62,7 +63,7 @@ impl MarkPane {
             self.selected = None
         }
     }
-    pub fn toggle_index(mut self, index: TreeIndex, tree: &Tree) -> Option<Self> {
+    pub fn toggle_index(mut self, index: TreeIndex, tree: &Tree, is_dir: bool) -> Option<Self> {
         match self.marked.entry(index) {
             Entry::Vacant(entry) => {
                 if let Some(e) = tree.node_weight(index) {
@@ -73,6 +74,7 @@ impl MarkPane {
                         path: path_of(tree, index),
                         index: sorting_index,
                         num_errors_during_deletion: 0,
+                        is_dir,
                     });
                 }
             }
@@ -258,7 +260,7 @@ impl MarkPane {
                         _ => (path, num_path_graphemes),
                     }
                 };
-                let fg_path = get_name_color(Color::Reset, false, true);  // TODO: determine whether directory
+                let fg_path = get_name_color(Color::Reset, !v.is_dir, true);
                 let path = Text::Styled(
                     path.into(),
                     Style {

--- a/src/interactive/widgets/mod.rs
+++ b/src/interactive/widgets/mod.rs
@@ -14,8 +14,14 @@ pub use mark::*;
 
 use tui::style::Color;
 
-pub const COLOR_BYTESIZE_SELECTED: Color = Color::DarkGray;
 pub const COLOR_MARKED: Color = Color::Yellow;
-pub const COLOR_MARKED_LIGHT: Color = Color::LightYellow;
 pub const COLOR_MARKED_DARK: Color = Color::Rgb(176, 126, 0);
-pub const COLOR_MARKED_DARKER: Color = Color::Rgb(106, 66, 0);
+
+fn get_name_color(fg: Color, is_file: bool, is_marked: bool) -> Color {
+   match (is_file, is_marked) {
+        (true, false) => Color::DarkGray,
+        (true, true) => COLOR_MARKED_DARK,
+        (false, true) => COLOR_MARKED,
+        _ => fg,
+    }
+}

--- a/src/interactive/widgets/mod.rs
+++ b/src/interactive/widgets/mod.rs
@@ -17,8 +17,8 @@ use tui::style::Color;
 pub const COLOR_MARKED: Color = Color::Yellow;
 pub const COLOR_MARKED_DARK: Color = Color::Rgb(176, 126, 0);
 
-fn get_name_color(fg: Color, is_file: bool, is_marked: bool) -> Color {
-   match (is_file, is_marked) {
+fn entry_color(fg: Color, is_file: bool, is_marked: bool) -> Color {
+    match (is_file, is_marked) {
         (true, false) => Color::DarkGray,
         (true, true) => COLOR_MARKED_DARK,
         (false, true) => COLOR_MARKED,


### PR DESCRIPTION
Fixes #13.

Due to the way colors work in the terminal, I had to change the color scheme for dark terminals as well.

I also tried to make the coloring of the entries and the mark pane more consistent.