### PR TITLE
Fix disabled tests

### DIFF
--- a/src/interactive/app_test/unit.rs
+++ b/src/interactive/app_test/unit.rs
@@ -17,8 +17,6 @@ fn it_can_handle_ending_traversal_reaching_top_but_skipping_levels() -> Result<(
     Ok(())
 }
 
-// Won't work on windows as there are backslashes in the paths :D
-#[cfg_attr(windows, ignore)]
 #[test]
 fn it_can_handle_ending_traversal_without_reaching_the_top() -> Result<()> {
     let (_, app) = initialized_app_and_terminal_from_fixture(&["sample-02"])?;

--- a/src/interactive/app_test/unit.rs
+++ b/src/interactive/app_test/unit.rs
@@ -4,8 +4,6 @@ use crate::interactive::app_test::utils::{
 use anyhow::Result;
 use pretty_assertions::assert_eq;
 
-// Won't work on windows as there are backslashes in the paths :D
-#[cfg_attr(windows, ignore)]
 #[test]
 fn it_can_handle_ending_traversal_reaching_top_but_skipping_levels() -> Result<()> {
     let (_, app) = initialized_app_and_terminal_from_fixture(&["sample-01"])?;

--- a/src/interactive/app_test/utils.rs
+++ b/src/interactive/app_test/utils.rs
@@ -255,7 +255,7 @@ pub fn sample_02_tree() -> Tree {
         let r = add_node("", root_size, None);
         {
             let s = add_node(
-                format!("{}/{}", FIXTURE_PATH, "sample-02").as_str(),
+                Path::new(FIXTURE_PATH).join("sample-02").to_str().unwrap(),
                 root_size,
                 Some(r),
             );

--- a/src/interactive/app_test/utils.rs
+++ b/src/interactive/app_test/utils.rs
@@ -211,7 +211,10 @@ pub fn sample_01_tree() -> Tree {
     let mut t = Tree::new();
     {
         let mut add_node = make_add_node(&mut t);
+        #[cfg(not(windows))]
         let root_size = 1259070;
+        #[cfg(windows)]
+        let root_size = 1259069;
         let r = add_node("", root_size, None);
         {
             let s = add_node(&fixture_str("sample-01"), root_size, Some(r));
@@ -219,7 +222,10 @@ pub fn sample_01_tree() -> Tree {
                 add_node(".hidden.666", 666, Some(s));
                 add_node("a", 256, Some(s));
                 add_node("b.empty", 0, Some(s));
+                #[cfg(not(windows))]
                 add_node("c.lnk", 1, Some(s));
+                #[cfg(windows)]
+                add_node("c.lnk", 0, Some(s));
                 let d = add_node("dir", 1258024, Some(s));
                 {
                     add_node("1000bytes", 1000, Some(d));


### PR DESCRIPTION
- fixes 'sample_01_tree' size miscalculation; symbolic links are '0' size on windows vs '1' size on *nix-types
- fixes 'sample_02_tree' path construction error

Both tests now complete successfully on Windows and *nix-type platforms.