### PR TITLE
fix: --ignore_dir now work as expected

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -292,7 +292,7 @@ mod tests {
             ),
         ];
 
-        parameters.append(&mut vec![
+        parameters.extend([
             ("src", vec!["src"], true),
             ("src/interactive", vec!["src"], false),
             ("src/interactive/..", vec!["src"], true),
@@ -300,18 +300,12 @@ mod tests {
 
         for (path, ignore_dirs, expected_result) in parameters {
             let ignore_dirs = canonicalize_ignore_dirs(
-                &ignore_dirs
-                    .into_iter()
-                    .map(|p| PathBuf::from(p))
-                    .collect::<Vec<PathBuf>>(),
+                &ignore_dirs.into_iter().map(Into::into).collect::<Vec<_>>(),
             );
             assert_eq!(
-                ignore_directory(&PathBuf::from(path), &ignore_dirs),
+                ignore_directory(path.as_ref(), &ignore_dirs),
                 expected_result,
-                "result='{}' for path='{}' and ignore_dir='{:?}' ",
-                expected_result,
-                path,
-                ignore_dirs
+                "result='{expected_result}' for path='{path}' and ignore_dir='{ignore_dirs:?}' "
             );
         }
     }

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -185,7 +185,7 @@ pub fn initialized_app_and_terminal_with_closure(
             count_hard_links: false,
             sorting: TraversalSorting::AlphabeticalByFileName,
             cross_filesystems: false,
-            ignore_dirs: Vec::new(),
+            ignore_dirs: Default::default(),
         },
         input_paths,
         Interaction::None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
     if let Some(log_file) = &opt.log_file {
         log_panics::init();
         WriteLogger::init(
-            LevelFilter::Info,
+            LevelFilter::Debug,
             Config::default(),
             OpenOptions::new()
                 .write(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code, rust_2018_idioms, unsafe_code)]
 use anyhow::Result;
 use clap::Parser;
-use dua::TraversalSorting;
+use dua::{canonicalize_ignore_dirs, TraversalSorting};
 use log::info;
 use simplelog::{Config, LevelFilter, WriteLogger};
 use std::fs::OpenOptions;
@@ -46,7 +46,7 @@ fn main() -> Result<()> {
         count_hard_links: opt.count_hard_links,
         sorting: TraversalSorting::None,
         cross_filesystems: !opt.stay_on_filesystem,
-        ignore_dirs: opt.ignore_dirs,
+        ignore_dirs: canonicalize_ignore_dirs(&opt.ignore_dirs),
     };
     let res = match opt.command {
         #[cfg(feature = "tui-crossplatform")]


### PR DESCRIPTION
Fixes #196. Paths and ignore directories are canonicalized before comparison. E.g. this now works as expected:

```
cargo run -- -i $(pwd)/../dua-cli/target i ../dua-cli
```