### PR TITLE
Add support for real/apparent size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "byte-unit",
  "failure",
  "failure-tools",
+ "filesize",
  "itertools",
  "jwalk",
  "log",
@@ -240,6 +241,15 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "filesize"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a941e39ae509cebcd46c6734c20553a9a209b92cea5fc54618fe778fea61701"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4.6"
 tui-react = { path = "./tui-react", version = "0.2" }
 num_cpus = "1.10.0"
 unicode-segmentation = "1.3.0"
+filesize = "0.1.0"
 
 [[bin]]
 name="dua"

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -29,7 +29,17 @@ pub fn aggregate(
             match entry {
                 Ok(entry) => {
                     let file_size = match entry.metadata {
-                        Some(Ok(ref m)) if !m.is_dir() => m.len(),
+                        Some(Ok(ref m)) if !m.is_dir() => {
+                            if options.apparent_size {
+                                m.len()
+                            } else {
+                                filesize::file_real_size_fast(&entry.path(), m)
+                                    .unwrap_or_else(|_| {
+                                        num_errors += 1;
+                                        0
+                                    })
+                            }
+                        },
                         Some(Ok(_)) => 0,
                         Some(Err(_)) => {
                             num_errors += 1;

--- a/src/common.rs
+++ b/src/common.rs
@@ -152,6 +152,7 @@ pub struct WalkOptions {
     /// for more information.
     pub threads: usize,
     pub byte_format: ByteFormat,
+    pub apparent_size: bool,
     pub color: Color,
     pub sorting: TraversalSorting,
 }

--- a/src/interactive/app_test/utils.rs
+++ b/src/interactive/app_test/utils.rs
@@ -164,6 +164,7 @@ pub fn initialized_app_and_terminal_with_closure<P: AsRef<Path>>(
         WalkOptions {
             threads: 1,
             byte_format: ByteFormat::Metric,
+            apparent_size: true,
             color: Color::None,
             sorting: TraversalSorting::AlphabeticalByFileName,
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ fn run() -> Result<(), Error> {
         } else {
             Color::None
         },
+        apparent_size: opt.apparent_size,
         sorting: TraversalSorting::None,
     };
     let res = match opt.command {

--- a/src/options.rs
+++ b/src/options.rs
@@ -52,6 +52,10 @@ pub struct Args {
     #[structopt(short = "f", long = "format")]
     pub format: Option<ByteFormat>,
 
+    /// Display apparent size instead of disk usage.
+    #[structopt(short = "A", long = "apparent-size")]
+    pub apparent_size: bool,
+
     /// One or more input files or directories. If unset, we will use all entries in the current working directory.
     #[structopt(parse(from_os_str))]
     pub input: Vec<PathBuf>,

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -93,7 +93,18 @@ impl Traversal {
                             entry.file_name
                         };
                         let file_size = match entry.metadata {
-                                Some(Ok(ref m)) if !m.is_dir() => m.len(),
+                                Some(Ok(ref m)) if !m.is_dir() => {
+                                    if walk_options.apparent_size {
+                                        m.len()
+                                    } else {
+                                        filesize::file_real_size_fast(&data.name, m)
+                                            .unwrap_or_else(|_| {
+                                                t.io_errors += 1;
+                                                data.metadata_io_error = true;
+                                                0
+                                            })
+                                    }
+                                },
                                 Some(Ok(_)) => 0,
                                 Some(Err(_)) => {
                                     t.io_errors += 1;


### PR DESCRIPTION
This adds support for retrieving the real on-disk size of files using the `filesize` crate, leaving the previous behaviour under `-A`/`--apparent-size` flags to match BSD/GNU `du`.