### PR TITLE
ci: fix the failure of the release workflow by updating actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: echo "${{ env.ARTIFACT_VERSION }}" > artifacts/release-version
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: artifacts


### PR DESCRIPTION
The release workflow failed because actions/upload-artifact@v1 doesn't work anymore.

https://github.com/Byron/dua-cli/actions/runs/11649383977/job/32436848048

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Due to this error, no asset was released at v2.29.3.

https://github.com/Byron/dua-cli/releases/tag/v2.29.3

<img width="266" alt="image" src="https://github.com/user-attachments/assets/f6a4f49b-551e-4d45-87a3-e1056a7c66c5">