### PR TITLE
Feature: Auto submit new manifest to winget-pkgs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,3 +207,17 @@ jobs:
           asset_path: ${{ env.ASSET }}
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream
+
+  winget-release:
+    name: winget-release
+    needs: ["build-release"]
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Byron.dua-cli
+          installers-regex: '-pc-windows-msvc\.zip$'
+          # This step uses russellbanks/Komac to submit manifests.
+          # It requires a PAT with `public_repo` scope.
+          # See https://github.com/marketplace/actions/winget-releaser#configuration-options-%EF%B8%8F
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
## Summary

- This pull request modifies YAML configurations of GitHub Workflows.
- This introduce a new job `winget-release` in `.github\workflows\release.yml`.
  - It runs after job `build-release`.
  - After all production assets are uploaded to GitHub Releases, another pull request will be created by [WinGet Releaser](https://github.com/marketplace/actions/winget-releaser)
    - The action will create YAML manifests of the new release by using [Komac](https://github.com/russellbanks/Komac), just like what human contributors do.
    - Currently, 2 assets (matching regex `pc-windows-msvc.zip$`) will be included in the manifest.

## Additional informations

- Resolve #255 

> [!IMPORTANT]
>
> In order to run properly, this job requires:
>
> 1. Create a **classic** PAT with `public_repo` permissions granted, and add it to a repository secret called `WINGET_TOKEN`.
> 2. Create a fork of [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) on your account.