### PR TITLE
fix overhead

### DIFF
--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -63,6 +63,7 @@ pub fn sorted_entries(
     node_idx: TreeIndex,
     sorting: SortMode,
     glob_root: Option<TreeIndex>,
+    is_scanning: bool,
 ) -> Vec<EntryDataBundle> {
     use SortMode::*;
     fn cmp_count(l: &EntryDataBundle, r: &EntryDataBundle) -> Ordering {
@@ -76,7 +77,7 @@ pub fn sorted_entries(
                 let use_glob_path = glob_root.map_or(false, |glob_root| glob_root == node_idx);
                 let (path, exists, is_dir) = {
                     let path = path_of(tree, idx, glob_root);
-                    if glob_root == Some(node_idx) {
+                    if is_scanning || glob_root == Some(node_idx) {
                         (path, true, entry.is_dir)
                     } else {
                         let meta = path.symlink_metadata();

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -257,11 +257,7 @@ impl AppState {
                 self.cycle_focus(window);
             }
             Char('/') if !glob_focussed => {
-                if self.scan.is_some() {
-                    self.message = Some("glob search disabled during traversal".into());
-                } else {
-                    self.toggle_glob_search(window);
-                }
+                self.toggle_glob_search(window);
             }
             Char('?') if !glob_focussed => self.toggle_help_pane(window),
             Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) && !glob_focussed => {

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -194,7 +194,11 @@ impl AppState {
         is_finished: bool,
     ) {
         let tree_view = self.tree_view(traversal);
-        self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+        self.entries = tree_view.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.scan.is_some(),
+        );
 
         if !self.received_events {
             let previously_selected_entry =
@@ -440,7 +444,11 @@ impl AppState {
         tree.remove_entries(index, remove_root_node);
         tree.recompute_sizes_recursively(parent_index);
 
-        self.entries = tree.sorted_entries(self.navigation().view_root, self.sorting);
+        self.entries = tree.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.scan.is_some(),
+        );
         self.navigation_mut().selected = self.entries.first().map(|e| e.index);
 
         self.scan = Some(FilesystemScan {
@@ -493,7 +501,8 @@ impl AppState {
                     traversal: tree_view.traversal,
                     glob_tree_root: Some(tree_root),
                 };
-                let new_entries = glob_tree_view.sorted_entries(tree_root, self.sorting);
+                let new_entries =
+                    glob_tree_view.sorted_entries(tree_root, self.sorting, self.scan.is_some());
 
                 let new_entries = self
                     .navigation_mut()
@@ -545,7 +554,11 @@ impl AppState {
         window.glob_pane = None;
 
         tree_view.glob_tree_root.take();
-        self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+        self.entries = tree_view.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.scan.is_some(),
+        );
     }
 }
 

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -67,7 +67,7 @@ impl AppState {
             .map(|parent_idx| {
                 (
                     parent_idx,
-                    tree_view.sorted_entries(parent_idx, self.sorting),
+                    tree_view.sorted_entries(parent_idx, self.sorting, self.scan.is_some()),
                 )
             })
     }
@@ -89,7 +89,7 @@ impl AppState {
         self.navigation().selected.map(|previously_selected| {
             (
                 previously_selected,
-                tree_view.sorted_entries(previously_selected, self.sorting),
+                tree_view.sorted_entries(previously_selected, self.sorting, self.scan.is_some()),
             )
         })
     }
@@ -122,17 +122,29 @@ impl AppState {
 
     pub fn cycle_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_size();
-        self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+        self.entries = tree_view.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.scan.is_some(),
+        );
     }
 
     pub fn cycle_mtime_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_mtime();
-        self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+        self.entries = tree_view.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.scan.is_some(),
+        );
     }
 
     pub fn cycle_count_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_count();
-        self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+        self.entries = tree_view.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.scan.is_some(),
+        );
     }
 
     pub fn toggle_mtime_column(&mut self) {
@@ -318,7 +330,11 @@ impl AppState {
         if !tree_view.exists(self.navigation().view_root) {
             self.go_to_root(tree_view);
         } else {
-            self.entries = tree_view.sorted_entries(self.navigation().view_root, self.sorting);
+            self.entries = tree_view.sorted_entries(
+                self.navigation().view_root,
+                self.sorting,
+                self.scan.is_some(),
+            );
         }
 
         if self
@@ -337,7 +353,7 @@ impl AppState {
 
     pub fn go_to_root(&mut self, tree_view: &TreeView<'_>) {
         let root = self.navigation().tree_root;
-        let entries = tree_view.sorted_entries(root, self.sorting);
+        let entries = tree_view.sorted_entries(root, self.sorting, self.scan.is_some());
         self.navigation_mut().exit_node(root, &entries);
         self.entries = entries;
     }

--- a/src/interactive/app/terminal.rs
+++ b/src/interactive/app/terminal.rs
@@ -49,6 +49,7 @@ impl TerminalApp {
             state.navigation().view_root,
             state.sorting,
             state.glob_root(),
+            state.scan.is_some(),
         );
         state.navigation_mut().selected = state.entries.first().map(|b| b.index);
 

--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -46,12 +46,18 @@ impl TreeView<'_> {
         path_of(&self.traversal.tree, node_idx, self.glob_tree_root)
     }
 
-    pub fn sorted_entries(&self, view_root: TreeIndex, sorting: SortMode) -> Vec<EntryDataBundle> {
+    pub fn sorted_entries(
+        &self,
+        view_root: TreeIndex,
+        sorting: SortMode,
+        is_scanning: bool,
+    ) -> Vec<EntryDataBundle> {
         sorted_entries(
             &self.traversal.tree,
             view_root,
             sorting,
             self.glob_tree_root,
+            is_scanning,
         )
     }
 


### PR DESCRIPTION
Related to #223

Previously each time the UI refreshes, every 250ms, it display
entries but also check their metadata to assure they exist.

This could lead to performance loss when the displayed folder
has a lot of entries.
