### PR TITLE
Fix link to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make install
 
 #### Windows
 
-You will find pre-built binaries for Windows in the [releases section](https://github.com/Byron/dua-cli).
+You will find pre-built binaries for Windows in the [releases section][releases].
 Alternatively, install via cargo as in
 
 ```


### PR DESCRIPTION
One of the link to releases section is actually just linking to the repo currently