### PR TITLE
feat: arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,14 @@ jobs:
             rustembedded/cross:arm-unknown-linux-gnueabihf \
             arm-linux-gnueabihf-strip \
             /target/arm-unknown-linux-gnueabihf/release/${{ env.EXE_NAME }}
+      - name: Strip release binary (arm64)
+        if: matrix.build == 'linux-arm64'
+        run: |
+          docker run --rm -v \
+            "$PWD/target:/target:Z" \
+            rustembedded/cross:aarch64-musl \
+            musl-strip \
+            /target/aarch64-unknown-linux-musl/release/${{ env.EXE_NAME }}
       - name: Build archive
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           docker run --rm -v \
             "$PWD/target:/target:Z" \
-            rustembedded/cross:aarch64-musl \
+            messense/rust-musl-cross:aarch64-musl \
             musl-strip \
             /target/aarch64-unknown-linux-musl/release/${{ env.EXE_NAME }}
       - name: Build archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       EXE_NAME: dua
     strategy:
       matrix:
-        build: [linux, linux-arm, macos, win-msvc, win32-msvc]
+        build: [linux, linux-arm, linux-arm64, macos, win-msvc, win32-msvc]
         include:
           - build: linux
             os: ubuntu-latest
@@ -86,6 +86,10 @@ jobs:
             os: ubuntu-latest
             rust: nightly
             target: arm-unknown-linux-gnueabihf
+          - build: linux-arm64
+            os: ubuntu-latest
+            rust: stable
+            target: aarch64-unknown-linux-musl
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
Hello! Looking at https://github.com/Byron/dua-cli/issues/68 I see this was requested/fulfilled previously, though it seems releases have only ever been for `arm`, which is 32bit architecture specifically.

This PR adds aarch64/arm64 build support, using https://github.com/rust-cross/rust-musl-cross - I'm not overly familiar with rust and friends, so this may not be desired. Does seem to work as expected though (tested on the arm64 machine I'm wanting to use) - you can see/test results here: https://github.com/chessmango-forks/dua-cli/releases/tag/v2.28.3