### PR TITLE
Draw window before processing events, fixes #143

### DIFF
--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -77,6 +77,7 @@ impl AppState {
         use crosstermion::input::Key::*;
         use FocussedPane::*;
 
+        self.draw(window, traversal, *display, terminal)?;
         for event in events {
             let key = match event {
                 Event::Key(key) => key,


### PR DESCRIPTION
Fixes #143 (on my machine). It looks like commit 28f5ac90cc1ba7d668ae8a83eb5cd899294a8301 unintentionally removed a call to `draw`. Putting it back in appears to fix the issue. Will definitely need to verify on other people's machines.