### PR TITLE
Add scrollbar for main list

### DIFF
--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -11,10 +11,10 @@ use std::collections::HashSet;
 use std::time::SystemTime;
 use tui::{
     buffer::Buffer,
-    layout::Rect,
+    layout::{Margin, Rect},
     style::{Color, Modifier, Style},
     text::Span,
-    widgets::{Block, Borders},
+    widgets::{Block, Borders, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget},
 };
 use tui_react::util::rect::line_bound;
 use tui_react::{
@@ -132,7 +132,24 @@ impl Entries {
             columns_with_separators(columns, percentage_style, false)
         });
 
+        let line_count = lines.len();
         list.render(props, lines, area, buf);
+
+        let scrollbar = Scrollbar::default()
+            .orientation(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(None)
+            .end_symbol(None);
+        let scroll_offset = selected
+            .and_then(|selected_idx| {
+                entries
+                    .iter()
+                    .find_position(|bundle| bundle.index == selected_idx)
+                    .map(|(pos, _)| pos)
+            })
+            .unwrap_or(list.offset);
+        let mut scrollbar_state = ScrollbarState::new(line_count).position(scroll_offset);
+
+        scrollbar.render(area.inner(&Margin::new(0, 1)), buf, &mut scrollbar_state);
 
         if *is_focussed {
             let bound = draw_top_right_help(area, &title, buf);

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -83,7 +83,8 @@ impl Entries {
             block: Some(title_block),
             entry_in_view,
         };
-        let lines = entries.iter().map(|bundle| {
+        let mut scroll_offset = None;
+        let lines = entries.iter().enumerate().map(|(idx, bundle)| {
             let node_idx = &bundle.index;
             let is_dir = &bundle.is_dir;
             let exists = &bundle.exists;
@@ -91,6 +92,9 @@ impl Entries {
 
             let is_marked = marked.map(|m| m.contains_key(node_idx)).unwrap_or(false);
             let is_selected = selected.map_or(false, |idx| idx == *node_idx);
+            if is_selected {
+                scroll_offset = Some(idx);
+            }
             let fraction = bundle.size as f32 / total as f32;
             let text_style = style(is_selected, *is_focussed);
             let percentage_style = percentage_style(fraction, text_style);
@@ -139,15 +143,8 @@ impl Entries {
             .orientation(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
             .end_symbol(None);
-        let scroll_offset = selected
-            .and_then(|selected_idx| {
-                entries
-                    .iter()
-                    .find_position(|bundle| bundle.index == selected_idx)
-                    .map(|(pos, _)| pos)
-            })
-            .unwrap_or(list.offset);
-        let mut scrollbar_state = ScrollbarState::new(line_count).position(scroll_offset);
+        let mut scrollbar_state =
+            ScrollbarState::new(line_count).position(scroll_offset.unwrap_or(list.offset));
 
         scrollbar.render(area.inner(&Margin::new(0, 1)), buf, &mut scrollbar_state);
 


### PR DESCRIPTION
This PR adds a scrollbar for the main list to better indicate the current position of the viewport. See it in action:

https://github.com/Byron/dua-cli/assets/3109144/88cea506-fa29-4d80-95ad-be4b0e79740c

