### PR TITLE
Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Via `xbps` on your VoidLinux system.
 xbps-install dua-cli
 ```
 
+#### Fedora
+Via `dnf` on your Fedora system.
+
+```
+sudo dnf install rust-dua-cli
+```
+
 ### Usage
 
 ```bash


### PR DESCRIPTION
Happy to say that `dua-cli` packaged finally and [available](https://src.fedoraproject.org/rpms/rust-dua-cli) in official Fedora repos. At this moment only for Rawhide branch but soon will be for current release.