### PR TITLE
Improve aggregate progress reporting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,12 @@ license = "MIT"
 include = ["src/**/*", "Cargo.*", "LICENSE", "README.md", "CHANGELOG.md", "!**/tests/*"]
 
 [features]
-default = ["tui-crossplatform", "trash-move", "aggregate-scan-progress"]
+default = ["tui-crossplatform", "trash-move"]
 tui-unix = ["crosstermion/tui-react-termion", "tui-shared"]
 tui-crossplatform = ["crosstermion/tui-react-crossterm", "tui-shared"]
 
 tui-shared = ["tui", "tui-react", "open", "unicode-segmentation"]
 trash-move = ["trash"]
-aggregate-scan-progress = []
 
 [dependencies]
 clap = { version = "3.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ check:## run cargo-check with various features
 	cargo check --no-default-features --features tui-unix
 	cargo check --no-default-features --features tui-crossplatform
 	cargo check --no-default-features --features trash-move
-	cargo check --no-default-features --features aggregate-scan-progress
 
 unit-tests: ## run all unit tests
 	cargo test --all


### PR DESCRIPTION
Previously, aggregate mode progress reports were handled by an
infinitely-looping thread carrying a 64-bit atomic of the current count,
which it would print periodically.

This resulted in #99 - breaking on platforms without 64-bit atomics,
for which a feature was added to disable it.

It also implied a race condition, where the "Enumerating ..." message
could be printed after results had been gathered but before dua exited.

Additionally, part of the status message could be left on the display if
the first line of a report was too short to cover it.

This commit should resolve these:

 * The 64-bit atomic counter is replaced with an 8-bit AtomicBool
 * All printing is controlled from the main thread
 * The first line is cleared prior to printing a report

The only notable drawback I see with this approach is that progress
reporting can sometimes be delayed, since the display is only evaluated
for update during periods the aggregation loop makes progress. The
practical difference appears relatively minor.

Since this should resolve #99, the aggregate-scan-progress feature is
removed.