### PR TITLE
Adds keybinding for 'c' to toggle sorting by number of items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "clap",
  "crosstermion",
  "filesize",
+ "human_format",
  "itertools",
  "jwalk",
  "num_cpus",
@@ -359,6 +360,12 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "human_format"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
 
 [[package]]
 name = "idna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tui-react = { version = "0.19.0", optional = true }
 open = { version = "5.0", optional = true }
 wild = "2.0.4"
 owo-colors = "3.5.0"
+human_format = "1.0.3"
 
 [[bin]]
 name="dua"

--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -9,10 +9,10 @@ pub enum SortMode {
     #[default]
     SizeDescending,
     SizeAscending,
-    MTimeAscending,
     MTimeDescending,
-    CountAscending,
+    MTimeAscending,
     CountDescending,
+    CountAscending,
 }
 
 impl SortMode {
@@ -21,7 +21,7 @@ impl SortMode {
         *self = match self {
             SizeDescending => SizeAscending,
             SizeAscending => SizeDescending,
-            _ => SizeAscending,
+            _ => SizeDescending,
         }
     }
 
@@ -30,7 +30,7 @@ impl SortMode {
         *self = match self {
             MTimeAscending => MTimeDescending,
             MTimeDescending => MTimeAscending,
-            _ => MTimeAscending,
+            _ => MTimeDescending,
         }
     }
 
@@ -39,7 +39,7 @@ impl SortMode {
         *self = match self {
             CountAscending => CountDescending,
             CountDescending => CountAscending,
-            _ => CountAscending,
+            _ => CountDescending,
         }
     }
 }

--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -11,6 +11,8 @@ pub enum SortMode {
     SizeAscending,
     MTimeAscending,
     MTimeDescending,
+    CountAscending,
+    CountDescending,
 }
 
 impl SortMode {
@@ -19,18 +21,25 @@ impl SortMode {
         *self = match self {
             SizeDescending => SizeAscending,
             SizeAscending => SizeDescending,
-            MTimeAscending => SizeAscending,
-            MTimeDescending => SizeDescending,
+            _ => SizeAscending,
         }
     }
 
     pub fn toggle_mtime(&mut self) {
         use SortMode::*;
         *self = match self {
-            SizeDescending => MTimeDescending,
-            SizeAscending => MTimeAscending,
             MTimeAscending => MTimeDescending,
             MTimeDescending => MTimeAscending,
+            _ => MTimeAscending,
+        }
+    }
+
+    pub fn toggle_count(&mut self) {
+        use SortMode::*;
+        *self = match self {
+            CountAscending => CountDescending,
+            CountDescending => CountAscending,
+            _ => CountAscending,
         }
     }
 }
@@ -62,6 +71,8 @@ pub fn sorted_entries(tree: &Tree, node_idx: TreeIndex, sorting: SortMode) -> Ve
             SizeAscending => l.data.size.cmp(&r.data.size),
             MTimeAscending => l.data.mtime.cmp(&r.data.mtime),
             MTimeDescending => r.data.mtime.cmp(&l.data.mtime),
+            CountAscending => l.data.entry_count.cmp(&r.data.entry_count),
+            CountDescending => r.data.entry_count.cmp(&l.data.entry_count),
         })
         .collect()
 }

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -149,6 +149,7 @@ impl AppState {
                     Ctrl('d') | PageDown => self.change_entry_selection(CursorDirection::PageDown),
                     Char('s') => self.cycle_sorting(traversal),
                     Char('m') => self.cycle_mtime_sorting(traversal),
+                    Char('c') => self.cycle_count_sorting(traversal),
                     Char('g') => display.byte_vis.cycle(),
                     _ => {}
                 },

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -161,6 +161,11 @@ impl AppState {
         self.entries = sorted_entries(&traversal.tree, self.root, self.sorting);
     }
 
