### PR TITLE
feat: show and hide mtime and item count columns with 'M' and 'C' respectively

### DIFF
--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -289,8 +289,10 @@ impl AppState {
                     }
                     Char('s') => self.cycle_sorting(&tree_view),
                     Char('m') => self.cycle_mtime_sorting(&tree_view),
+                    Char('M') => self.toggle_mtime_column(),
                     Char('c') => self.cycle_count_sorting(&tree_view),
-                    Char('g') => display.byte_vis.cycle(),
+                    Char('C') => self.toggle_count_column(),
+                    Char('g') | Char('S') => display.byte_vis.cycle(),
                     Char('d') => self.mark_entry(
                         CursorMode::Advance,
                         MarkEntryMode::Toggle,

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -1,6 +1,6 @@
 use crate::interactive::{
     app::tree_view::TreeView,
-    widgets::{GlobPane, HelpPane, MainWindow, MarkMode, MarkPane},
+    widgets::{Column, GlobPane, HelpPane, MainWindow, MarkMode, MarkPane},
     DisplayOptions, EntryDataBundle,
 };
 use crosstermion::input::Key;
@@ -133,6 +133,22 @@ impl AppState {
     pub fn cycle_count_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_count();
         self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+    }
+
+    pub fn toggle_mtime_column(&mut self) {
+        self.toggle_column(Column::MTime);
+    }
+
+    pub fn toggle_count_column(&mut self) {
+        self.toggle_column(Column::Count);
+    }
+
+    fn toggle_column(&mut self, column: Column) {
+        if self.show_columns.contains(&column) {
+            self.show_columns.remove(&column);
+        } else {
+            self.show_columns.insert(column);
+        }
     }
 
     pub fn toggle_glob_search(&mut self, window: &mut MainWindow) {

--- a/src/interactive/app/state.rs
+++ b/src/interactive/app/state.rs
@@ -1,4 +1,8 @@
+use std::collections::HashSet;
+
 use dua::traverse::BackgroundTraversal;
+
+use crate::interactive::widgets::Column;
 
 use super::{navigation::Navigation, EntryDataBundle, SortMode};
 
@@ -24,6 +28,7 @@ pub struct AppState {
     pub glob_navigation: Option<Navigation>,
     pub entries: Vec<EntryDataBundle>,
     pub sorting: SortMode,
+    pub show_columns: HashSet<Column>,
     pub message: Option<String>,
     pub focussed: FocussedPane,
     pub received_events: bool,

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -149,9 +149,11 @@ impl HelpPane {
                     "Toggle sort by modified time descending/ascending.",
                     None,
                 );
+                hotkey("M", "Show/hide modified time.", None);
                 hotkey("c", "Toggle sort by items descending/ascending.", None);
+                hotkey("C", "Show/hide item count.", None);
                 hotkey(
-                    "g",
+                    "g/S",
                     "Cycle through percentage display and bar options.",
                     None,
                 );

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -111,6 +111,7 @@ impl MainWindow {
             border_style: entries_style,
             is_focussed: matches!(state.focussed, Main),
             sort_mode: state.sorting,
+            show_columns: &state.show_columns,
         };
         self.entries_pane
             .render(props, entries_area, terminal.current_buffer_mut());


### PR DESCRIPTION
Implements #212

<img width="739" alt="Screenshot 2024-01-09 at 22 11 33" src="https://github.com/Byron/dua-cli/assets/697414/69efc2c4-48c6-49f6-be02-2ea03ef6184e">
