### PR TITLE
Fix styling for entries for interactive mode

### DIFF
--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -77,7 +77,7 @@ impl AppState {
         use crosstermion::input::Key::*;
         use FocussedPane::*;
 
-        self.draw(window, traversal, display.clone(), terminal)?;
+        self.draw(window, traversal, *display, terminal)?;
         for key in keys {
             self.reset_message();
             match key {
@@ -107,7 +107,7 @@ impl AppState {
 
             match self.focussed {
                 FocussedPane::Mark => {
-                    self.dispatch_to_mark_pane(key, window, traversal, display.clone(), terminal)
+                    self.dispatch_to_mark_pane(key, window, traversal, *display, terminal)
                 }
                 FocussedPane::Help => {
                     window.help_pane.as_mut().expect("help pane").key(key);
@@ -147,7 +147,7 @@ impl AppState {
                     _ => {}
                 },
             };
-            self.draw(window, traversal, display.clone(), terminal)?;
+            self.draw(window, traversal, *display, terminal)?;
         }
         Ok(ProcessingResult::Finished(WalkResult {
             num_errors: traversal.io_errors,

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -56,9 +56,9 @@ impl HelpPane {
             };
 
             let spacer = || add_newlines(2);
-            let title = |name| {
+            let title = |name: &str| {
                 lines.borrow_mut().push(Spans::from(Span::styled(
-                    format!("{}", name),
+                    name.to_string(),
                     Style {
                         add_modifier: Modifier::BOLD | Modifier::UNDERLINED,
                         ..Default::default()

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -301,7 +301,7 @@ impl MarkPane {
                             .saturating_sub(format.total_width())
                     ),
                     Style {
-                        fg: fg_path.into(),
+                        fg: fg_path,
                         ..base_style
                     },
                 );

--- a/src/interactive/widgets/mod.rs
+++ b/src/interactive/widgets/mod.rs
@@ -19,9 +19,9 @@ pub const COLOR_MARKED_DARK: Color = Color::Rgb(176, 126, 0);
 
 fn entry_color(fg: Option<Color>, is_file: bool, is_marked: bool) -> Option<Color> {
     match (is_file, is_marked) {
-        (true, false) => Color::DarkGray.into(),
+        (true, false) => fg,
         (true, true) => COLOR_MARKED_DARK.into(),
         (false, true) => COLOR_MARKED.into(),
-        _ => fg,
+        (false, false) => Color::Cyan.into(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,8 @@
 #![forbid(unsafe_code)]
-#![allow(clippy::match_bool)]
 use anyhow::{anyhow, Result};
 use dua::{ByteFormat, TraversalSorting};
 use std::{fs, io, io::Write, path::PathBuf, process};
 use structopt::StructOpt;
-use wild;
 
 #[cfg(any(feature = "tui-unix", feature = "tui-crossplatform"))]
 mod interactive;


### PR DESCRIPTION
This changeset replaced colors for entries in interactive mode
directory: from none to cyan
regular file: from dark gray to none

Before:
![before](https://user-images.githubusercontent.com/4850908/88313683-8b6a4f80-cd1c-11ea-8a0d-62f97fe5d3c0.png)

After:
![after](https://user-images.githubusercontent.com/4850908/88313694-902f0380-cd1c-11ea-83c8-45c071ef4a92.png)
