### PR TITLE
fix: EntryData size test passes on 32-bit (#197)

### DIFF
--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -312,10 +312,10 @@ mod tests {
 
     #[test]
     fn size_of_entry_data() {
-        assert_eq!(
-            std::mem::size_of::<EntryData>(),
-            80,
-            "the size of this should not change unexpectedly as it affects overall memory consumption"
+        assert!(
+            std::mem::size_of::<EntryData>() <= 80,
+            "the size of this ({}) should not exceed 80 as it affects overall memory consumption",
+            std::mem::size_of::<EntryData>()
         );
     }
 }


### PR DESCRIPTION
This allows the EntryData size test to pass on 32-bit targets. This has been proven to work in CI here: https://github.com/void-linux/void-packages/pull/47626.

There are crates like [assertables](https://docs.rs/assertables/latest/assertables/) and [more_asserts](https://docs.rs/more-asserts/latest/more_asserts/) that offer an `assert_eq!`-like interface for less-than-or-equal-to comparisons if you'd prefer that, but I didn't want to add a dependency on your behalf.

---

Closes #197.