### PR TITLE
Implements glob search feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "trash",
  "tui-react",
  "unicode-segmentation",
+ "unicode-width",
  "wild",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,15 +15,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -315,12 +307,14 @@ version = "2.23.0"
 dependencies = [
  "anyhow",
  "atty",
+ "bstr",
  "byte-unit",
  "chrono",
  "clap",
  "crosstermion",
  "filesize",
- "globset",
+ "gix-glob",
+ "gix-path",
  "human_format",
  "itertools 0.12.0",
  "jwalk",
@@ -351,6 +345,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "filesize"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,23 +378,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-features"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d46a4a5c6bb5bebec9c0d18b65ada20e6517dbd7cf855b87dd4bbdce3a771b2"
+dependencies = [
+ "gix-hash",
+ "gix-trace",
+ "libc",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db19298c5eeea2961e5b3bf190767a2d1f09b8802aeb5f258e42276350aff19"
+dependencies = [
+ "bitflags 2.4.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8cf8c2266f63e582b7eb206799b63aa5fa68ee510ad349f637dfe2d0653de0"
+dependencies = [
+ "faster-hex",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86d6fac2fabe07b67b7835f46d07571f68b11aa1aaecae94fe722ea4ef305e1"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "home",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b686a35799b53a9825575ca3f06481d0a053a409c4d97ffcf5ddd67a8760b497"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "globset"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
-dependencies = [
- "aho-corasick",
- "bstr",
- "log",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "hashbrown"
@@ -423,6 +465,15 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "human_format"
@@ -776,17 +827,6 @@ name = "regex-automata"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustversion"
@@ -905,6 +945,26 @@ dependencies = [
  "libredox",
  "numtoa",
  "redox_termios",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +111,16 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "bstr"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542f33a8835a0884b006a0c3df3dadd99c0c3f296ed26c2fdc8028e01ad6230c"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "byte-unit"
@@ -301,6 +320,7 @@ dependencies = [
  "clap",
  "crosstermion",
  "filesize",
+ "globset",
  "human_format",
  "itertools 0.12.0",
  "jwalk",
@@ -358,6 +378,19 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "hashbrown"
@@ -519,6 +552,12 @@ checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -730,6 +769,23 @@ name = "redox_termios"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustversion"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ wild = "2.0.4"
 owo-colors = "3.5.0"
 human_format = "1.0.3"
 once_cell = "1.19"
-globset = "0.4.14"
+gix-glob = "0.14.1"
+gix-path = "0.10.1"
+bstr = "1.8.0"
 
 [[bin]]
 name="dua"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = ["tui-crossplatform", "trash-move"]
 tui-unix = ["crosstermion/tui-react-termion", "tui-shared"]
 tui-crossplatform = ["crosstermion/tui-react-crossterm", "tui-shared"]
 
-tui-shared = ["tui", "tui-react", "open", "unicode-segmentation"]
+tui-shared = ["tui", "tui-react", "open", "unicode-segmentation", "unicode-width"]
 trash-move = ["trash"]
 
 [dependencies]
@@ -32,6 +32,7 @@ chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 
 # 'tui' related
 unicode-segmentation = { version = "1.3.0", optional = true }
+unicode-width = { version = "0.1.5", optional = true }
 crosstermion = { version = "0.12.0", default-features = false, optional = true }
 tui = { package = "ratatui", version = "0.24.0", optional = true, default-features = false }
 tui-react = { version = "0.21.0", optional = true }
@@ -54,7 +55,7 @@ panic = 'abort'
 incremental = false
 overflow-checks = false
 lto = "fat"
-codegen-units = 1
+#codegen-units = 1
 build-override = { opt-level = 3 }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ wild = "2.0.4"
 owo-colors = "3.5.0"
 human_format = "1.0.3"
 once_cell = "1.19"
+globset = "0.4.14"
 
 [[bin]]
 name="dua"

--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -70,21 +70,22 @@ pub fn sorted_entries(
     }
     tree.neighbors_directed(node_idx, Direction::Outgoing)
         .filter_map(|idx| {
-            tree.node_weight(idx).map(|w| {
-                let mut use_glob_path = false;
-                if let Some(glob_root) = glob_root {
-                    use_glob_path = node_idx == glob_root;
-                }
-                let p = path_of(tree, idx, glob_root);
-                let pm = p.symlink_metadata();
+            tree.node_weight(idx).map(|entry| {
+                let use_glob_path = glob_root.map_or(false, |glob_root| glob_root == node_idx);
+                let path = path_of(tree, idx, glob_root);
+                let meta = path.symlink_metadata();
                 EntryDataBundle {
                     index: idx,
-                    name: if use_glob_path { p } else { w.name.clone() },
-                    size: w.size,
-                    mtime: w.mtime,
-                    entry_count: w.entry_count,
-                    exists: pm.is_ok(),
-                    is_dir: pm.ok().map_or(false, |m| m.is_dir()),
+                    name: if use_glob_path {
+                        path
+                    } else {
+                        entry.name.clone()
+                    },
+                    size: entry.size,
+                    mtime: entry.mtime,
+                    entry_count: entry.entry_count,
+                    exists: meta.is_ok(),
+                    is_dir: meta.ok().map_or(false, |m| m.is_dir()),
                 }
             })
         })

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -242,8 +242,13 @@ impl AppState {
                     tree_view.tree_as_mut().add_edge(tree_root, idx, ());
                 }
 
+                let glob_tree_view = GlobTreeView {
+                    traversal: tree_view.traversal_as_mut(),
+                    glob_tree_root: tree_root
+                };
+
                 let new_entries =
-                    sorted_entries(tree_view.tree(), tree_root, self.sorting, Some(tree_root));
+                    glob_tree_view.sorted_entries(tree_root, self.sorting);
 
                 let new_entries = self
                     .navigation_mut()
@@ -294,15 +299,16 @@ impl AppState {
         self.glob_mode = None;
         window.glob_pane = None;
 
+        let normal_tree_view = NormalTreeView {
+            traversal: tree_view.traversal_as_mut()
+        };
+
         let new_entries = self.navigation().selected.map(|previously_selected| {
             (
                 previously_selected,
-                sorted_entries(
-                    tree_view.tree(),
+                normal_tree_view.sorted_entries(
                     self.navigation().view_root,
-                    self.sorting,
-                    None,
-                ),
+                    self.sorting),
             )
         });
         self.enter_node(new_entries);

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -244,11 +244,10 @@ impl AppState {
 
                 let glob_tree_view = GlobTreeView {
                     traversal: tree_view.traversal_as_mut(),
-                    glob_tree_root: tree_root
+                    glob_tree_root: tree_root,
                 };
 
-                let new_entries =
-                    glob_tree_view.sorted_entries(tree_root, self.sorting);
+                let new_entries = glob_tree_view.sorted_entries(tree_root, self.sorting);
 
                 let new_entries = self
                     .navigation_mut()
@@ -300,15 +299,13 @@ impl AppState {
         window.glob_pane = None;
 
         let normal_tree_view = NormalTreeView {
-            traversal: tree_view.traversal_as_mut()
+            traversal: tree_view.traversal_as_mut(),
         };
 
         let new_entries = self.navigation().selected.map(|previously_selected| {
             (
                 previously_selected,
-                normal_tree_view.sorted_entries(
-                    self.navigation().view_root,
-                    self.sorting),
+                normal_tree_view.sorted_entries(self.navigation().view_root, self.sorting),
             )
         });
         self.enter_node(new_entries);

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -1,36 +1,39 @@
 use crate::interactive::{
+    app::navigation::NavigationState,
     sorted_entries,
-    widgets::{MainWindow, MainWindowProps},
+    widgets::{glob_search, MainWindow, MainWindowProps},
     ByteVisualization, CursorDirection, CursorMode, DisplayOptions, EntryDataBundle, MarkEntryMode,
     SortMode,
 };
 use anyhow::Result;
 use crosstermion::input::{input_channel, Event, Key};
 use dua::{
-    traverse::{Traversal, TreeIndex},
+    traverse::{EntryData, Traversal},
     WalkOptions, WalkResult,
 };
-use std::{collections::BTreeMap, path::PathBuf};
+use std::path::PathBuf;
 use tui::backend::Backend;
 use tui_react::Terminal;
 
-#[derive(Default, Copy, Clone)]
+use super::tree_view::{GlobTreeView, NormalTreeView, TreeView};
+
+#[derive(Default, Copy, Clone, PartialEq)]
 pub enum FocussedPane {
     #[default]
     Main,
     Help,
     Mark,
+    Glob,
 }
 
 #[derive(Default)]
 pub struct AppState {
-    pub root: TreeIndex,
-    pub selected: Option<TreeIndex>,
+    pub normal_mode: NavigationState,
+    pub glob_mode: Option<NavigationState>,
     pub entries: Vec<EntryDataBundle>,
     pub sorting: SortMode,
     pub message: Option<String>,
     pub focussed: FocussedPane,
-    pub bookmarks: BTreeMap<TreeIndex, TreeIndex>,
     pub is_scanning: bool,
 }
 
@@ -40,10 +43,18 @@ pub enum ProcessingResult {
 }
 
 impl AppState {
+    pub fn navigation_mut(&mut self) -> &mut NavigationState {
+        self.glob_mode.as_mut().unwrap_or(&mut self.normal_mode)
+    }
+
+    pub fn navigation(&self) -> &NavigationState {
+        self.glob_mode.as_ref().unwrap_or(&self.normal_mode)
+    }
+
     pub fn draw<B>(
         &mut self,
         window: &mut MainWindow,
-        traversal: &Traversal,
+        tree_view: &dyn TreeView,
         display: DisplayOptions,
         terminal: &mut Terminal<B>,
     ) -> Result<()>
@@ -51,7 +62,11 @@ impl AppState {
         B: Backend,
     {
         let props = MainWindowProps {
-            traversal,
+            current_path: tree_view.current_path(self.navigation().view_root),
+            entries_traversed: tree_view.traversal().entries_traversed,
+            total_bytes: tree_view.traversal().total_bytes,
+            start: tree_view.traversal().start,
+            elapsed: tree_view.traversal().elapsed,
             display,
             state: self,
         };
@@ -72,93 +87,220 @@ impl AppState {
         use crosstermion::input::Key::*;
         use FocussedPane::*;
 
-        self.draw(window, traversal, *display, terminal)?;
+        {
+            let tree_view = self.tree_view(traversal);
+            self.draw(window, tree_view.as_ref(), *display, terminal)?;
+        }
+
         for event in events {
             let key = match event {
                 Event::Key(key) => key,
                 Event::Resize(_, _) => Alt('\r'),
             };
 
+            let mut tree_view = self.tree_view(traversal);
+
             self.reset_message();
+            let mut handled = true;
             match key {
-                Char('?') => self.toggle_help_pane(window),
+                Char('?') if self.focussed != FocussedPane::Glob => self.toggle_help_pane(window),
+                Char('/') if self.focussed != FocussedPane::Glob => {
+                    self.toggle_glob_search(window);
+                }
                 Char('\t') => {
                     self.cycle_focus(window);
                 }
-                Ctrl('c') => {
+                Ctrl('c') if self.focussed != FocussedPane::Glob => {
                     return Ok(ProcessingResult::ExitRequested(WalkResult {
-                        num_errors: traversal.io_errors,
+                        num_errors: tree_view.traversal().io_errors,
                     }))
                 }
-                Char('q') | Esc => match self.focussed {
-                    Main => {
-                        return Ok(ProcessingResult::ExitRequested(WalkResult {
-                            num_errors: traversal.io_errors,
-                        }))
+                Char('q') if self.focussed != FocussedPane::Glob => {
+                    if let Some(value) = self.handle_quit(tree_view.as_mut(), window) {
+                        return value;
                     }
-                    Mark => self.focussed = Main,
-                    Help => {
-                        self.focussed = Main;
-                        window.help_pane = None
+                }
+                Esc => {
+                    if let Some(value) = self.handle_quit(tree_view.as_mut(), window) {
+                        return value;
                     }
-                },
-                _ => {}
+                }
+                _ => {
+                    handled = false;
+                }
             }
 
-            match self.focussed {
-                Mark => self.dispatch_to_mark_pane(key, window, traversal, *display, terminal),
-                Help => {
-                    window
-                        .help_pane
-                        .as_mut()
-                        .expect("help pane")
-                        .process_events(key);
-                }
-                Main => match key {
-                    Char('O') => self.open_that(traversal),
-                    Char(' ') => self.mark_entry(
-                        CursorMode::KeepPosition,
-                        MarkEntryMode::Toggle,
+            if !handled {
+                match self.focussed {
+                    Mark => self.dispatch_to_mark_pane(
+                        key,
                         window,
-                        traversal,
+                        tree_view.as_mut(),
+                        *display,
+                        terminal,
                     ),
-                    Char('d') => self.mark_entry(
-                        CursorMode::Advance,
-                        MarkEntryMode::Toggle,
-                        window,
-                        traversal,
-                    ),
-                    Char('x') => self.mark_entry(
-                        CursorMode::Advance,
-                        MarkEntryMode::MarkForDeletion,
-                        window,
-                        traversal,
-                    ),
-                    Char('a') => self.mark_all_entries(MarkEntryMode::Toggle, window, traversal),
-                    Char('u') | Char('h') | Backspace | Left => {
-                        self.exit_node_with_traversal(traversal)
+                    Help => {
+                        window
+                            .help_pane
+                            .as_mut()
+                            .expect("help pane")
+                            .process_events(key);
                     }
-                    Char('o') | Char('l') | Char('\n') | Right => {
-                        self.enter_node_with_traversal(traversal)
+                    Glob => {
+                        let glob_pane = window.glob_pane.as_mut().expect("glob pane");
+                        match key {
+                            Char('\n') => {
+                                self.search_glob_pattern(tree_view.as_mut(), &glob_pane.input)
+                            }
+                            _ => glob_pane.process_events(key),
+                        }
                     }
-                    Char('H') | Home => self.change_entry_selection(CursorDirection::ToTop),
-                    Char('G') | End => self.change_entry_selection(CursorDirection::ToBottom),
-                    Ctrl('u') | PageUp => self.change_entry_selection(CursorDirection::PageUp),
-                    Char('k') | Up => self.change_entry_selection(CursorDirection::Up),
-                    Char('j') | Down => self.change_entry_selection(CursorDirection::Down),
-                    Ctrl('d') | PageDown => self.change_entry_selection(CursorDirection::PageDown),
-                    Char('s') => self.cycle_sorting(traversal),
-                    Char('m') => self.cycle_mtime_sorting(traversal),
-                    Char('c') => self.cycle_count_sorting(traversal),
-                    Char('g') => display.byte_vis.cycle(),
-                    _ => {}
-                },
-            };
-            self.draw(window, traversal, *display, terminal)?;
+                    Main => match key {
+                        Char('O') => self.open_that(tree_view.as_ref()),
+                        Char(' ') => self.mark_entry(
+                            CursorMode::KeepPosition,
+                            MarkEntryMode::Toggle,
+                            window,
+                            tree_view.as_ref(),
+                        ),
+                        Char('d') => self.mark_entry(
+                            CursorMode::Advance,
+                            MarkEntryMode::Toggle,
+                            window,
+                            tree_view.as_ref(),
+                        ),
+                        Char('x') => self.mark_entry(
+                            CursorMode::Advance,
+                            MarkEntryMode::MarkForDeletion,
+                            window,
+                            tree_view.as_ref(),
+                        ),
+                        Char('a') => {
+                            self.mark_all_entries(MarkEntryMode::Toggle, window, tree_view.as_ref())
+                        }
+                        Char('u') | Char('h') | Backspace | Left => {
+                            self.exit_node_with_traversal(tree_view.as_ref())
+                        }
+                        Char('o') | Char('l') | Char('\n') | Right => {
+                            self.enter_node_with_traversal(tree_view.as_ref())
+                        }
+                        Char('H') | Home => self.change_entry_selection(CursorDirection::ToTop),
+                        Char('G') | End => self.change_entry_selection(CursorDirection::ToBottom),
+                        Ctrl('u') | PageUp => self.change_entry_selection(CursorDirection::PageUp),
+                        Char('k') | Up => self.change_entry_selection(CursorDirection::Up),
+                        Char('j') | Down => self.change_entry_selection(CursorDirection::Down),
+                        Ctrl('d') | PageDown => {
+                            self.change_entry_selection(CursorDirection::PageDown)
+                        }
+                        Char('s') => self.cycle_sorting(tree_view.as_ref()),
+                        Char('m') => self.cycle_mtime_sorting(tree_view.as_ref()),
+                        Char('c') => self.cycle_count_sorting(tree_view.as_ref()),
+                        Char('g') => display.byte_vis.cycle(),
+                        _ => {}
+                    },
+                };
+            }
+            self.draw(window, tree_view.as_ref(), *display, terminal)?;
         }
         Ok(ProcessingResult::Finished(WalkResult {
             num_errors: traversal.io_errors,
         }))
+    }
+
+    fn tree_view<'a>(&mut self, traversal: &'a mut Traversal) -> Box<dyn TreeView + 'a> {
+        let tree_view: Box<dyn TreeView> = if let Some(glob_source) = &self.glob_mode {
+            Box::new(GlobTreeView {
+                traversal,
+                glob_tree_root: glob_source.tree_root,
+            })
+        } else {
+            Box::new(NormalTreeView { traversal })
+        };
+        tree_view
+    }
+
+    fn search_glob_pattern(&mut self, tree_view: &mut dyn TreeView, glob_pattern: &str) {
+        use FocussedPane::*;
+        let search_results =
+            glob_search(tree_view.tree(), self.normal_mode.view_root, glob_pattern);
+        match search_results {
+            Ok(search_results) => {
+                if let Some(glob_source) = &self.glob_mode {
+                    tree_view.tree_as_mut().remove_node(glob_source.tree_root);
+                }
+
+                let tree_root = tree_view.tree_as_mut().add_node(EntryData::default());
+                let glob_source = NavigationState {
+                    tree_root,
+                    view_root: tree_root,
+                    selected: Some(tree_root),
+                    ..Default::default()
+                };
+                self.glob_mode = Some(glob_source);
+
+                for idx in search_results {
+                    tree_view.tree_as_mut().add_edge(tree_root, idx, ());
+                }
+
+                let new_entries =
+                    sorted_entries(tree_view.tree(), tree_root, self.sorting, Some(tree_root));
+
+                let new_entries = self
+                    .navigation_mut()
+                    .selected
+                    .map(|previously_selected| (previously_selected, new_entries));
+
+                self.enter_node(new_entries);
+                self.focussed = Main;
+            }
+            _ => self.message = Some("Glob search error!".into()),
+        }
+    }
+
+    fn handle_quit(
+        &mut self,
+        tree_view: &mut dyn TreeView,
+        window: &mut MainWindow,
+    ) -> Option<std::result::Result<ProcessingResult, anyhow::Error>> {
+        use FocussedPane::*;
+        match self.focussed {
+            Main => {
+                if self.glob_mode.is_some() {
+                    self.handle_glob_quit(tree_view, window);
+                } else {
+                    return Some(Ok(ProcessingResult::ExitRequested(WalkResult {
+                        num_errors: tree_view.traversal().io_errors,
+                    })));
+                }
+            }
+            Mark => self.focussed = Main,
+            Help => {
+                self.focussed = Main;
+                window.help_pane = None
+            }
+            Glob => {
+                self.handle_glob_quit(tree_view, window);
+            }
+        }
+        None
+    }
+
+    fn handle_glob_quit(&mut self, tree_view: &mut dyn TreeView, window: &mut MainWindow) {
+        use FocussedPane::*;
+        self.focussed = Main;
+        if let Some(glob_source) = &self.glob_mode {
+            tree_view.tree_as_mut().remove_node(glob_source.tree_root);
+        }
+        self.glob_mode = None;
+        window.glob_pane = None;
+
+        let new_entries = self.navigation().selected.map(|previously_selected| {
+            (
+                previously_selected,
+                tree_view.sorted_entries(self.navigation().view_root, self.sorting),
+            )
+        });
+        self.enter_node(new_entries);
     }
 }
 
@@ -171,7 +313,7 @@ where
     B: Backend,
 {
     let area = terminal.pre_render()?;
-    window.render(props, area, terminal.current_buffer_mut());
+    window.render(props, area, terminal);
     terminal.post_render()?;
     Ok(())
 }
@@ -202,6 +344,7 @@ impl TerminalApp {
             )
             .ok();
     }
+
     pub fn process_events<B>(
         &mut self,
         terminal: &mut Terminal<B>,
@@ -258,11 +401,16 @@ impl TerminalApp {
         let mut received_events = false;
         let traversal = Traversal::from_walk(options, input_paths, |traversal| {
             if !received_events {
-                state.root = traversal.root_index;
+                state.navigation_mut().view_root = traversal.root_index;
             }
-            state.entries = sorted_entries(&traversal.tree, state.root, state.sorting);
+            state.entries = sorted_entries(
+                &traversal.tree,
+                state.navigation().view_root,
+                state.sorting,
+                state.glob_root(),
+            );
             if !received_events {
-                state.selected = state.entries.first().map(|b| b.index);
+                state.navigation_mut().selected = state.entries.first().map(|b| b.index);
             }
             state.reset_message(); // force "scanning" to appear
 
@@ -279,6 +427,7 @@ impl TerminalApp {
                 ProcessingResult::ExitRequested(_) => true,
                 ProcessingResult::Finished(_) => false,
             };
+
             Ok(should_exit)
         })?;
 
@@ -289,10 +438,16 @@ impl TerminalApp {
 
         state.is_scanning = false;
         if !received_events {
-            state.root = traversal.root_index;
+            state.navigation_mut().view_root = traversal.root_index;
         }
-        state.entries = sorted_entries(&traversal.tree, state.root, state.sorting);
-        state.selected = state
+        state.entries = sorted_entries(
+            &traversal.tree,
+            state.navigation().view_root,
+            state.sorting,
+            state.glob_root(),
+        );
+        state.navigation_mut().selected = state
+            .navigation()
             .selected
             .filter(|_| received_events)
             .or_else(|| state.entries.first().map(|b| b.index));

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -297,7 +297,12 @@ impl AppState {
         let new_entries = self.navigation().selected.map(|previously_selected| {
             (
                 previously_selected,
-                tree_view.sorted_entries(self.navigation().view_root, self.sorting),
+                sorted_entries(
+                    tree_view.tree(),
+                    self.navigation().view_root,
+                    self.sorting,
+                    None,
+                ),
             )
         });
         self.enter_node(new_entries);

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -140,10 +140,7 @@ impl AppState {
                 window.glob_pane = Some(GlobPane::default());
                 Glob
             }
-            Glob => {
-                window.glob_pane = None;
-                Main
-            }
+            Glob => unreachable!("BUG: glob pane must catch the input leading here"),
         }
     }
 
@@ -329,7 +326,7 @@ impl AppState {
     }
 
     pub fn glob_root(&self) -> Option<TreeIndex> {
-        self.glob_mode.as_ref().map(|e| e.tree_root)
+        self.glob_navigation.as_ref().map(|e| e.tree_root)
     }
 
     fn mark_entry_by_index(

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -115,8 +115,8 @@ impl AppState {
     }
 
     pub fn change_entry_selection(&mut self, direction: CursorDirection) {
-        let nex_index = self.navigation().get_next_index(direction, &self.entries);
-        self.navigation_mut().select(nex_index);
+        let next_index = self.navigation().get_next_index(direction, &self.entries);
+        self.navigation_mut().select(next_index);
     }
 
     pub fn cycle_sorting(&mut self, tree_view: &dyn TreeView) {

--- a/src/interactive/app/mod.rs
+++ b/src/interactive/app/mod.rs
@@ -2,6 +2,8 @@ mod bytevis;
 mod common;
 mod eventloop;
 mod handlers;
+mod navigation;
+pub mod tree_view;
 
 pub use bytevis::*;
 pub use common::*;

--- a/src/interactive/app/navigation.rs
+++ b/src/interactive/app/navigation.rs
@@ -13,7 +13,7 @@ pub struct Navigation {
 }
 
 impl Navigation {
-    pub fn get_previously_selected_index(
+    pub fn previously_selected_index(
         &self,
         view_root: TreeIndex,
         entries: &[EntryDataBundle],
@@ -47,7 +47,7 @@ impl Navigation {
             .or_else(|| entries.first().map(|b| b.index));
     }
 
-    pub fn get_next_index(
+    pub fn next_index(
         &self,
         direction: CursorDirection,
         entries: &[EntryDataBundle],

--- a/src/interactive/app/navigation.rs
+++ b/src/interactive/app/navigation.rs
@@ -1,0 +1,79 @@
+use dua::traverse::TreeIndex;
+use itertools::Itertools;
+use std::collections::BTreeMap;
+
+use super::{CursorDirection, EntryDataBundle};
+
+#[derive(Default)]
+pub struct NavigationState {
+    pub tree_root: TreeIndex,
+    pub view_root: TreeIndex,
+    pub selected: Option<TreeIndex>,
+    pub bookmarks: BTreeMap<TreeIndex, TreeIndex>,
+}
+
+impl NavigationState {
+    pub fn get_previously_selected_index(
+        &self,
+        view_root: TreeIndex,
+        entries: &[EntryDataBundle],
+    ) -> Option<TreeIndex> {
+        let idx = self
+            .bookmarks
+            .get(&view_root)
+            .and_then(|selected| {
+                entries
+                    .iter()
+                    .find_position(|b| b.index == *selected)
+                    .map(|(pos, _)| pos)
+            })
+            .unwrap_or(0);
+        entries.get(idx).map(|a| a.index)
+    }
+
+    pub fn enter_node(&mut self, previously_selected: TreeIndex, new_selected: TreeIndex) {
+        let view_root = self.view_root;
+        self.bookmarks.insert(view_root, previously_selected);
+        self.view_root = previously_selected;
+        self.selected = Some(new_selected);
+    }
+
+    pub fn exit_node(&mut self, parent_idx: TreeIndex, entries: &[EntryDataBundle]) {
+        self.view_root = parent_idx;
+        self.selected = self
+            .bookmarks
+            .get(&parent_idx)
+            .copied()
+            .or_else(|| entries.first().map(|b| b.index));
+    }
+
+    pub fn get_next_index(
+        &self,
+        direction: CursorDirection,
+        entries: &[EntryDataBundle],
+    ) -> Option<TreeIndex> {
+        let next_selected_pos = match self.selected {
+            Some(ref selected) => entries
+                .iter()
+                .find_position(|b| b.index == *selected)
+                .map(|(idx, _)| direction.move_cursor(idx))
+                .unwrap_or(0),
+            None => 0,
+        };
+
+        let selected = entries
+            .get(next_selected_pos)
+            .or_else(|| entries.last())
+            .map(|b| b.index);
+
+        selected.or(self.selected)
+    }
+
+    pub fn select(&mut self, selected: Option<TreeIndex>) {
+        self.selected = selected;
+        if let Some(selected) = selected {
+            let view_root = self.view_root;
+            self.bookmarks.insert(view_root, selected);
+        }
+    }
+}

--- a/src/interactive/app/navigation.rs
+++ b/src/interactive/app/navigation.rs
@@ -5,14 +5,14 @@ use std::collections::BTreeMap;
 use super::{CursorDirection, EntryDataBundle};
 
 #[derive(Default)]
-pub struct NavigationState {
+pub struct Navigation {
     pub tree_root: TreeIndex,
     pub view_root: TreeIndex,
     pub selected: Option<TreeIndex>,
     pub bookmarks: BTreeMap<TreeIndex, TreeIndex>,
 }
 
-impl NavigationState {
+impl Navigation {
     pub fn get_previously_selected_index(
         &self,
         view_root: TreeIndex,
@@ -61,19 +61,17 @@ impl NavigationState {
             None => 0,
         };
 
-        let selected = entries
+        entries
             .get(next_selected_pos)
             .or_else(|| entries.last())
-            .map(|b| b.index);
-
-        selected.or(self.selected)
+            .map(|b| b.index)
+            .or(self.selected)
     }
 
     pub fn select(&mut self, selected: Option<TreeIndex>) {
         self.selected = selected;
         if let Some(selected) = selected {
-            let view_root = self.view_root;
-            self.bookmarks.insert(view_root, selected);
+            self.bookmarks.insert(self.view_root, selected);
         }
     }
 }

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -51,12 +51,13 @@ fn simple_user_journey_read_only() -> Result<()> {
 
         assert_eq!(
             node_by_name(&app, fixture_str(short_root)),
-            node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+            node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
             "it selects the first node in the list",
         );
 
         assert_eq!(
-            app.traversal.root_index, app.state.root,
+            app.traversal.root_index,
+            app.state.navigation().view_root,
             "the root is the 'virtual' root",
         );
     }
@@ -132,28 +133,28 @@ fn simple_user_journey_read_only() -> Result<()> {
         app.process_events(&mut terminal, into_keys(b"j".iter()))?;
         assert_eq!(
             node_by_name(&app, fixture_str(long_root)),
-            node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+            node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
             "it moves the cursor down and selects the next entry based on the current sort mode"
         );
         // when hitting it while there is nowhere to go
         app.process_events(&mut terminal, into_keys(b"j".iter()))?;
         assert_eq!(
             node_by_name(&app, fixture_str(long_root)),
-            node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+            node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
             "it stays at the previous position"
         );
         // when hitting the k key
         app.process_events(&mut terminal, into_keys(b"k".iter()))?;
         assert_eq!(
             node_by_name(&app, fixture_str(short_root)),
-            node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+            node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
             "it moves the cursor up and selects the next entry based on the current sort mode"
         );
         // when hitting the k key again
         app.process_events(&mut terminal, into_keys(b"k".iter()))?;
         assert_eq!(
             node_by_name(&app, fixture_str(short_root)),
-            node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+            node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
             "it stays at the current cursor position as there is nowhere to go"
         );
         // when hitting the o key with a directory selected
@@ -161,12 +162,13 @@ fn simple_user_journey_read_only() -> Result<()> {
         {
             let new_root_idx = index_by_name(&app, fixture_str(short_root));
             assert_eq!(
-                new_root_idx, app.state.root,
+                new_root_idx,
+                app.state.navigation().view_root,
                 "it enters the entry if it is a directory, changing the root"
             );
             assert_eq!(
                 index_by_name(&app, "dir"),
-                *app.state.selected.as_ref().unwrap(),
+                *app.state.navigation().selected.as_ref().unwrap(),
                 "it selects the first entry in the directory"
             );
 
@@ -174,12 +176,13 @@ fn simple_user_journey_read_only() -> Result<()> {
             app.process_events(&mut terminal, into_keys(b"u".iter()))?;
             {
                 assert_eq!(
-                    app.traversal.root_index, app.state.root,
+                    app.traversal.root_index,
+                    app.state.navigation().view_root,
                     "it sets the root to be the (roots) parent directory, being the virtual root"
                 );
                 assert_eq!(
                     node_by_name(&app, fixture_str(short_root)),
-                    node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+                    node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
                     "changes the selection to the first item in the list of entries"
                 );
             }
@@ -189,12 +192,13 @@ fn simple_user_journey_read_only() -> Result<()> {
         app.process_events(&mut terminal, into_keys(b"ju".iter()))?;
         {
             assert_eq!(
-                app.traversal.root_index, app.state.root,
+                app.traversal.root_index,
+                app.state.navigation().view_root,
                 "it keeps the root - it can't go further up"
             );
             assert_eq!(
                 node_by_name(&app, fixture_str(long_root)),
-                node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+                node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
                 "keeps the previous selection"
             );
         }
@@ -204,7 +208,7 @@ fn simple_user_journey_read_only() -> Result<()> {
     {
         // when hitting the 'd' key (also move cursor back to start)
         app.process_events(&mut terminal, into_keys(b"k".iter()))?;
-        let previously_selected_index = *app.state.selected.as_ref().unwrap();
+        let previously_selected_index = *app.state.navigation().selected.as_ref().unwrap();
         app.process_events(&mut terminal, into_keys(b"d".iter()))?;
         {
             assert_eq!(
@@ -219,7 +223,7 @@ fn simple_user_journey_read_only() -> Result<()> {
                 "it marks the selected node"
             );
             assert_eq!(
-                app.state.selected.as_ref().unwrap().index(),
+                app.state.navigation().selected.as_ref().unwrap().index(),
                 app.state.entries[1].index.index(),
                 "moves the cursor down one level to facilitate many markings in a row"
             );
@@ -236,7 +240,7 @@ fn simple_user_journey_read_only() -> Result<()> {
             );
 
             assert_eq!(
-                app.state.selected.as_ref().unwrap().index(),
+                app.state.navigation().selected.as_ref().unwrap().index(),
                 app.state.entries[1].index.index(),
                 "it could not advance the cursor, thus the newly marked item is still selected"
             );
@@ -271,7 +275,7 @@ fn simple_user_journey_read_only() -> Result<()> {
 
             assert_eq!(
                 node_by_index(&app, previously_selected_index),
-                node_by_index(&app, *app.state.selected.as_ref().unwrap()),
+                node_by_index(&app, *app.state.navigation().selected.as_ref().unwrap()),
                 "it does not advance the selection"
             );
         }

--- a/src/interactive/app/tests/journeys_with_writes.rs
+++ b/src/interactive/app/tests/journeys_with_writes.rs
@@ -32,9 +32,14 @@ fn basic_user_journey_with_deletion() -> Result<()> {
         app.window.mark_pane.is_none(),
         "the marker pane is gone as all entries have been removed"
     );
-    assert_eq!(app.state.selected, None, "nothing is left to be selected");
     assert_eq!(
-        app.state.root, app.traversal.root_index,
+        app.state.navigation().selected,
+        None,
+        "nothing is left to be selected"
+    );
+    assert_eq!(
+        app.state.navigation().view_root,
+        app.traversal.root_index,
         "the only root left is the top-level"
     );
     assert!(

--- a/src/interactive/app/tests/unit.rs
+++ b/src/interactive/app/tests/unit.rs
@@ -33,7 +33,7 @@ fn it_can_handle_ending_traversal_without_reaching_the_top() -> Result<()> {
 }
 
 #[test]
-fn glob_pattern() {
+fn it_can_do_a_glob_search() {
     let (tree, root_index) = sample_02_tree();
     let result = glob_search(&tree, root_index, "tests/fixtures/sample-02").unwrap();
     let expected = vec![TreeIndex::from(1)];

--- a/src/interactive/app/tests/unit.rs
+++ b/src/interactive/app/tests/unit.rs
@@ -22,7 +22,7 @@ fn it_can_handle_ending_traversal_reaching_top_but_skipping_levels() -> Result<(
 #[test]
 fn it_can_handle_ending_traversal_without_reaching_the_top() -> Result<()> {
     let (_, app) = initialized_app_and_terminal_from_fixture(&["sample-02"])?;
-    let (expected_tree, _) = sample_02_tree();
+    let (expected_tree, _) = sample_02_tree(true);
 
     assert_eq!(
         debug(app.traversal.tree),
@@ -34,7 +34,7 @@ fn it_can_handle_ending_traversal_without_reaching_the_top() -> Result<()> {
 
 #[test]
 fn it_can_do_a_glob_search() {
-    let (tree, root_index) = sample_02_tree();
+    let (tree, root_index) = sample_02_tree(false);
     let result = glob_search(&tree, root_index, "tests/fixtures/sample-02").unwrap();
     let expected = vec![TreeIndex::from(1)];
     assert_eq!(result, expected);

--- a/src/interactive/app/tests/unit.rs
+++ b/src/interactive/app/tests/unit.rs
@@ -1,7 +1,9 @@
 use crate::interactive::app::tests::utils::{
     debug, initialized_app_and_terminal_from_fixture, sample_01_tree, sample_02_tree,
 };
+use crate::interactive::widgets::glob_search;
 use anyhow::Result;
+use dua::traverse::TreeIndex;
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -20,7 +22,7 @@ fn it_can_handle_ending_traversal_reaching_top_but_skipping_levels() -> Result<(
 #[test]
 fn it_can_handle_ending_traversal_without_reaching_the_top() -> Result<()> {
     let (_, app) = initialized_app_and_terminal_from_fixture(&["sample-02"])?;
-    let expected_tree = sample_02_tree();
+    let (expected_tree, _) = sample_02_tree();
 
     assert_eq!(
         debug(app.traversal.tree),
@@ -28,4 +30,12 @@ fn it_can_handle_ending_traversal_without_reaching_the_top() -> Result<()> {
         "filesystem graph is stable and matches the directory structure"
     );
     Ok(())
+}
+
+#[test]
+fn glob_pattern() {
+    let (tree, root_index) = sample_02_tree();
+    let result = glob_search(&tree, root_index, "tests/fixtures/sample-02").unwrap();
+    let expected = vec![TreeIndex::from(1)];
+    assert_eq!(result, expected);
 }

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -255,18 +255,19 @@ pub fn sample_01_tree() -> Tree {
     tree
 }
 
-pub fn sample_02_tree() -> Tree {
+pub fn sample_02_tree() -> (Tree, TreeIndex) {
     let mut tree = Tree::new();
+    let root_index: TreeIndex;
     {
         let mut add_node = make_add_node(&mut tree);
         let root_size = 1540;
-        let rn = add_node("", root_size, 10, None);
+        root_index = add_node("", root_size, 10, None);
         {
             let sn = add_node(
                 Path::new(FIXTURE_PATH).join("sample-02").to_str().unwrap(),
                 root_size,
                 9,
-                Some(rn),
+                Some(root_index),
             );
             {
                 add_node("a", 256, 0, Some(sn));
@@ -287,7 +288,7 @@ pub fn sample_02_tree() -> Tree {
             }
         }
     }
-    tree
+    (tree, root_index)
 }
 
 pub fn make_add_node(

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -255,7 +255,7 @@ pub fn sample_01_tree() -> Tree {
     tree
 }
 
-pub fn sample_02_tree() -> (Tree, TreeIndex) {
+pub fn sample_02_tree(use_native_separator: bool) -> (Tree, TreeIndex) {
     let mut tree = Tree::new();
     let root_index: TreeIndex;
     {
@@ -264,7 +264,15 @@ pub fn sample_02_tree() -> (Tree, TreeIndex) {
         root_index = add_node("", root_size, 10, None);
         {
             let sn = add_node(
-                Path::new(FIXTURE_PATH).join("sample-02").to_str().unwrap(),
+                format!(
+                    "{FIXTURE_PATH}{}sample-02",
+                    if use_native_separator {
+                        std::path::MAIN_SEPARATOR_STR
+                    } else {
+                        "/"
+                    }
+                )
+                .as_str(),
                 root_size,
                 9,
                 Some(root_index),

--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 pub trait TreeView {
     fn traversal(&self) -> &Traversal;
+    fn traversal_as_mut(&mut self) -> &mut Traversal;
 
     fn tree(&self) -> &Tree;
     fn tree_as_mut(&mut self) -> &mut Tree;
@@ -60,6 +61,10 @@ impl<'a> TreeView for NormalTreeView<'a> {
     }
 
     fn traversal(&self) -> &Traversal {
+        self.traversal
+    }
+
+    fn traversal_as_mut(&mut self) -> &mut Traversal {
         self.traversal
     }
 
@@ -152,6 +157,10 @@ impl<'a> TreeView for GlobTreeView<'a> {
     }
 
     fn traversal(&self) -> &Traversal {
+        self.traversal
+    }
+
+    fn traversal_as_mut(&mut self) -> &mut Traversal {
         self.traversal
     }
 

--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -41,6 +41,14 @@ pub struct NormalTreeView<'a> {
 }
 
 impl<'a> TreeView for NormalTreeView<'a> {
+    fn traversal(&self) -> &Traversal {
+        self.traversal
+    }
+
+    fn traversal_as_mut(&mut self) -> &mut Traversal {
+        self.traversal
+    }
+
     fn tree(&self) -> &Tree {
         &self.traversal.tree
     }
@@ -58,14 +66,6 @@ impl<'a> TreeView for NormalTreeView<'a> {
 
     fn remove_entries(&mut self, index: TreeIndex) -> usize {
         remove_entries(self.traversal, index)
-    }
-
-    fn traversal(&self) -> &Traversal {
-        self.traversal
-    }
-
-    fn traversal_as_mut(&mut self) -> &mut Traversal {
-        self.traversal
     }
 
     fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {
@@ -95,6 +95,14 @@ pub struct GlobTreeView<'a> {
 }
 
 impl<'a> TreeView for GlobTreeView<'a> {
+    fn traversal(&self) -> &Traversal {
+        self.traversal
+    }
+
+    fn traversal_as_mut(&mut self) -> &mut Traversal {
+        self.traversal
+    }
+
     fn tree(&self) -> &Tree {
         &self.traversal.tree
     }
@@ -135,10 +143,6 @@ impl<'a> TreeView for GlobTreeView<'a> {
         parent
     }
 
-    fn remove_entries(&mut self, index: TreeIndex) -> usize {
-        remove_entries(self.traversal, index)
-    }
-
     fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
         path_of(&self.traversal.tree, node_idx, Some(self.glob_tree_root))
     }
@@ -156,12 +160,8 @@ impl<'a> TreeView for GlobTreeView<'a> {
         current_path(&self.traversal.tree, view_root, Some(self.glob_tree_root))
     }
 
-    fn traversal(&self) -> &Traversal {
-        self.traversal
-    }
-
-    fn traversal_as_mut(&mut self) -> &mut Traversal {
-        self.traversal
+    fn remove_entries(&mut self, index: TreeIndex) -> usize {
+        remove_entries(self.traversal, index)
     }
 
     fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {

--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -1,0 +1,210 @@
+use super::{sorted_entries, EntryDataBundle, SortMode};
+use crate::interactive::path_of;
+use dua::traverse::{EntryData, Traversal, Tree, TreeIndex};
+use petgraph::{visit::Bfs, Direction};
+use std::path::{Path, PathBuf};
+
+pub trait TreeView {
+    fn traversal(&self) -> &Traversal;
+
+    fn tree(&self) -> &Tree;
+    fn tree_as_mut(&mut self) -> &mut Tree;
+
+    fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex>;
+    fn view_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
+        self.fs_parent_of(idx)
+    }
+
+    fn exists(&self, idx: TreeIndex) -> bool {
+        self.tree().node_weight(idx).is_some()
+    }
+
+    fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
+        path_of(self.tree(), node_idx, None)
+    }
+
+    fn sorted_entries(&self, view_root: TreeIndex, sorting: SortMode) -> Vec<EntryDataBundle> {
+        sorted_entries(self.tree(), view_root, sorting, None)
+    }
+
+    fn current_path(&self, view_root: TreeIndex) -> String {
+        current_path(self.tree(), view_root, None)
+    }
+
+    fn remove_entries(&mut self, index: TreeIndex) -> usize;
+    fn recompute_sizes_recursively(&mut self, index: TreeIndex);
+}
+
+pub struct NormalTreeView<'a> {
+    pub traversal: &'a mut Traversal,
+}
+
+impl<'a> TreeView for NormalTreeView<'a> {
+    fn tree(&self) -> &Tree {
+        &self.traversal.tree
+    }
+
+    fn tree_as_mut(&mut self) -> &mut Tree {
+        &mut self.traversal.tree
+    }
+
+    fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
+        self.traversal
+            .tree
+            .neighbors_directed(idx, Direction::Incoming)
+            .next()
+    }
+
+    fn remove_entries(&mut self, index: TreeIndex) -> usize {
+        remove_entries(self.traversal, index)
+    }
+
+    fn traversal(&self) -> &Traversal {
+        self.traversal
+    }
+
+    fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {
+        loop {
+            self.traversal
+                .tree
+                .node_weight_mut(index)
+                .expect("valid index")
+                .size = neighbours_size(self.tree(), index);
+
+            match self.fs_parent_of(index) {
+                None => break,
+                Some(parent) => index = parent,
+            }
+        }
+        self.traversal.total_bytes = self
+            .traversal
+            .tree
+            .node_weight(self.traversal.root_index)
+            .map(|w| w.size);
+    }
+}
+
+pub struct GlobTreeView<'a> {
+    pub traversal: &'a mut Traversal,
+    pub glob_tree_root: TreeIndex,
+}
+
+impl<'a> TreeView for GlobTreeView<'a> {
+    fn tree(&self) -> &Tree {
+        &self.traversal.tree
+    }
+
+    fn tree_as_mut(&mut self) -> &mut Tree {
+        &mut self.traversal.tree
+    }
+
+    fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
+        let iter = self
+            .traversal
+            .tree
+            .neighbors_directed(idx, petgraph::Incoming);
+
+        let mut parent = None;
+        for parent_idx in iter {
+            if parent_idx == self.glob_tree_root {
+                continue;
+            }
+            parent = Some(parent_idx);
+        }
+        parent
+    }
+
+    fn view_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
+        let iter = self
+            .traversal
+            .tree
+            .neighbors_directed(idx, petgraph::Incoming);
+
+        let mut parent = None;
+        for parent_idx in iter {
+            parent = Some(parent_idx);
+            if parent_idx == self.glob_tree_root {
+                break;
+            }
+        }
+        parent
+    }
+
+    fn remove_entries(&mut self, index: TreeIndex) -> usize {
+        remove_entries(self.traversal, index)
+    }
+
+    fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
+        path_of(&self.traversal.tree, node_idx, Some(self.glob_tree_root))
+    }
+
+    fn sorted_entries(&self, view_root: TreeIndex, sorting: SortMode) -> Vec<EntryDataBundle> {
+        sorted_entries(
+            &self.traversal.tree,
+            view_root,
+            sorting,
+            Some(self.glob_tree_root),
+        )
+    }
+
+    fn current_path(&self, view_root: TreeIndex) -> String {
+        current_path(&self.traversal.tree, view_root, Some(self.glob_tree_root))
+    }
+
+    fn traversal(&self) -> &Traversal {
+        self.traversal
+    }
+
+    fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {
+        loop {
+            self.traversal
+                .tree
+                .node_weight_mut(index)
+                .expect("valid index")
+                .size = neighbours_size(self.tree(), index);
+
+            match self.fs_parent_of(index) {
+                None => break,
+                Some(parent) => index = parent,
+            }
+        }
+        self.traversal.total_bytes = self
+            .traversal
+            .tree
+            .node_weight(self.traversal.root_index)
+            .map(|w| w.size);
+    }
+}
+
+fn neighbours_size(tree: &Tree, index: TreeIndex) -> u128 {
+    tree.neighbors_directed(index, Direction::Outgoing)
+        .filter_map(|idx| tree.node_weight(idx).map(|w| w.size))
+        .sum()
+}
+
+fn current_path(
+    tree: &petgraph::stable_graph::StableGraph<EntryData, ()>,
+    root: petgraph::stable_graph::NodeIndex,
+    glob_root: Option<TreeIndex>,
+) -> String {
+    match path_of(tree, root, glob_root).to_string_lossy().to_string() {
+        ref p if p.is_empty() => Path::new(".")
+            .canonicalize()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| String::from(".")),
+        p => p,
+    }
+}
+
+fn remove_entries(traversal: &mut Traversal, index: TreeIndex) -> usize {
+    let mut entries_deleted = 0;
+
+    let mut bfs = Bfs::new(&traversal.tree, index);
+    while let Some(nx) = bfs.next(&traversal.tree) {
+        traversal.tree.remove_node(nx);
+        traversal.entries_traversed -= 1;
+        entries_deleted += 1;
+    }
+
+    entries_deleted
+}

--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -4,173 +4,89 @@ use dua::traverse::{EntryData, Traversal, Tree, TreeIndex};
 use petgraph::{visit::Bfs, Direction};
 use std::path::{Path, PathBuf};
 
-pub trait TreeView {
-    fn traversal(&self) -> &Traversal;
-    fn traversal_as_mut(&mut self) -> &mut Traversal;
-
-    fn tree(&self) -> &Tree;
-    fn tree_as_mut(&mut self) -> &mut Tree;
-
-    fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex>;
-    fn view_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
-        self.fs_parent_of(idx)
-    }
-
-    fn exists(&self, idx: TreeIndex) -> bool {
-        self.tree().node_weight(idx).is_some()
-    }
-
-    fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
-        path_of(self.tree(), node_idx, None)
-    }
-
-    fn sorted_entries(&self, view_root: TreeIndex, sorting: SortMode) -> Vec<EntryDataBundle> {
-        sorted_entries(self.tree(), view_root, sorting, None)
-    }
-
-    fn current_path(&self, view_root: TreeIndex) -> String {
-        current_path(self.tree(), view_root, None)
-    }
-
-    fn remove_entries(&mut self, index: TreeIndex) -> usize;
-    fn recompute_sizes_recursively(&mut self, index: TreeIndex);
-}
-
-pub struct NormalTreeView<'a> {
+pub struct TreeView<'a> {
     pub traversal: &'a mut Traversal,
+    pub glob_tree_root: Option<TreeIndex>,
 }
 
-impl<'a> TreeView for NormalTreeView<'a> {
-    fn traversal(&self) -> &Traversal {
-        self.traversal
-    }
-
-    fn traversal_as_mut(&mut self) -> &mut Traversal {
-        self.traversal
-    }
-
-    fn tree(&self) -> &Tree {
+impl TreeView<'_> {
+    pub fn tree(&self) -> &Tree {
         &self.traversal.tree
     }
 
-    fn tree_as_mut(&mut self) -> &mut Tree {
+    pub fn tree_mut(&mut self) -> &mut Tree {
         &mut self.traversal.tree
     }
 
-    fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
+    pub fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
         self.traversal
             .tree
-            .neighbors_directed(idx, Direction::Incoming)
-            .next()
+            .neighbors_directed(idx, petgraph::Incoming)
+            .find(|idx| match self.glob_tree_root {
+                None => true,
+                Some(glob_root) => *idx != glob_root,
+            })
     }
 
-    fn remove_entries(&mut self, index: TreeIndex) -> usize {
-        remove_entries(self.traversal, index)
-    }
-
-    fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {
-        loop {
-            self.traversal
-                .tree
-                .node_weight_mut(index)
-                .expect("valid index")
-                .size = neighbours_size(self.tree(), index);
-
-            match self.fs_parent_of(index) {
-                None => break,
-                Some(parent) => index = parent,
-            }
-        }
-        self.traversal.total_bytes = self
-            .traversal
-            .tree
-            .node_weight(self.traversal.root_index)
-            .map(|w| w.size);
-    }
-}
-
-pub struct GlobTreeView<'a> {
-    pub traversal: &'a mut Traversal,
-    pub glob_tree_root: TreeIndex,
-}
-
-impl<'a> TreeView for GlobTreeView<'a> {
-    fn traversal(&self) -> &Traversal {
-        self.traversal
-    }
-
-    fn traversal_as_mut(&mut self) -> &mut Traversal {
-        self.traversal
-    }
-
-    fn tree(&self) -> &Tree {
-        &self.traversal.tree
-    }
-
-    fn tree_as_mut(&mut self) -> &mut Tree {
-        &mut self.traversal.tree
-    }
-
-    fn fs_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
-        let iter = self
+    pub fn view_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
+        let mut iter = self
             .traversal
             .tree
             .neighbors_directed(idx, petgraph::Incoming);
-
-        let mut parent = None;
-        for parent_idx in iter {
-            if parent_idx == self.glob_tree_root {
-                continue;
-            }
-            parent = Some(parent_idx);
+        match self.glob_tree_root {
+            None => iter.next(),
+            Some(glob_root) => iter
+                .clone()
+                .find(|idx| *idx == glob_root)
+                .or_else(|| iter.next()),
         }
-        parent
     }
 
-    fn view_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
-        let iter = self
-            .traversal
-            .tree
-            .neighbors_directed(idx, petgraph::Incoming);
-
-        let mut parent = None;
-        for parent_idx in iter {
-            parent = Some(parent_idx);
-            if parent_idx == self.glob_tree_root {
-                break;
-            }
-        }
-        parent
+    pub fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
+        path_of(&self.traversal.tree, node_idx, self.glob_tree_root)
     }
 
-    fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
-        path_of(&self.traversal.tree, node_idx, Some(self.glob_tree_root))
-    }
-
-    fn sorted_entries(&self, view_root: TreeIndex, sorting: SortMode) -> Vec<EntryDataBundle> {
+    pub fn sorted_entries(&self, view_root: TreeIndex, sorting: SortMode) -> Vec<EntryDataBundle> {
         sorted_entries(
             &self.traversal.tree,
             view_root,
             sorting,
-            Some(self.glob_tree_root),
+            self.glob_tree_root,
         )
     }
 
-    fn current_path(&self, view_root: TreeIndex) -> String {
-        current_path(&self.traversal.tree, view_root, Some(self.glob_tree_root))
+    pub fn current_path(&self, view_root: TreeIndex) -> String {
+        current_path(&self.traversal.tree, view_root, self.glob_tree_root)
     }
 
-    fn remove_entries(&mut self, index: TreeIndex) -> usize {
-        remove_entries(self.traversal, index)
+    pub fn remove_entries(&mut self, index: TreeIndex) -> usize {
+        let mut entries_deleted = 0;
+        let mut bfs = Bfs::new(self.tree(), index);
+
+        while let Some(nx) = bfs.next(&self.tree()) {
+            self.tree_mut().remove_node(nx);
+            self.traversal.entries_traversed -= 1;
+            entries_deleted += 1;
+        }
+        entries_deleted
     }
 
-    fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {
+    pub fn exists(&self, idx: TreeIndex) -> bool {
+        self.tree().node_weight(idx).is_some()
+    }
+
+    pub fn recompute_sizes_recursively(&mut self, mut index: TreeIndex) {
         loop {
+            let size_of_children = self
+                .tree()
+                .neighbors_directed(index, Direction::Outgoing)
+                .filter_map(|idx| self.tree().node_weight(idx).map(|w| w.size))
+                .sum();
             self.traversal
                 .tree
                 .node_weight_mut(index)
                 .expect("valid index")
-                .size = neighbours_size(self.tree(), index);
+                .size = size_of_children;
 
             match self.fs_parent_of(index) {
                 None => break,
@@ -178,17 +94,10 @@ impl<'a> TreeView for GlobTreeView<'a> {
             }
         }
         self.traversal.total_bytes = self
-            .traversal
-            .tree
+            .tree()
             .node_weight(self.traversal.root_index)
             .map(|w| w.size);
     }
-}
-
-fn neighbours_size(tree: &Tree, index: TreeIndex) -> u128 {
-    tree.neighbors_directed(index, Direction::Outgoing)
-        .filter_map(|idx| tree.node_weight(idx).map(|w| w.size))
-        .sum()
 }
 
 fn current_path(
@@ -203,17 +112,4 @@ fn current_path(
             .unwrap_or_else(|_| String::from(".")),
         p => p,
     }
-}
-
-fn remove_entries(traversal: &mut Traversal, index: TreeIndex) -> usize {
-    let mut entries_deleted = 0;
-
-    let mut bfs = Bfs::new(&traversal.tree, index);
-    while let Some(nx) = bfs.next(&traversal.tree) {
-        traversal.tree.remove_node(nx);
-        traversal.entries_traversed -= 1;
-        entries_deleted += 1;
-    }
-
-    entries_deleted
 }

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -10,13 +10,20 @@ mod utils {
     };
     use std::path::PathBuf;
 
-    pub fn path_of(tree: &Tree, mut node_idx: TreeIndex) -> PathBuf {
+    pub fn path_of(tree: &Tree, mut node_idx: TreeIndex, glob_root: Option<TreeIndex>) -> PathBuf {
         const THE_ROOT: usize = 1;
         let mut entries = Vec::new();
 
-        while let Some(parent_idx) = tree.neighbors_directed(node_idx, petgraph::Incoming).next() {
+        let mut iter = tree.neighbors_directed(node_idx, petgraph::Incoming);
+        while let Some(parent_idx) = iter.next() {
+            if let Some(glob_root) = glob_root {
+                if glob_root == parent_idx {
+                    continue;
+                }
+            }
             entries.push(get_entry_or_panic(tree, node_idx));
             node_idx = parent_idx;
+            iter = tree.neighbors_directed(node_idx, petgraph::Incoming);
         }
         entries.push(get_entry_or_panic(tree, node_idx));
         entries
@@ -30,3 +37,4 @@ mod utils {
     }
 }
 pub use utils::path_of;
+// pub use utils::glob_path_of;

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -36,5 +36,5 @@ mod utils {
             })
     }
 }
+
 pub use utils::path_of;
-// pub use utils::glob_path_of;

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -156,7 +156,7 @@ fn title(current_path: &str, item_count: u64, display: DisplayOptions, size: u12
 
 fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer) {
     let bound = line_bound(bound, bound.height.saturating_sub(1) as usize);
-    let help_text = " mark-move = d | mark-toggle = space | toggle-all = a";
+    let help_text = " mark-move = d | mark-toggle = space | toggle-all = a ";
     let help_text_block_width = block_width(help_text);
     if help_text_block_width <= bound.width {
         draw_text_nowrap_fn(

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -57,10 +57,10 @@ impl Entries {
         } = props.borrow();
         let list = &mut self.list;
 
-        let total: u128 = entries.iter().map(|b| b.data.size).sum();
+        let total: u128 = entries.iter().map(|b| b.size).sum();
         let (item_count, item_size): (u64, u128) = entries
             .iter()
-            .map(|f| (f.data.entry_count.unwrap_or(1), f.data.size))
+            .map(|f| (f.entry_count.unwrap_or(1), f.size))
             .reduce(|a, b| (a.0 + b.0, a.1 + b.1))
             .unwrap_or_default();
         let title = title(current_path, item_count, *display, item_size);
@@ -73,33 +73,32 @@ impl Entries {
         };
         let lines = entries.iter().map(|bundle| {
             let node_idx = &bundle.index;
-            let entry_data = &bundle.data;
             let is_dir = &bundle.is_dir;
             let exists = &bundle.exists;
-            let name = bundle.name();
+            let name = bundle.name.as_path();
 
             let is_marked = marked.map(|m| m.contains_key(node_idx)).unwrap_or(false);
             let is_selected = selected.map_or(false, |idx| idx == *node_idx);
-            let fraction = entry_data.size as f32 / total as f32;
+            let fraction = bundle.size as f32 / total as f32;
             let text_style = style(is_selected, *is_focussed);
             let percentage_style = percentage_style(fraction, text_style);
 
             let mut columns = Vec::new();
             if show_mtime_column(sort_mode) {
                 columns.push(mtime_column(
-                    entry_data.mtime,
+                    bundle.mtime,
                     column_style(Column::MTime, *sort_mode, text_style),
                 ));
             }
             columns.push(bytes_column(
                 *display,
-                entry_data.size,
+                bundle.size,
                 column_style(Column::Bytes, *sort_mode, text_style),
             ));
             columns.push(percentage_column(*display, fraction, percentage_style));
             if show_count_column(sort_mode) {
                 columns.push(count_column(
-                    entry_data.entry_count,
+                    bundle.entry_count,
                     column_style(Column::Count, *sort_mode, text_style),
                 ));
             }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -374,14 +374,8 @@ mod entries_test {
 
     #[test]
     fn test_shorten_string_middle() {
-        assert_eq!(
-            shorten_string_middle("12345678".into(), 7),
-            "12...78".to_string()
-        );
-        assert_eq!(
-            shorten_string_middle("12345678".into(), 3),
-            "...".to_string()
-        );
-        assert_eq!(shorten_string_middle("12345678".into(), 2), "".to_string());
+        assert_eq!(shorten_string_middle("12345678", 7), "12...78".to_string());
+        assert_eq!(shorten_string_middle("12345678", 3), "...".to_string());
+        assert_eq!(shorten_string_middle("12345678", 2), "".to_string());
     }
 }

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -6,13 +6,15 @@ use petgraph::Direction;
 use std::borrow::Borrow;
 use std::path::PathBuf;
 use tui::backend::Backend;
+use tui::prelude::Buffer;
 use tui::{
     layout::Rect,
     style::Style,
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Widget},
 };
-use tui_react::Terminal;
+use tui_react::util::{block_width, rect};
+use tui_react::{draw_text_nowrap_fn, Terminal};
 
 use crate::interactive::Cursor;
 
@@ -121,6 +123,8 @@ impl GlobPane {
             );
 
         if *has_focus {
+            draw_top_right_help(area, title, terminal.current_buffer_mut());
+
             cursor.show = true;
             cursor.x = inner_block_area.x + self.cursor_position as u16 + 1;
             cursor.y = inner_block_area.y;
@@ -128,6 +132,24 @@ impl GlobPane {
             cursor.show = false;
         }
     }
+}
+
+fn draw_top_right_help(area: Rect, title: &str, buf: &mut Buffer) -> Rect {
+    let help_text = " search = enter | cancel = esc ";
+    let help_text_block_width = block_width(help_text);
+    let bound = Rect {
+        width: area.width.saturating_sub(1),
+        ..area
+    };
+    if block_width(title) + help_text_block_width <= bound.width {
+        draw_text_nowrap_fn(
+            rect::snap_to_right(bound, help_text_block_width),
+            buf,
+            help_text,
+            |_, _, _| Style::default(),
+        );
+    }
+    bound
 }
 
 fn margin_left_right(r: Rect, margin: u16) -> Rect {

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -14,6 +14,8 @@ use tui::{
 };
 use tui_react::Terminal;
 
+use crate::interactive::Cursor;
+
 pub struct GlobPaneProps {
     pub border_style: Style,
     pub has_focus: bool,
@@ -73,13 +75,13 @@ impl GlobPane {
             let from_left_to_current_index = current_index - 1;
 
             // // Getting all characters before the selected character.
-            // let before_char_to_delete = self.input.chars().take(from_left_to_current_index);
+            let before_char_to_delete = self.input.chars().take(from_left_to_current_index);
             // // Getting all characters after selected character.
-            // let after_char_to_delete = self.input.chars().skip(current_index);
+            let after_char_to_delete = self.input.chars().skip(current_index);
 
             // Put all characters together except the selected one.
             // By leaving the selected one out, it is forgotten and therefore deleted.
-            self.input = self.input[0..from_left_to_current_index].to_string();
+            self.input = before_char_to_delete.chain(after_char_to_delete).collect();
             self.move_cursor_left();
         }
     }
@@ -93,6 +95,7 @@ impl GlobPane {
         props: impl Borrow<GlobPaneProps>,
         area: Rect,
         terminal: &mut Terminal<B>,
+        cursor: &mut Cursor,
     ) where
         B: Backend,
     {
@@ -118,16 +121,11 @@ impl GlobPane {
             );
 
         if *has_focus {
-            _ = terminal.show_cursor();
-            _ = terminal.set_cursor(
-                // Draw the cursor at the current position in the input field.
-                // This position is can be controlled via the left and right arrow key
-                inner_block_area.x + self.cursor_position as u16 + 1,
-                // Move one line down, from the border to the input line
-                inner_block_area.y,
-            );
+            cursor.show = true;
+            cursor.x = inner_block_area.x + self.cursor_position as u16 + 1;
+            cursor.y = inner_block_area.y;
         } else {
-            _ = terminal.hide_cursor();
+            cursor.show = false;
         }
     }
 }

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -15,6 +15,8 @@ use tui::{
 };
 use tui_react::util::{block_width, rect};
 use tui_react::{draw_text_nowrap_fn, Terminal};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use crate::interactive::Cursor;
 
@@ -26,7 +28,11 @@ pub struct GlobPaneProps {
 #[derive(Default)]
 pub struct GlobPane {
     pub input: String,
-    cursor_position: usize,
+    /// The index of the grapheme the cursor currently points to.
+    /// This hopefully rightfully assumes that a grapheme will be matching the block size on screen
+    /// and is treated as 'one character'. If not, it will be off, which isn't the end of the world.
+    // TODO: use `tui-textarea` for proper cursor handling, needs native crossterm events.
+    cursor_grapheme_idx: usize,
 }
 
 impl GlobPane {
@@ -51,45 +57,45 @@ impl GlobPane {
     }
 
     fn move_cursor_left(&mut self) {
-        let cursor_moved_left = self.cursor_position.saturating_sub(1);
-        self.cursor_position = self.clamp_cursor(cursor_moved_left);
+        let cursor_moved_left = self.cursor_grapheme_idx.saturating_sub(1);
+        self.cursor_grapheme_idx = self.clamp_cursor(cursor_moved_left);
     }
 
     fn move_cursor_right(&mut self) {
-        let cursor_moved_right = self.cursor_position.saturating_add(1);
-        self.cursor_position = self.clamp_cursor(cursor_moved_right);
+        let cursor_moved_right = self.cursor_grapheme_idx.saturating_add(1);
+        self.cursor_grapheme_idx = self.clamp_cursor(cursor_moved_right);
     }
 
     fn enter_char(&mut self, new_char: char) {
-        self.input.insert(self.cursor_position, new_char);
+        self.input.insert(
+            self.input
+                .graphemes(true)
+                .take(self.cursor_grapheme_idx)
+                .map(|g| g.as_bytes().len())
+                .sum::<usize>(),
+            new_char,
+        );
 
-        self.move_cursor_right();
-    }
-
-    fn delete_char(&mut self) {
-        let is_not_cursor_leftmost = self.cursor_position != 0;
-        if is_not_cursor_leftmost {
-            // Method "remove" is not used on the saved text for deleting the selected char.
-            // Reason: Using remove on String works on bytes instead of the chars.
-            // Using remove would require special care because of char boundaries.
-
-            let current_index = self.cursor_position;
-            let from_left_to_current_index = current_index - 1;
-
-            // // Getting all characters before the selected character.
-            let before_char_to_delete = self.input.chars().take(from_left_to_current_index);
-            // // Getting all characters after selected character.
-            let after_char_to_delete = self.input.chars().skip(current_index);
-
-            // Put all characters together except the selected one.
-            // By leaving the selected one out, it is forgotten and therefore deleted.
-            self.input = before_char_to_delete.chain(after_char_to_delete).collect();
-            self.move_cursor_left();
+        for _ in 0..new_char.to_string().graphemes(true).count() {
+            self.move_cursor_right();
         }
     }
 
+    fn delete_char(&mut self) {
+        if self.cursor_grapheme_idx == 0 {
+            return;
+        }
+
+        let cur_idx = self.cursor_grapheme_idx;
+        let before_char_to_delete = self.input.graphemes(true).take(cur_idx - 1);
+        let after_char_to_delete = self.input.graphemes(true).skip(cur_idx);
+
+        self.input = before_char_to_delete.chain(after_char_to_delete).collect();
+        self.move_cursor_left();
+    }
+
     fn clamp_cursor(&self, new_cursor_pos: usize) -> usize {
-        new_cursor_pos.clamp(0, self.input.len())
+        new_cursor_pos.clamp(0, self.input.graphemes(true).count())
     }
 
     pub fn render<B>(
@@ -106,7 +112,7 @@ impl GlobPane {
             has_focus,
         } = props.borrow();
 
-        let title = "Glob search";
+        let title = "Glob search from top";
         let block = Block::default()
             .title(title)
             .border_style(*border_style)
@@ -126,7 +132,14 @@ impl GlobPane {
             draw_top_right_help(area, title, terminal.current_buffer_mut());
 
             cursor.show = true;
-            cursor.x = inner_block_area.x + self.cursor_position as u16 + 1;
+            cursor.x = inner_block_area.x
+                + self
+                    .input
+                    .graphemes(true)
+                    .take(self.cursor_grapheme_idx)
+                    .map(|g| g.width())
+                    .sum::<usize>() as u16
+                + 1;
             cursor.y = inner_block_area.y;
         } else {
             cursor.show = false;
@@ -168,13 +181,10 @@ fn glob_search_neighbours(
     glob: &GlobMatcher,
     path: &mut PathBuf,
 ) {
-    let iter = tree.neighbors_directed(root_index, Direction::Outgoing);
-    for node_index in iter {
+    for node_index in tree.neighbors_directed(root_index, Direction::Outgoing) {
         if let Some(node) = tree.node_weight(node_index) {
             path.push(&node.name);
-            // println!("{path:?}");
             if glob.is_match(&path) {
-                // println!("match");
                 results.push(node_index);
             } else {
                 glob_search_neighbours(results, tree, node_index, glob, path);

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -1,0 +1,173 @@
+use anyhow::Result;
+use crosstermion::input::Key;
+use dua::traverse::{Tree, TreeIndex};
+use globset::{Glob, GlobMatcher};
+use petgraph::Direction;
+use std::borrow::Borrow;
+use std::path::PathBuf;
+use tui::backend::Backend;
+use tui::{
+    layout::Rect,
+    style::Style,
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, Paragraph, Widget},
+};
+use tui_react::Terminal;
+
+pub struct GlobPaneProps {
+    pub border_style: Style,
+    pub has_focus: bool,
+}
+
+#[derive(Default)]
+pub struct GlobPane {
+    pub input: String,
+    cursor_position: usize,
+}
+
+impl GlobPane {
+    pub fn process_events(&mut self, key: Key) {
+        use crosstermion::input::Key::*;
+
+        match key {
+            Char(to_insert) => {
+                self.enter_char(to_insert);
+            }
+            Backspace => {
+                self.delete_char();
+            }
+            Left => {
+                self.move_cursor_left();
+            }
+            Right => {
+                self.move_cursor_right();
+            }
+            _ => {}
+        };
+    }
+
+    fn move_cursor_left(&mut self) {
+        let cursor_moved_left = self.cursor_position.saturating_sub(1);
+        self.cursor_position = self.clamp_cursor(cursor_moved_left);
+    }
+
+    fn move_cursor_right(&mut self) {
+        let cursor_moved_right = self.cursor_position.saturating_add(1);
+        self.cursor_position = self.clamp_cursor(cursor_moved_right);
+    }
+
+    fn enter_char(&mut self, new_char: char) {
+        self.input.insert(self.cursor_position, new_char);
+
+        self.move_cursor_right();
+    }
+
+    fn delete_char(&mut self) {
+        let is_not_cursor_leftmost = self.cursor_position != 0;
+        if is_not_cursor_leftmost {
+            // Method "remove" is not used on the saved text for deleting the selected char.
+            // Reason: Using remove on String works on bytes instead of the chars.
+            // Using remove would require special care because of char boundaries.
+
+            let current_index = self.cursor_position;
+            let from_left_to_current_index = current_index - 1;
+
+            // // Getting all characters before the selected character.
+            // let before_char_to_delete = self.input.chars().take(from_left_to_current_index);
+            // // Getting all characters after selected character.
+            // let after_char_to_delete = self.input.chars().skip(current_index);
+
+            // Put all characters together except the selected one.
+            // By leaving the selected one out, it is forgotten and therefore deleted.
+            self.input = self.input[0..from_left_to_current_index].to_string();
+            self.move_cursor_left();
+        }
+    }
+
+    fn clamp_cursor(&self, new_cursor_pos: usize) -> usize {
+        new_cursor_pos.clamp(0, self.input.len())
+    }
+
+    pub fn render<B>(
+        &mut self,
+        props: impl Borrow<GlobPaneProps>,
+        area: Rect,
+        terminal: &mut Terminal<B>,
+    ) where
+        B: Backend,
+    {
+        let GlobPaneProps {
+            border_style,
+            has_focus,
+        } = props.borrow();
+
+        let title = "Glob search";
+        let block = Block::default()
+            .title(title)
+            .border_style(*border_style)
+            .borders(Borders::ALL);
+        let inner_block_area = block.inner(area);
+        block.render(area, terminal.current_buffer_mut());
+
+        let spans = vec![Span::from(&self.input)];
+        Paragraph::new(Text::from(Line::from(spans)))
+            .style(Style::default())
+            .render(
+                margin_left_right(inner_block_area, 1),
+                terminal.current_buffer_mut(),
+            );
+
+        if *has_focus {
+            _ = terminal.show_cursor();
+            _ = terminal.set_cursor(
+                // Draw the cursor at the current position in the input field.
+                // This position is can be controlled via the left and right arrow key
+                inner_block_area.x + self.cursor_position as u16 + 1,
+                // Move one line down, from the border to the input line
+                inner_block_area.y,
+            );
+        } else {
+            _ = terminal.hide_cursor();
+        }
+    }
+}
+
+fn margin_left_right(r: Rect, margin: u16) -> Rect {
+    Rect {
+        x: r.x + margin,
+        y: r.y,
+        width: r.width - 2 * margin,
+        height: r.height,
+    }
+}
+
+fn glob_search_neighbours(
+    results: &mut Vec<TreeIndex>,
+    tree: &Tree,
+    root_index: TreeIndex,
+    glob: &GlobMatcher,
+    path: &mut PathBuf,
+) {
+    let iter = tree.neighbors_directed(root_index, Direction::Outgoing);
+    for node_index in iter {
+        if let Some(node) = tree.node_weight(node_index) {
+            path.push(&node.name);
+            // println!("{path:?}");
+            if glob.is_match(&path) {
+                // println!("match");
+                results.push(node_index);
+            } else {
+                glob_search_neighbours(results, tree, node_index, glob, path);
+            }
+            path.pop();
+        }
+    }
+}
+
+pub fn glob_search(tree: &Tree, root_index: TreeIndex, glob: &str) -> Result<Vec<TreeIndex>> {
+    let glob = Glob::new(glob)?.compile_matcher();
+    let mut results = Vec::new();
+    let mut path = PathBuf::new();
+    glob_search_neighbours(&mut results, tree, root_index, &glob, &mut path);
+    Ok(results)
+}

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -161,6 +161,7 @@ impl HelpPane {
                 );
                 hotkey("<Space>", "Toggle the currently selected entry", None);
                 hotkey("a", "Toggle all entries", None);
+                hotkey("/", "Glob search", None);
                 spacer();
             }
             title("Keys in the Mark pane");

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -161,7 +161,11 @@ impl HelpPane {
                 );
                 hotkey("<Space>", "Toggle the currently selected entry", None);
                 hotkey("a", "Toggle all entries", None);
-                hotkey("/", "Glob search", None);
+                hotkey(
+                    "/",
+                    "Git-style glob search, case-insensitive, always from the top of the tree",
+                    None,
+                );
                 spacer();
             }
             title("Keys in the Mark pane");

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -1,23 +1,27 @@
 use crate::interactive::{
     widgets::{
-        Entries, EntriesProps, Footer, FooterProps, Header, HelpPane, HelpPaneProps, MarkPane,
-        MarkPaneProps, COLOR_MARKED,
+        Entries, EntriesProps, Footer, FooterProps, GlobPane, GlobPaneProps, Header, HelpPane,
+        HelpPaneProps, MarkPane, MarkPaneProps, COLOR_MARKED,
     },
     AppState, DisplayOptions, FocussedPane,
 };
-use dua::traverse::Traversal;
 use std::borrow::Borrow;
+use tui::backend::Backend;
 use tui::{
-    buffer::Buffer,
     layout::{Constraint, Direction, Layout, Rect},
     style::Modifier,
     style::{Color, Style},
 };
+use tui_react::Terminal;
 use Constraint::*;
 use FocussedPane::*;
 
 pub struct MainWindowProps<'a> {
-    pub traversal: &'a Traversal,
+    pub current_path: String,
+    pub entries_traversed: u64,
+    pub total_bytes: Option<u128>,
+    pub start: std::time::Instant,
+    pub elapsed: Option<std::time::Duration>,
     pub display: DisplayOptions,
     pub state: &'a AppState,
 }
@@ -27,34 +31,33 @@ pub struct MainWindow {
     pub help_pane: Option<HelpPane>,
     pub entries_pane: Entries,
     pub mark_pane: Option<MarkPane>,
+    pub glob_pane: Option<GlobPane>,
 }
 
 impl MainWindow {
-    pub fn render<'a>(
+    pub fn render<'a, B>(
         &mut self,
         props: impl Borrow<MainWindowProps<'a>>,
         area: Rect,
-        buf: &mut Buffer,
-    ) {
+        terminal: &mut Terminal<B>,
+    ) where
+        B: Backend,
+    {
         let MainWindowProps {
-            traversal:
-                Traversal {
-                    tree,
-                    entries_traversed,
-                    total_bytes,
-                    start,
-                    elapsed,
-                    ..
-                },
+            current_path,
+            entries_traversed,
+            total_bytes,
+            start,
+            elapsed,
             display,
             state,
         } = props.borrow();
 
-        let (entries_style, help_style, mark_style) = pane_border_style(state.focussed);
+        let (entries_style, help_style, mark_style, glob_style) = pane_border_style(state.focussed);
         let (header_area, content_area, footer_area) = main_window_layout(area);
 
         let header_bg_color = header_background_color(self.is_anything_marked(), state.focussed);
-        Header.render(header_bg_color, header_area, buf);
+        Header.render(header_bg_color, header_area, terminal.current_buffer_mut());
 
         let (entries_area, help_pane, mark_pane) = {
             let (left_pane, right_pane) = content_layout(content_area);
@@ -69,12 +72,23 @@ impl MainWindow {
             }
         };
 
+        let (entries_area, glob_pane) = match &mut self.glob_pane {
+            Some(ref mut glob_pane) => {
+                let regions = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Max(256), Length(3)].as_ref())
+                    .split(entries_area);
+                (regions[0], Some((regions[1], glob_pane)))
+            }
+            None => (entries_area, None),
+        };
+
         if let Some((mark_area, pane)) = mark_pane {
             let props = MarkPaneProps {
                 border_style: mark_style,
                 format: display.byte_format,
             };
-            pane.render(props, mark_area, buf);
+            pane.render(props, mark_area, terminal.current_buffer_mut());
         }
 
         if let Some((help_area, pane)) = help_pane {
@@ -82,22 +96,30 @@ impl MainWindow {
                 border_style: help_style,
                 has_focus: matches!(state.focussed, Help),
             };
-            pane.render(props, help_area, buf);
+            pane.render(props, help_area, terminal.current_buffer_mut());
         }
 
         let marked = self.mark_pane.as_ref().map(|p| p.marked());
         let props = EntriesProps {
-            tree,
-            root: state.root,
+            current_path: current_path.clone(),
             display: *display,
             entries: &state.entries,
             marked,
-            selected: state.selected,
+            selected: state.navigation().selected,
             border_style: entries_style,
             is_focussed: matches!(state.focussed, Main),
             sort_mode: state.sorting,
         };
-        self.entries_pane.render(props, entries_area, buf);
+        self.entries_pane
+            .render(props, entries_area, terminal.current_buffer_mut());
+
+        if let Some((glob_area, pane)) = glob_pane {
+            let props = GlobPaneProps {
+                border_style: glob_style,
+                has_focus: matches!(state.focussed, Glob),
+            };
+            pane.render(props, glob_area, terminal);
+        }
 
         Footer.render(
             FooterProps {
@@ -110,7 +132,7 @@ impl MainWindow {
                 sort_mode: state.sorting,
             },
             footer_area,
-            buf,
+            terminal.current_buffer_mut(),
         );
     }
 
@@ -154,7 +176,7 @@ fn main_window_layout(area: Rect) -> (Rect, Rect, Rect) {
     (regions[0], regions[1], regions[2])
 }
 
-fn pane_border_style(focused_pane: FocussedPane) -> (Style, Style, Style) {
+fn pane_border_style(focused_pane: FocussedPane) -> (Style, Style, Style, Style) {
     let grey = Style {
         fg: Color::DarkGray.into(),
         bg: Color::Reset.into(),
@@ -163,8 +185,9 @@ fn pane_border_style(focused_pane: FocussedPane) -> (Style, Style, Style) {
     };
     let bold = Style::default().add_modifier(Modifier::BOLD);
     match focused_pane {
-        Main => (bold, grey, grey),
-        Help => (grey, bold, grey),
-        Mark => (grey, grey, bold),
+        Main => (bold, grey, grey, grey),
+        Help => (grey, bold, grey, grey),
+        Mark => (grey, grey, bold, grey),
+        Glob => (grey, grey, grey, bold),
     }
 }

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -3,7 +3,7 @@ use crate::interactive::{
         Entries, EntriesProps, Footer, FooterProps, GlobPane, GlobPaneProps, Header, HelpPane,
         HelpPaneProps, MarkPane, MarkPaneProps, COLOR_MARKED,
     },
-    AppState, DisplayOptions, FocussedPane,
+    AppState, Cursor, DisplayOptions, FocussedPane,
 };
 use std::borrow::Borrow;
 use tui::backend::Backend;
@@ -40,6 +40,7 @@ impl MainWindow {
         props: impl Borrow<MainWindowProps<'a>>,
         area: Rect,
         terminal: &mut Terminal<B>,
+        cursor: &mut Cursor,
     ) where
         B: Backend,
     {
@@ -118,7 +119,7 @@ impl MainWindow {
                 border_style: glob_style,
                 has_focus: matches!(state.focussed, Glob),
             };
-            pane.render(props, glob_area, terminal);
+            pane.render(props, glob_area, terminal, cursor);
         }
 
         Footer.render(

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -75,7 +75,7 @@ impl MarkPane {
     pub fn toggle_index(
         mut self,
         index: TreeIndex,
-        tree_view: &dyn TreeView,
+        tree_view: &TreeView<'_>,
         is_dir: bool,
         toggle: bool,
     ) -> Option<Self> {

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -1,12 +1,10 @@
 use crate::interactive::widgets::COUNT;
 use crate::interactive::{
-    fit_string_graphemes_with_ellipsis, path_of, widgets::entry_color, CursorDirection,
+    app::tree_view::TreeView, fit_string_graphemes_with_ellipsis, widgets::entry_color,
+    CursorDirection,
 };
 use crosstermion::{input::Key, input::Key::*};
-use dua::{
-    traverse::{Tree, TreeIndex},
-    ByteFormat,
-};
+use dua::{traverse::TreeIndex, ByteFormat};
 use itertools::Itertools;
 use std::{
     borrow::Borrow,
@@ -77,18 +75,18 @@ impl MarkPane {
     pub fn toggle_index(
         mut self,
         index: TreeIndex,
-        tree: &Tree,
+        tree_view: &dyn TreeView,
         is_dir: bool,
         toggle: bool,
     ) -> Option<Self> {
         match self.marked.entry(index) {
             Entry::Vacant(entry) => {
-                if let Some(e) = tree.node_weight(index) {
+                if let Some(e) = tree_view.tree().node_weight(index) {
                     let sorting_index = self.last_sorting_index + 1;
                     self.last_sorting_index = sorting_index;
                     entry.insert(EntryMark {
                         size: e.size,
-                        path: path_of(tree, index),
+                        path: tree_view.path_of(index),
                         index: sorting_index,
                         num_errors_during_deletion: 0,
                         is_dir,

--- a/src/interactive/widgets/mod.rs
+++ b/src/interactive/widgets/mod.rs
@@ -1,5 +1,6 @@
 mod entries;
 mod footer;
+mod glob;
 mod header;
 mod help;
 mod main;
@@ -7,6 +8,7 @@ mod mark;
 
 pub use entries::*;
 pub use footer::*;
+pub use glob::*;
 pub use header::*;
 pub use help::*;
 pub use main::*;

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -22,6 +22,7 @@ pub struct EntryData {
     pub entry_count: Option<u64>,
     /// If set, the item meta-data could not be obtained
     pub metadata_io_error: bool,
+    pub is_dir: bool,
 }
 
 impl Default for EntryData {
@@ -32,6 +33,7 @@ impl Default for EntryData {
             mtime: UNIX_EPOCH,
             entry_count: None,
             metadata_io_error: bool::default(),
+            is_dir: false,
         }
     }
 }
@@ -191,6 +193,7 @@ impl Traversal {
                                     }
                                 } else {
                                     data.entry_count = Some(0);
+                                    data.is_dir = true;
                                 }
 
                                 match m.modified() {


### PR DESCRIPTION
Implements glob search feature as requested in #154 

<img width="1229" alt="Screenshot 2023-12-19 at 21 15 21" src="https://github.com/Byron/dua-cli/assets/697414/2dae8242-1333-4884-b88f-548e25cbb3ad">

There are three main components to in the implementation of this feature:
* `NavigationState`
    * there are separate instances for normal and glob modes. This lives inside the `AppState` and holds the state of there the user has been navigating etc.
* Depending in which mode you are you need a different "view" of the tree. This is where new `TreeView` trait comes in. `AppState::process_events` has been refactored to create appropriate tree view (normal vs glob) for the mode you are in and us that to handle the events.
    * Doing a glob search adds a new tree root which gets removed when the search is cancelled.
* Glob has its own pane etc. where user input and rendering is handled.
* UI components have been refactored to only need basic types and not reference `traversal` or `tree` at all.
