### PR TITLE
Add ArchLinux to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Via `dnf` on your Fedora system.
 sudo dnf install dua-cli
 ```
 
+#### Arch Linux
+Via `pacman` on your ArchLinux system.
+
+```
+sudo pacman -S dua-cli
+```
+
 ### Usage
 
 ```bash


### PR DESCRIPTION
dua-cli is now available out-of-the-box on Arch Linux!

Thanks Sven-Hendrik Haase for adopting the package into the `[community]` repo!