### PR TITLE
src, aggregate: fix colors for aggregate mode

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -111,9 +111,17 @@ pub fn aggregate(
 
 fn path_color_of(path: impl AsRef<Path>) -> Option<Color> {
     if path.as_ref().is_file() {
-        Some(Color::BrightBlack)
-    } else {
         None
+    } else {
+        Some(Color::Cyan)
+    }
+}
+
+fn colorize_path(path: &Path, path_color: Option<colored::Color>) -> colored::ColoredString {
+    if let Some(path_color) = path_color {
+        path.display().to_string().as_str().color(path_color)
+    } else {
+        path.display().to_string().as_str().normal()
     }
 }
 
@@ -134,11 +142,7 @@ fn output_colored_path(
             .to_string()
             .as_str()
             .green(),
-        path.as_ref()
-            .display()
-            .to_string()
-            .as_str()
-            .color(path_color.unwrap_or(Color::White)),
+        colorize_path(path.as_ref(), path_color),
         if num_errors == 0 {
             Cow::Borrowed("")
         } else {


### PR DESCRIPTION
Use cyan color for folders in aggregate mode

Before:
![before](https://user-images.githubusercontent.com/4850908/88533783-7c7ee800-d00f-11ea-9b43-7eaf03aaa0bf.png)

After:
![after](https://user-images.githubusercontent.com/4850908/88533797-80126f00-d00f-11ea-8270-bab2c2ebc5d2.png)
