### PR TITLE
Add Apple M2 to default thread derivation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn derive_default_threads(threads: usize) -> usize {
             .processors()
             .get(0)
             .map_or(0, |p| match p.brand() {
-                "Apple M1"|"Apple M1 Pro"|"Apple M1 Max" => 4,
+                "Apple M1"|"Apple M1 Pro"|"Apple M1 Max"|"Apple M2" => 4,
                 other => {
                     eprintln!(
                         "Couldn't auto-configure correct amount of threads for {}. Create an issue here: https://github.com/byron/dua-cli/issues",


### PR DESCRIPTION
Closes #135 (I really overestimated how complex these changes would be 😅)

Measured 1-8 threads on both a small (100MB) and large (80GB) directories, 4 threads was the most performant in both cases.