+    pub fn cycle_count_sorting(&mut self, traversal: &Traversal) {
+        self.sorting.toggle_count();
+        self.entries = sorted_entries(&traversal.tree, self.root, self.sorting);
+    }
+
     pub fn reset_message(&mut self) {
         if self.is_scanning {
             self.message = Some("-> scanning <-".into());

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -67,14 +67,14 @@ fn simple_user_journey_read_only() -> Result<()> {
         app.process_events(&mut terminal, into_keys(b"m".iter()))?;
         assert_eq!(
             app.state.sorting,
-            SortMode::MTimeDescending,
+            SortMode::MTimeAscending,
             "it sets the sort mode to descending by mtime"
         );
         // when hitting the M key again
         app.process_events(&mut terminal, into_keys(b"m".iter()))?;
         assert_eq!(
             app.state.sorting,
-            SortMode::MTimeAscending,
+            SortMode::MTimeDescending,
             "it sets the sort mode to ascending by mtime"
         );
         // when hitting the S key

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -67,25 +67,44 @@ fn simple_user_journey_read_only() -> Result<()> {
         app.process_events(&mut terminal, into_keys(b"m".iter()))?;
         assert_eq!(
             app.state.sorting,
-            SortMode::MTimeAscending,
+            SortMode::MTimeDescending,
             "it sets the sort mode to descending by mtime"
         );
         // when hitting the M key again
         app.process_events(&mut terminal, into_keys(b"m".iter()))?;
         assert_eq!(
             app.state.sorting,
-            SortMode::MTimeDescending,
+            SortMode::MTimeAscending,
             "it sets the sort mode to ascending by mtime"
+        );
+        // when hitting the C key
+        app.process_events(&mut terminal, into_keys(b"c".iter()))?;
+        assert_eq!(
+            app.state.sorting,
+            SortMode::CountDescending,
+            "it sets the sort mode to descending by count"
+        );
+        // when hitting the C key again
+        app.process_events(&mut terminal, into_keys(b"c".iter()))?;
+        assert_eq!(
+            app.state.sorting,
+            SortMode::CountAscending,
+            "it sets the sort mode to ascending by count"
+        );
+        assert_eq!(
+            node_by_index(&app, app.state.entries[0].index),
+            node_by_name(&app, fixture_str(long_root)),
+            "it recomputes the cached entries"
         );
         // when hitting the S key
         app.process_events(&mut terminal, into_keys(b"s".iter()))?;
         assert_eq!(
             app.state.sorting,
-            SortMode::SizeAscending,
-            "it sets the sort mode to ascending by size"
+            SortMode::SizeDescending,
+            "it sets the sort mode to descending by size"
         );
         assert_eq!(
-            node_by_index(&app, app.state.entries[0].index),
+            node_by_index(&app, app.state.entries[1].index),
             node_by_name(&app, fixture_str(long_root)),
             "it recomputes the cached entries"
         );
@@ -93,9 +112,13 @@ fn simple_user_journey_read_only() -> Result<()> {
         app.process_events(&mut terminal, into_keys(b"s".iter()))?;
         assert_eq!(
             app.state.sorting,
-            SortMode::SizeDescending,
-            "it sets the sort mode to descending by size"
+            SortMode::SizeAscending,
+            "it sets the sort mode to ascending by size"
         );
+        // hit the S key again to get Descending - the rest depends on it
+        app.process_events(&mut terminal, into_keys(b"s".iter()))?;
+        assert_eq!(app.state.sorting, SortMode::SizeDescending,);
+
         assert_eq!(
             node_by_index(&app, app.state.entries[0].index),
             node_by_name(&app, fixture_str(short_root)),

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -13,7 +13,6 @@ use std::{
     fs::{copy, create_dir_all, remove_dir, remove_file},
     io::ErrorKind,
     path::{Path, PathBuf},
-    time::UNIX_EPOCH,
 };
 use tui::backend::TestBackend;
 use tui_react::Terminal;

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -224,32 +224,32 @@ pub fn sample_01_tree() -> Tree {
         let root_size = 1259070;
         #[cfg(windows)]
         let root_size = 1259069;
-        let rn = add_node("", root_size, None);
+        let rn = add_node("", root_size, 14, None);
         {
-            let sn = add_node(&fixture_str("sample-01"), root_size, Some(rn));
+            let sn = add_node(&fixture_str("sample-01"), root_size, 13, Some(rn));
             {
-                add_node(".hidden.666", 666, Some(sn));
-                add_node("a", 256, Some(sn));
-                add_node("b.empty", 0, Some(sn));
+                add_node(".hidden.666", 666, 0, Some(sn));
+                add_node("a", 256, 0, Some(sn));
+                add_node("b.empty", 0, 0, Some(sn));
                 #[cfg(not(windows))]
-                add_node("c.lnk", 1, Some(sn));
+                add_node("c.lnk", 1, 0, Some(sn));
                 #[cfg(windows)]
-                add_node("c.lnk", 0, Some(sn));
-                let dn = add_node("dir", 1258024, Some(sn));
+                add_node("c.lnk", 0, 0, Some(sn));
+                let dn = add_node("dir", 1258024, 7, Some(sn));
                 {
-                    add_node("1000bytes", 1000, Some(dn));
-                    add_node("dir-a.1mb", 1_000_000, Some(dn));
-                    add_node("dir-a.kb", 1024, Some(dn));
-                    let en = add_node("empty-dir", 0, Some(dn));
+                    add_node("1000bytes", 1000, 0, Some(dn));
+                    add_node("dir-a.1mb", 1_000_000, 0, Some(dn));
+                    add_node("dir-a.kb", 1024, 0, Some(dn));
+                    let en = add_node("empty-dir", 0, 1, Some(dn));
                     {
-                        add_node(".gitkeep", 0, Some(en));
+                        add_node(".gitkeep", 0, 0, Some(en));
                     }
-                    let sub = add_node("sub", 256_000, Some(dn));
+                    let sub = add_node("sub", 256_000, 1, Some(dn));
                     {
-                        add_node("dir-sub-a.256kb", 256_000, Some(sub));
+                        add_node("dir-sub-a.256kb", 256_000, 0, Some(sub));
                     }
                 }
-                add_node("z123.b", 123, Some(sn));
+                add_node("z123.b", 123, 0, Some(sn));
             }
         }
     }
@@ -261,27 +261,28 @@ pub fn sample_02_tree() -> Tree {
     {
         let mut add_node = make_add_node(&mut tree);
         let root_size = 1540;
-        let rn = add_node("", root_size, None);
+        let rn = add_node("", root_size, 10, None);
         {
             let sn = add_node(
                 Path::new(FIXTURE_PATH).join("sample-02").to_str().unwrap(),
                 root_size,
+                9,
                 Some(rn),
             );
             {
-                add_node("a", 256, Some(sn));
-                add_node("b", 1, Some(sn));
-                let dn = add_node("dir", 1283, Some(sn));
+                add_node("a", 256, 0, Some(sn));
+                add_node("b", 1, 0, Some(sn));
+                let dn = add_node("dir", 1283, 6, Some(sn));
                 {
-                    add_node("c", 257, Some(dn));
-                    add_node("d", 2, Some(dn));
-                    let en = add_node("empty-dir", 0, Some(dn));
+                    add_node("c", 257, 0, Some(dn));
+                    add_node("d", 2, 0, Some(dn));
+                    let en = add_node("empty-dir", 0, 1, Some(dn));
                     {
-                        add_node(".gitkeep", 0, Some(en));
+                        add_node(".gitkeep", 0, 0, Some(en));
                     }
-                    let sub = add_node("sub", 1024, Some(dn));
+                    let sub = add_node("sub", 1024, 1, Some(dn));
                     {
-                        add_node("e", 1024, Some(sub));
+                        add_node("e", 1024, 0, Some(sub));
                     }
                 }
             }
@@ -290,13 +291,15 @@ pub fn sample_02_tree() -> Tree {
     tree
 }
 
-pub fn make_add_node(t: &mut Tree) -> impl FnMut(&str, u128, Option<NodeIndex>) -> NodeIndex + '_ {
-    move |name, size, maybe_from_idx| {
+pub fn make_add_node(
+    t: &mut Tree,
+) -> impl FnMut(&str, u128, u64, Option<NodeIndex>) -> NodeIndex + '_ {
+    move |name, size, entry_count, maybe_from_idx| {
         let n = t.add_node(EntryData {
             name: PathBuf::from(name),
             size,
-            mtime: UNIX_EPOCH,
-            metadata_io_error: false,
+            entry_count,
+            ..Default::default()
         });
         if let Some(from) = maybe_from_idx {
             t.add_edge(from, n, ());

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -297,7 +297,7 @@ pub fn make_add_node(
         let n = t.add_node(EntryData {
             name: PathBuf::from(name),
             size,
-            entry_count,
+            entry_count: (entry_count > 0).then_some(entry_count),
             ..Default::default()
         });
         if let Some(from) = maybe_from_idx {

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -104,7 +104,6 @@ impl Entries {
                 if show_count_column(sort_mode) {
                     columns.push(count_column(
                         entry_data.entry_count,
-                        *is_dir,
                         column_style(Column::Count, *sort_mode, text_style),
                     ));
                 }
@@ -245,18 +244,18 @@ fn mtime_column(entry_mtime: SystemTime, style: Style) -> Span<'static> {
     Span::styled(format!("{:>20}", formatted_time), style)
 }
 
-fn count_column(entry_count: u64, is_dir: bool, style: Style) -> Span<'static> {
-    let count_in_units = human_format::Formatter::new()
-        .with_decimals(0)
-        .with_separator("")
-        .format(entry_count as f64);
+fn count_column(entry_count: Option<u64>, style: Style) -> Span<'static> {
     Span::styled(
         format!(
             "{:>4}",
-            if is_dir {
-                count_in_units
-            } else {
-                "".to_string()
+            match entry_count {
+                Some(count) => {
+                    human_format::Formatter::new()
+                        .with_decimals(0)
+                        .with_separator("")
+                        .format(count as f64)
+                }
+                None => "".to_string(),
             }
         ),
         style,

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -89,7 +89,7 @@ impl Entries {
                 let percentage_style = percentage_style(fraction, text_style);
 
                 let mut columns = Vec::new();
-                if should_show_mtime_column(sort_mode) {
+                if show_mtime_column(sort_mode) {
                     columns.push(mtime_column(
                         entry_data.mtime,
                         column_style(Column::MTime, *sort_mode, text_style),
@@ -101,7 +101,7 @@ impl Entries {
                     column_style(Column::Bytes, *sort_mode, text_style),
                 ));
                 columns.push(percentage_column(*display, fraction, percentage_style));
-                if should_show_count_column(sort_mode) {
+                if show_count_column(sort_mode) {
                     columns.push(count_column(
                         entry_data.entry_count,
                         *is_dir,
@@ -330,14 +330,14 @@ fn column_style(column: Column, sort_mode: SortMode, style: Style) -> Style {
     }
 }
 
-fn should_show_mtime_column(sort_mode: &SortMode) -> bool {
+fn show_mtime_column(sort_mode: &SortMode) -> bool {
     matches!(
         sort_mode,
         SortMode::MTimeAscending | SortMode::MTimeDescending
     )
 }
 
-fn should_show_count_column(sort_mode: &SortMode) -> bool {
+fn show_count_column(sort_mode: &SortMode) -> bool {
     matches!(
         sort_mode,
         SortMode::CountAscending | SortMode::CountDescending

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -5,6 +5,7 @@ use crate::interactive::{
 };
 use chrono::DateTime;
 use dua::traverse::{EntryData, Tree, TreeIndex};
+use human_format;
 use itertools::Itertools;
 use std::time::SystemTime;
 use std::{borrow::Borrow, path::Path};
@@ -89,15 +90,24 @@ impl Entries {
 
                 let mut columns = Vec::new();
                 if should_show_mtime_column(sort_mode) {
-                    columns.push(mtime_column(entry_data.mtime, *sort_mode, text_style));
+                    columns.push(mtime_column(
+                        entry_data.mtime,
+                        column_style(Column::MTime, *sort_mode, text_style),
+                    ));
                 }
                 columns.push(bytes_column(
                     *display,
                     entry_data.size,
-                    *sort_mode,
-                    text_style,
+                    column_style(Column::Bytes, *sort_mode, text_style),
                 ));
                 columns.push(percentage_column(*display, fraction, percentage_style));
+                if should_show_count_column(sort_mode) {
+                    columns.push(count_column(
+                        entry_data.entry_count,
+                        *is_dir,
+                        column_style(Column::Count, *sort_mode, text_style),
+                    ));
+                }
                 columns.push(name_column(
                     &entry_data.name,
                     *is_dir,
@@ -229,18 +239,27 @@ fn columns_with_separators(columns: Vec<Span<'_>>, style: Style) -> Vec<Span<'_>
     columns_with_separators
 }
 
-fn mtime_column(entry_mtime: SystemTime, sort_mode: SortMode, style: Style) -> Span<'static> {
+fn mtime_column(entry_mtime: SystemTime, style: Style) -> Span<'static> {
     let datetime = DateTime::<chrono::Utc>::from(entry_mtime);
     let formatted_time = datetime.format("%d/%m/%Y %H:%M:%S").to_string();
+    Span::styled(format!("{:>20}", formatted_time), style)
+}
+
+fn count_column(entry_count: u64, is_dir: bool, style: Style) -> Span<'static> {
+    let count_in_units = human_format::Formatter::new()
+        .with_decimals(0)
+        .with_separator("")
+        .format(entry_count as f64);
     Span::styled(
-        format!("{:>20}", formatted_time),
-        Style {
-            fg: match sort_mode {
-                SortMode::SizeAscending | SortMode::SizeDescending => style.fg,
-                SortMode::MTimeAscending | SortMode::MTimeDescending => Color::Green.into(),
-            },
-            ..style
-        },
+        format!(
+            "{:>4}",
+            if is_dir {
+                count_in_units
+            } else {
+                "".to_string()
+            }
+        ),
+        style,
     )
 }
 
@@ -279,31 +298,48 @@ fn percentage_column(display: DisplayOptions, fraction: f32, style: Style) -> Sp
     Span::styled(format!("{}", display.byte_vis.display(fraction)), style)
 }
 
-fn bytes_column(
-    display: DisplayOptions,
-    entry_size: u128,
-    sort_mode: SortMode,
-    style: Style,
-) -> Span<'static> {
+fn bytes_column(display: DisplayOptions, entry_size: u128, style: Style) -> Span<'static> {
     Span::styled(
         format!(
             "{:>byte_column_width$}",
             display.byte_format.display(entry_size).to_string(), // we would have to impl alignment/padding ourselves otherwise...
             byte_column_width = display.byte_format.width()
         ),
-        Style {
-            fg: match sort_mode {
-                SortMode::SizeAscending | SortMode::SizeDescending => Color::Green.into(),
-                SortMode::MTimeAscending | SortMode::MTimeDescending => style.fg,
-            },
-            ..style
-        },
+        style,
     )
+}
+
+#[derive(PartialEq)]
+enum Column {
+    Bytes,
+    MTime,
+    Count,
+}
+
+fn column_style(column: Column, sort_mode: SortMode, style: Style) -> Style {
+    Style {
+        fg: match (sort_mode, column) {
+            (SortMode::SizeAscending | SortMode::SizeDescending, Column::Bytes)
+            | (SortMode::MTimeAscending | SortMode::MTimeDescending, Column::MTime)
+            | (SortMode::CountAscending | SortMode::CountDescending, Column::Count) => {
+                Color::Green.into()
+            }
+            _ => style.fg,
+        },
+        ..style
+    }
 }
 
 fn should_show_mtime_column(sort_mode: &SortMode) -> bool {
     matches!(
         sort_mode,
         SortMode::MTimeAscending | SortMode::MTimeDescending
+    )
+}
+
+fn should_show_count_column(sort_mode: &SortMode) -> bool {
+    matches!(
+        sort_mode,
+        SortMode::CountAscending | SortMode::CountDescending
     )
 }

--- a/src/interactive/widgets/footer.rs
+++ b/src/interactive/widgets/footer.rs
@@ -43,6 +43,8 @@ impl Footer {
                     SortMode::SizeDescending => "size descending",
                     SortMode::MTimeAscending => "modified ascending",
                     SortMode::MTimeDescending => "modified descending",
+                    SortMode::CountAscending => "items ascending",
+                    SortMode::CountDescending => "items descending",
                 },
                 match total_bytes {
                     Some(b) => format!("{}", format.display(*b)),

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -134,6 +134,7 @@ impl HelpPane {
             {
                 hotkey("s", "toggle sort by size ascending/descending", None);
                 hotkey("m", "toggle sort by mtime ascending/descending", None);
+                hotkey("c", "toggle sort by items ascending/descending", None);
                 hotkey(
                     "g",
                     "cycle through percentage display and bar options",


### PR DESCRIPTION
Adds keybinding for 'c' to toggle sorting by number of items. I have used `human_format` to convert numbers to more human readable form.

Number of items in each directory is collected the same way as the size was done before during file system traversal. I have updated the tests to ensure the counts are calculated correctly.

Sorting by number of items + current sorting mode in the footer:
<img width="632" alt="Screenshot 2023-12-08 at 22 16 47" src="https://github.com/Byron/dua-cli/assets/697414/fa0b919a-ac04-4b71-8080-6d0a7be1a53f">
