### PR TITLE
Disable default features for tui in tui-react

### DIFF
--- a/tui-react/Cargo.toml
+++ b/tui-react/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-tui = "0.8.0"
+tui = { version = "0.8.0", default-features = false }
 log = "0.4.6"
 unicode-segmentation = "1.6.0"
 unicode-width = "0.1.7"


### PR DESCRIPTION
The only default feature in tui is the termion backend, but tui-react doesn't depend on any backend. With the termion backend enabled by default you can't change the backend to another one in other crates.