### PR TITLE
Improve mark widget tip style

### DIFF
--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -364,7 +364,7 @@ impl MarkPane {
             Paragraph::new(Text::from(Spans::from(vec![
                 #[cfg(feature = "trash-move")]
                 Span::styled(
-                    " Ctrl + t",
+                    " Ctrl + t ",
                     Style {
                         fg: Color::White.into(),
                         bg: Color::Black.into(),
@@ -374,9 +374,10 @@ impl MarkPane {
                 #[cfg(feature = "trash-move")]
                 Span::styled(" to trash or ", default_style),
                 Span::styled(
-                    " Ctrl + r",
+                    " Ctrl + r ",
                     Style {
                         fg: Color::LightRed.into(),
+                        bg: Color::Black.into(),
                         add_modifier: default_style.add_modifier | Modifier::RAPID_BLINK,
                         ..default_style
                     },


### PR DESCRIPTION
I find the current style looking a little bit weird, so I tried to improve it a little bit, see comparison below.

Before:
![image](https://user-images.githubusercontent.com/44045911/130340552-adfad99a-c906-41fc-9858-3316b9aab25a.png)
![image](https://user-images.githubusercontent.com/44045911/130340555-1d7b37eb-c456-4f7d-9fc7-095638a4dca3.png)

After:
![image](https://user-images.githubusercontent.com/44045911/130340569-1682a00d-4db0-4f26-b6d1-9365dd93352a.png)
![image](https://user-images.githubusercontent.com/44045911/130340564-f34ec19c-9f45-4b97-aed5-8e1e69973994.png)
