### PR TITLE
traverse: don't recurse on cross-device filesystems

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -97,7 +97,7 @@ pub fn aggregate(
                 continue;
             }
         };
-        for entry in walk_options.iter_from_path(path.as_ref()) {
+        for entry in walk_options.iter_from_path(path.as_ref(), device_id) {
             stats.entries_traversed += 1;
             progress.throttled(|out| {
                 write!(out, "Enumerating {} entries\r", stats.entries_traversed).ok();

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -103,7 +103,7 @@ impl Traversal {
                 }
             };
             for (eid, entry) in walk_options
-                .iter_from_path(path.as_ref())
+                .iter_from_path(path.as_ref(), device_id)
                 .into_iter()
                 .enumerate()
             {


### PR DESCRIPTION
Like it says in the title. Right now, if you pass `-x`, dua doesn't count files on other devices, but it still enumerates them. However, a good reason to use `-x` is if you have network mounts that are slow, so this fixes that.