### PR TITLE
Make the trash feature optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,12 @@ license = "MIT"
 include = ["src/**/*", "Cargo.*", "LICENSE", "README.md", "CHANGELOG.md", "!**/tests/*"]
 
 [features]
-default = ["tui-crossplatform"]
+default = ["tui-crossplatform", "trash-move"]
 tui-unix = ["crosstermion/tui-react-termion", "tui-shared"]
 tui-crossplatform = ["crosstermion/tui-react-crossterm", "tui-shared"]
 
 tui-shared = ["tui", "tui-react", "open", "unicode-segmentation"]
+trash-move = ["trash"]
 
 [dependencies]
 clap = "3.0.0-beta.2"
@@ -27,7 +28,7 @@ num_cpus = "1.10.0"
 filesize = "0.2.0"
 anyhow = "1.0.31"
 colored = "2.0.0"
-trash = "2.0.1"
+trash = { version = "2.0.1", optional = true }
 
 # 'tui' related
 unicode-segmentation = { version = "1.3.0", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,13 @@ check:## run cargo-check with various features
 	cargo check --all
 	cargo check --all-features
 	cargo check --no-default-features
-	cargo check --features tui-unix
-	cargo check --features tui-crossplatform
+	cargo check --no-default-features --features tui-unix
+	cargo check --no-default-features --features tui-crossplatform
+	cargo check --no-default-features --features trash-move
 
 unit-tests: ## run all unit tests
 	cargo test --all
+	cargo test --all --no-default-features --features trash-move
 
 continuous-unit-tests: ## run all unit tests whenever something changes
 	watchexec -w src $(MAKE) unit-tests

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -229,6 +229,7 @@ impl AppState {
                     self.message = None;
                     res
                 }
+                #[cfg(feature = "trash-move")]
                 Some(MarkMode::Trash) => {
                     self.message = Some("Trashing entries...".to_string());
                     let mut entries_trashed = 0;
@@ -272,6 +273,7 @@ impl AppState {
         Ok(entries_deleted)
     }
 
+    #[cfg(feature = "trash-move")]
     pub fn trash_entry(
         &mut self,
         index: TreeIndex,

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -168,6 +168,7 @@ impl HelpPane {
                     "Permanently delete all marked entries without prompt!",
                     Some("This operation cannot be undone!"),
                 );
+                #[cfg(feature = "trash-move")]
                 hotkey(
                     "Ctrl + t",
                     "Move all marked entries to the trash bin",

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -28,6 +28,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 pub enum MarkMode {
     Delete,
+    #[cfg(feature = "trash-move")]
     Trash,
 }
 
@@ -110,6 +111,7 @@ impl MarkPane {
         let action = None;
         match key {
             Ctrl('r') => return Some(self.prepare_deletion(MarkMode::Delete)),
+            #[cfg(feature = "trash-move")]
             Ctrl('t') => return Some(self.prepare_deletion(MarkMode::Trash)),
             Char('x') | Char('d') | Char(' ') => {
                 return self.remove_selected().map(|s| (s, action))
@@ -360,6 +362,7 @@ impl MarkPane {
                 sub_modifier: Modifier::empty(),
             };
             Paragraph::new(Text::from(Spans::from(vec![
+                #[cfg(feature = "trash-move")]
                 Span::styled(
                     " Ctrl + t",
                     Style {
@@ -368,6 +371,7 @@ impl MarkPane {
                         ..default_style
                     },
                 ),
+                #[cfg(feature = "trash-move")]
                 Span::styled(" to trash or ", default_style),
                 Span::styled(
                     " Ctrl + r",


### PR DESCRIPTION
On *BSD systems, the [trash](https://github.com/ArturKovacs/trash-rs) crate does not compile successfully in what appears to rely on Linux-specific implementations (`libc::getmntent` to name a few). 

<details>
<summary>Compilation log</summary>
<p>

```
error[E0432]: unresolved import `chrono`
  --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:18:5
   |
18 | use chrono::{NaiveDateTime, TimeZone};
   |     ^^^^^^ use of undeclared crate or module `chrono`

error[E0432]: unresolved import `scopeguard`
  --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:20:5
   |
20 | use scopeguard::defer;
   |     ^^^^^^^^^^ use of undeclared crate or module `scopeguard`

error: cannot determine resolution for the macro `defer`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:591:5
    |
591 |     defer! { unsafe { libc::fclose(file); } }
    |     ^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

error[E0433]: failed to resolve: use of undeclared crate or module `libc`
  --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:36:28
   |
36 |         let uid = unsafe { libc::getuid() };
   |                            ^^^^ use of undeclared crate or module `libc`

error[E0433]: failed to resolve: use of undeclared crate or module `libc`
  --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:81:24
   |
81 |     let uid = unsafe { libc::getuid() };
   |                        ^^^^ use of undeclared crate or module `libc`

error[E0433]: failed to resolve: use of undeclared crate or module `chrono`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:176:32
    |
176 |                     let time = chrono::Local.from_local_datetime(&naive_local).earliest();
    |                                ^^^^^^ use of undeclared crate or module `chrono`

error[E0433]: failed to resolve: use of undeclared crate or module `chrono`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:403:27
    |
403 |                 let now = chrono::Local::now();
    |                           ^^^^^^ use of undeclared crate or module `chrono`

error[E0433]: failed to resolve: use of undeclared crate or module `url`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:518:12
    |
518 |     return url::Url::parse(&url).unwrap().to_file_path().unwrap().to_str().unwrap().into();
    |            ^^^ use of undeclared crate or module `url`

error[E0433]: failed to resolve: use of undeclared crate or module `url`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:522:15
    |
522 |     let url = url::Url::from_file_path(absolute_file_path.as_ref()).unwrap();
    |               ^^^ use of undeclared crate or module `url`

error[E0433]: failed to resolve: use of undeclared crate or module `libc`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:581:18
    |
581 |         unsafe { libc::fopen(mounts_path.as_c_str().as_ptr(), read_arg.as_c_str().as_ptr()) };
    |                  ^^^^ use of undeclared crate or module `libc`

error[E0433]: failed to resolve: use of undeclared crate or module `libc`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:584:25
    |
584 |         file = unsafe { libc::fopen(mtab_path.as_c_str().as_ptr(), read_arg.as_c_str().as_ptr()) };
    |                         ^^^^ use of undeclared crate or module `libc`

error[E0433]: failed to resolve: use of undeclared crate or module `libc`
   --> /home/lcook/.cargo/registry/src/github.com-1ecc6299db9ec823/trash-2.0.1/src/freedesktop.rs:594:31
    |
594 |         let mntent = unsafe { libc::getmntent(file) };
    |                               ^^^^ use of undeclared crate or module `libc`
```

</p>
</details>  

Until the issue is fixed upstream or I have the time to fix it myself, we can keep `trash` feature-gated, allowing you to *opt-out* compiling it in. Merging the change also relieves the burden of maintaining a local patch in addressing the problem. Furthermore, modularising features makes maintainer-ship ever so slightly straightforward and a direction I typically endorse. 

If there is any other approach or suggestions you have, please let me know. 

As a side note, it would be appreciated to push a new version release should you decide to merge this pull request. Doing so constitutes me dropping this patch used before building the FreeBSD package and possibly any additional distributions if they run into the same problem.