### PR TITLE
Skip through single root directory

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,10 +126,15 @@ fn main() -> Result<()> {
     process::exit(res.to_exit_code());
 }
 
-fn paths_from(paths: Vec<PathBuf>, cross_filesystems: bool) -> Result<Vec<PathBuf>, io::Error> {
+fn paths_from(mut paths: Vec<PathBuf>, cross_filesystems: bool) -> Result<Vec<PathBuf>, io::Error> {
     let device_id = std::env::current_dir()
         .ok()
         .and_then(|cwd| crossdev::init(&cwd).ok());
+
+    if paths.len() == 1 {
+        std::env::set_current_dir(&paths[0])?;
+        paths.remove(0);
+    }
 
     if paths.is_empty() {
         cwd_dirlist().map(|paths| match device_id {


### PR DESCRIPTION
Implements the suggestion from #110 to skip single root directory.

Before:
<img width="505" alt="Screenshot 2023-12-06 at 00 05 25" src="https://github.com/Byron/dua-cli/assets/697414/003518c4-9914-491b-9e7f-9f3c9010fb6a">

After:
<img width="565" alt="Screenshot 2023-12-06 at 00 05 37" src="https://github.com/Byron/dua-cli/assets/697414/374e9952-5c1a-4516-bb8c-45f85758293e">
