### PR TITLE
Add Scoop installation for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ curl -LSfs https://raw.githubusercontent.com/Byron/dua-cli/master/ci/install.sh 
     sh -s -- --git Byron/dua-cli --target x86_64-unknown-linux-musl --crate dua --tag v2.17.4
 ```
 
-#### Windows and others
+#### Windows via [Scoop](https://scoop.sh/)
+```sh
+scoop install dua
+```
+
+#### Others
 
 See the [releases section][releases] for manual installation.
 


### PR DESCRIPTION
[`dua`](https://scoop.sh/#/apps?q=main%2Fdua&s=0&d=1&o=true) is available in Scoop for Windows.