### PR TITLE
Add `a` key to toggle marked status of all entries

### DIFF
--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -136,6 +136,7 @@ impl AppState {
                         window,
                         traversal,
                     ),
+                    Char('a') => self.mark_all_entries(MarkEntryMode::Toggle, window, traversal),
                     Char('u') | Char('h') | Backspace | Left => {
                         self.exit_node_with_traversal(traversal)
                     }

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -154,15 +154,17 @@ impl HelpPane {
                     None,
                 );
                 hotkey("<Space>", "Toggle the currently selected entry", None);
+                hotkey("a", "Toggle all entries", None);
                 spacer();
             }
             title("Keys in the Mark pane");
             {
                 hotkey(
                     "x/d/<Space>",
-                    "remove the selected entry from the list",
+                    "Remove the selected entry from the list",
                     None,
                 );
+                hotkey("a", "Remove all entries from the list", None);
                 hotkey(
                     "Ctrl + r",
                     "Permanently delete all marked entries without prompt!",

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -116,6 +116,7 @@ impl MarkPane {
             Char('x') | Char('d') | Char(' ') => {
                 return self.remove_selected().map(|s| (s, action))
             }
+            Char('a') => return None,
             Char('H') => self.change_selection(CursorDirection::ToTop),
             Char('G') => self.change_selection(CursorDirection::ToBottom),
             Ctrl('u') | PageUp => self.change_selection(CursorDirection::PageUp),


### PR DESCRIPTION
Hi, I just found this project, and I think it's great! However, one inconvenience I've found with it is the inability to mark all files in a directory for deletion. I have added <kbd>a</kbd> to fulfill that functionality here.

I extracted the functionality of the `mark_entry` function that uses `index` into a function `mark_entry_by_index` that is then used in the original `mark_entry` function and a new `mark_all_entries` function.

Another thing to mention is that I made <kbd>a</kbd> toggle the marked status of all entries, rather than marking all of them, because I think the former would be slightly more useful in that if you wanted to mark all but select files, you could start by marking those select files, then toggle all.