### PR TITLE
Dependencies: switch from colored to owo-colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,17 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,13 +236,13 @@ dependencies = [
  "atty",
  "byte-unit",
  "clap",
- "colored",
  "crosstermion",
  "filesize",
  "itertools",
  "jwalk",
  "num_cpus",
  "open",
+ "owo-colors",
  "petgraph",
  "pretty_assertions",
  "sysinfo",
@@ -370,12 +359,6 @@ dependencies = [
  "crossbeam",
  "rayon",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -512,6 +495,12 @@ checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ itertools = "0.10.0"
 num_cpus = "1.10.0"
 filesize = "0.2.0"
 anyhow = "1.0.31"
-colored = "2.0.0"
 trash = { version = "2.1.5", optional = true, default-features = false, features = ["coinit_apartmentthreaded"] }
 
 # 'tui' related
@@ -37,6 +36,7 @@ tui = { version = "0.17.0", optional = true, default-features = false }
 tui-react = { version = "0.17.0", optional = true }
 open = { version = "3.0", optional = true }
 wild = "2.0.4"
+owo-colors = "3.5.0"
 
 [target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
 sysinfo = { version = "0.23.2", default-features = false }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,7 +1,7 @@
 use crate::{crossdev, InodeFilter, WalkOptions, WalkResult};
 use anyhow::Result;
-use colored::{Color, Colorize};
 use filesize::PathExt;
+use owo_colors::{AnsiColors as Color, OwoColorize};
 use std::{borrow::Cow, io, path::Path};
 use std::{
     sync::{
@@ -199,23 +199,19 @@ fn output_colored_path(
     path: impl AsRef<Path>,
     num_bytes: u128,
     num_errors: u64,
-    path_color: Option<colored::Color>,
+    path_color: Option<Color>,
 ) -> std::result::Result<(), io::Error> {
     writeln!(
         out,
         "{:>byte_column_width$} {}{}",
-        options
-            .byte_format
-            .display(num_bytes)
-            .to_string()
-            .as_str()
-            .green(),
+        options.byte_format.display(num_bytes).green(),
         {
-            let path = path.as_ref().display().to_string();
+            let path = path.as_ref().display();
             match path_color {
                 Some(color) => path.color(color),
-                None => path.normal(),
+                None => path.color(Color::Default),
             }
+            .to_string()
         },
         if num_errors == 0 {
             Cow::Borrowed("")


### PR DESCRIPTION
`owo-colors` is well-maintained, zero-allocation, zero-dependencies crate
for terminal colors. Also it works on any type that implements Display trait,
not just on strings.

I made minimal changes to the source code for this switch.
