### PR TITLE
Fix deletion process on Rust 1.55

### DIFF
--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -426,13 +426,15 @@ fn delete_directory_recursively(path: PathBuf) -> Result<(), usize> {
                     }
                 }
             }
-            Err(ref e) if e.kind() == io::ErrorKind::Other => {
-                // assume file, save IOps
-                num_errors += into_error_count(fs::remove_file(path));
-                continue;
-            }
+            // Err(ref e) if e.kind() == io::ErrorKind::NotADirectory => {
+            //     // assume file, save IOps
+            //     num_errors += into_error_count(fs::remove_file(path));
+            //     continue;
+            // }
             Err(_) => {
-                num_errors += 1;
+                // TODO: Reintroduce commented code once the `io_error_more` feature is stable
+                // num_errors += 1;
+                num_errors += into_error_count(fs::remove_file(path));
                 continue;
             }
         };


### PR DESCRIPTION
Rust 1.55 unfortunately breaks the existing code which assumed that
ErrorKind::Other will be returned by fs::read_dir() when a file is
encountered. For now just always try deleting as if it's a file with the
possibility to add the optimization back again once the `io_error_more`
feature is stabilized.

References:
- https://blog.rust-lang.org/2021/09/09/Rust-1.55.0.html#stdioerrorkind-variants-updated
- https://github.com/rust-lang/rust/pull/85746
- https://github.com/rust-lang/rust/issues/86442