### PR TITLE
feat: use ratatui instead of tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -251,12 +251,11 @@ dependencies = [
 [[package]]
 name = "crosstermion"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99aabd9b02c2d5f72697f30ffb46f5a9ff4bd240d826049892cf62c31daeed04"
+source = "git+https://github.com/joshka/tui-crates?branch=ratatui#78e6a5924349cd3b86e3de98d5b2baf47e9d8991"
 dependencies = [
  "crossterm",
+ "ratatui",
  "termion",
- "tui",
  "tui-react",
 ]
 
@@ -293,8 +292,8 @@ dependencies = [
  "owo-colors",
  "petgraph",
  "pretty_assertions",
+ "ratatui",
  "trash",
- "tui",
  "tui-react",
  "unicode-segmentation",
  "wild",
@@ -648,6 +647,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm",
+ "termion",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.6"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
 dependencies = [
  "libc",
  "numtoa",
@@ -820,27 +833,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm",
- "termion",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "tui-react"
 version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542c37309aaf01ddaea86891f7845a8b0124194c6ccae6dbae7d223752648f4d"
+source = "git+https://github.com/joshka/tui-crates?branch=ratatui#78e6a5924349cd3b86e3de98d5b2baf47e9d8991"
 dependencies = [
  "log",
- "tui",
+ "ratatui",
  "unicode-segmentation",
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["tui-crossplatform", "trash-move"]
 tui-unix = ["crosstermion/tui-react-termion", "tui-shared"]
 tui-crossplatform = ["crosstermion/tui-react-crossterm", "tui-shared"]
 
-tui-shared = ["tui", "tui-react", "open", "unicode-segmentation"]
+tui-shared = ["ratatui", "tui-react", "open", "unicode-segmentation"]
 trash-move = ["trash"]
 
 [dependencies]
@@ -29,10 +29,10 @@ filesize = "0.2.0"
 anyhow = "1.0.31"
 trash = { version = "3.0.0", optional = true, default-features = false, features = ["coinit_apartmentthreaded"] }
 
-# 'tui' related
+# 'ratatui' related
 unicode-segmentation = { version = "1.3.0", optional = true }
 crosstermion = { version = "0.10.1", default-features = false, optional = true }
-tui = { version = "0.19.0", optional = true, default-features = false }
+ratatui = { version = "0.20.1", optional = true, default-features = false }
 tui-react = { version = "0.19.0", optional = true }
 open = { version = "3.0", optional = true }
 wild = "2.0.4"
@@ -55,3 +55,8 @@ build-override = { opt-level = 0 }
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
+
+[patch.crates-io]
+# Remove this once the ratatui is merged into https://github.com/Byron/tui-crates
+crosstermion = { git = "https://github.com/joshka/tui-crates", branch = "ratatui" }
+tui-react = { git = "https://github.com/joshka/tui-crates", branch = "ratatui" }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Installation
 
-### Binary Release 
+### Binary Release
 
 #### MacOS
 
@@ -17,13 +17,15 @@ curl -LSfs https://raw.githubusercontent.com/Byron/dua-cli/master/ci/install.sh 
     sh -s -- --git Byron/dua-cli --crate dua --tag v2.17.4
 ```
 
-#### MacOS via [MacPorts](https://www.macports.org):
+#### MacOS via [MacPorts](https://www.macports.org)
+
 ```sh
 sudo port selfupdate
 sudo port install dua-cli
 ```
 
 #### MacOS via [Homebrew](https://brew.sh)
+
 ```sh
 brew update
 brew install dua-cli
@@ -39,6 +41,7 @@ curl -LSfs https://raw.githubusercontent.com/Byron/dua-cli/master/ci/install.sh 
 ```
 
 #### Windows via [Scoop](https://scoop.sh/)
+
 ```sh
 scoop install dua
 ```
@@ -50,9 +53,11 @@ See the [releases section][releases] for manual installation of a binary, pre-bu
 [releases]: https://github.com/Byron/dua-cli/releases
 
 #### Cargo
+
 Via `cargo`, which can be obtained using [rustup][rustup]
 
 For _Unix_…
+
 ```
 cargo install dua-cli
 
@@ -64,11 +69,13 @@ cargo install dua-cli --no-default-features --features tui-crossplatform
 ```
 
 For _Windows_, nightly features are currently required.
+
 ```
 cargo +nightly install dua-cli
 ```
 
 #### VoidLinux
+
 Via `xbps` on your VoidLinux system.
 
 ```
@@ -76,6 +83,7 @@ xbps-install dua-cli
 ```
 
 #### Fedora
+
 Via `dnf` on your Fedora system.
 
 ```
@@ -83,6 +91,7 @@ sudo dnf install dua-cli
 ```
 
 #### Arch Linux
+
 Via `pacman` on your ArchLinux system.
 
 ```
@@ -90,6 +99,7 @@ sudo pacman -S dua-cli
 ```
 
 #### NetBSD
+
 Via `pkgin` on your NetBSD system.
 
 ```
@@ -155,7 +165,7 @@ make
 
 #### But why is…
 
-#### …there two available backends? `crossterm` works everywhere!
+#### …there two available backends? `crossterm` works everywhere
 
 Why add complexity to support `termion` if `crossterm` works everywhere? The answer is compile time and binary size, which both are larger
 when using `crossterm`. Thus on Unix we still build with `termion`, but there is no reason to stop supporting it once `crossterm` has no
@@ -179,15 +189,15 @@ Thanks to [jwalk][jwalk], all there was left to do is to write a command-line in
   column sizes are not correctly computed, leading to certain columns not being shown.
   In other cases, the terminal gets things wrong - I use alacritty, and with certain characaters it
   performs worse than, say iTerm3.
-  See https://github.com/minimaxir/big-list-of-naughty-strings/blob/master/blns.txt for the source.
+  See <https://github.com/minimaxir/big-list-of-naughty-strings/blob/master/blns.txt> for the source.
 * In interactive mode, you will need about 60MB of memory for 1 million entries in the graph.
 * In interactive mode, the maximum amount of files is limited to 2^32 - 1 (`u32::max_value() - 1`) entries.
   * One node is used as to 'virtual' root
   * The actual amount of nodes stored might be lower, as there might be more edges than nodes, which are also limited by a `u32` (I guess)
   * The limitation is imposed by the underlying [`petgraph`][petgraph] crate, which declares it as `unsafe` to use u64 for instance.
-  * It's possibly *UB* when that limit is reached, however, it was never observed either.
+  * It's possibly _UB_ when that limit is reached, however, it was never observed either.
 
-### Similar Programs 
+### Similar Programs
 
 * **CLI:**
   * `du`
@@ -205,5 +215,3 @@ Thanks to [jwalk][jwalk], all there was left to do is to write a command-line in
 [petgraph]: https://crates.io/crates/petgraph
 [rustup]: https://rustup.rs/
 [jwalk]: https://crates.io/crates/jwalk
-[termion]: https://crates.io/crates/termion
-[tui]: https://github.com/fdehau/tui-rs

--- a/src/interactive/app/bytevis.rs
+++ b/src/interactive/app/bytevis.rs
@@ -62,21 +62,21 @@ impl DisplayByteVisualization {
         // Print the filled part of the bar
         let block_length = (length as f32 * percentage).floor() as usize;
         for _ in 0..block_length {
-            f.write_str(tui::symbols::block::FULL)?;
+            f.write_str(ratatui::symbols::block::FULL)?;
         }
 
         // Bar is done if full length is already used, continue working if not
         if block_length < length {
             let block_sections = [
                 " ",
-                tui::symbols::block::ONE_EIGHTH,
-                tui::symbols::block::ONE_QUARTER,
-                tui::symbols::block::THREE_EIGHTHS,
-                tui::symbols::block::HALF,
-                tui::symbols::block::FIVE_EIGHTHS,
-                tui::symbols::block::THREE_QUARTERS,
-                tui::symbols::block::SEVEN_EIGHTHS,
-                tui::symbols::block::FULL,
+                ratatui::symbols::block::ONE_EIGHTH,
+                ratatui::symbols::block::ONE_QUARTER,
+                ratatui::symbols::block::THREE_EIGHTHS,
+                ratatui::symbols::block::HALF,
+                ratatui::symbols::block::FIVE_EIGHTHS,
+                ratatui::symbols::block::THREE_QUARTERS,
+                ratatui::symbols::block::SEVEN_EIGHTHS,
+                ratatui::symbols::block::FULL,
             ];
             // Get the index based on how filled the remaining part is
             let index =

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -10,8 +10,8 @@ use dua::{
     traverse::{Traversal, TreeIndex},
     WalkOptions, WalkResult,
 };
+use ratatui::backend::Backend;
 use std::{collections::BTreeMap, path::PathBuf};
-use tui::backend::Backend;
 use tui_react::Terminal;
 
 #[derive(Default, Copy, Clone)]

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -8,8 +8,8 @@ use crosstermion::input::Key;
 use dua::traverse::{Traversal, TreeIndex};
 use itertools::Itertools;
 use petgraph::{visit::Bfs, Direction};
+use ratatui::backend::Backend;
 use std::{fs, io, path::PathBuf};
-use tui::backend::Backend;
 use tui_react::Terminal;
 
 #[derive(Copy, Clone)]

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -6,6 +6,7 @@ use dua::{
 use itertools::Itertools;
 use jwalk::{DirEntry, WalkDir};
 use petgraph::prelude::NodeIndex;
+use ratatui::backend::TestBackend;
 use std::{
     env::temp_dir,
     ffi::OsStr,
@@ -14,7 +15,6 @@ use std::{
     io::ErrorKind,
     path::{Path, PathBuf},
 };
-use tui::backend::TestBackend;
 use tui_react::Terminal;
 
 use crate::interactive::{app::tests::FIXTURE_PATH, Interaction, TerminalApp};

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -5,14 +5,14 @@ use crate::interactive::{
 };
 use dua::traverse::{Tree, TreeIndex};
 use itertools::Itertools;
-use std::{borrow::Borrow, path::Path};
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, Borders},
 };
+use std::{borrow::Borrow, path::Path};
 use tui_react::util::rect::line_bound;
 use tui_react::{
     draw_text_nowrap_fn, fill_background_to_right,

--- a/src/interactive/widgets/footer.rs
+++ b/src/interactive/widgets/footer.rs
@@ -1,6 +1,5 @@
 use dua::ByteFormat;
-use std::borrow::Borrow;
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::Modifier,
@@ -8,6 +7,7 @@ use tui::{
     text::{Span, Spans, Text},
     widgets::{Paragraph, Widget},
 };
+use std::borrow::Borrow;
 
 pub struct Footer;
 

--- a/src/interactive/widgets/header.rs
+++ b/src/interactive/widgets/header.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier, Style},

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -1,13 +1,13 @@
 use crate::interactive::CursorDirection;
 use crosstermion::{input::Key, input::Key::*};
-use std::{borrow::Borrow, cell::RefCell};
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph, Widget},
 };
+use std::{borrow::Borrow, cell::RefCell};
 use tui_react::{
     draw_text_nowrap_fn,
     util::{block_width, rect},

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -6,13 +6,13 @@ use crate::interactive::{
     AppState, DisplayOptions, FocussedPane,
 };
 use dua::traverse::Traversal;
-use std::borrow::Borrow;
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::Modifier,
     style::{Color, Style},
 };
+use std::borrow::Borrow;
 use Constraint::*;
 use FocussedPane::*;
 

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -7,17 +7,17 @@ use dua::{
     ByteFormat,
 };
 use itertools::Itertools;
-use std::{
-    borrow::Borrow,
-    collections::{btree_map::Entry, BTreeMap},
-    path::PathBuf,
-};
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Span, Spans, Text},
     widgets::{Block, Borders, Paragraph, Widget},
+};
+use std::{
+    borrow::Borrow,
+    collections::{btree_map::Entry, BTreeMap},
+    path::PathBuf,
 };
 use tui_react::{
     draw_text_nowrap_fn,

--- a/src/interactive/widgets/mod.rs
+++ b/src/interactive/widgets/mod.rs
@@ -12,7 +12,7 @@ pub use help::*;
 pub use main::*;
 pub use mark::*;
 
-use tui::style::Color;
+use ratatui::style::Color;
 
 pub const COLOR_MARKED: Color = Color::Yellow;
 pub const COLOR_MARKED_DARK: Color = Color::Rgb(176, 126, 0);


### PR DESCRIPTION
- cargo toml patch is temporary and should be removed once the ratatui patches for crosstermion and tui-react are applied

I ran make tests

Relies on https://github.com/Byron/tui-crates/pull/2

[![asciicast](https://asciinema.org/a/6bzustyRZCzquhxgpsJpMEyfj.svg)](https://asciinema.org/a/6bzustyRZCzquhxgpsJpMEyfj)