### PR TITLE
Feature: allow sorting by dirname / filename in interactive mode

### DIFF
--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -15,6 +15,8 @@ pub enum SortMode {
     MTimeAscending,
     CountDescending,
     CountAscending,
+    NameDescending,
+    NameAscending,
 }
 
 impl SortMode {
@@ -42,6 +44,15 @@ impl SortMode {
             CountAscending => CountDescending,
             CountDescending => CountAscending,
             _ => CountDescending,
+        }
+    }
+
+    pub fn toggle_name(&mut self) {
+        use SortMode::*;
+        *self = match self {
+            NameAscending => NameDescending,
+            NameDescending => NameAscending,
+            _ => NameAscending,
         }
     }
 }
@@ -86,6 +97,15 @@ pub fn sorted_entries(
             .cmp(&r.entry_count)
             .then_with(|| l.name.cmp(&r.name))
     }
+    fn cmp_name(l: &EntryDataBundle, r: &EntryDataBundle) -> Ordering {
+        if l.is_dir && !r.is_dir {
+            Ordering::Less
+        } else if !l.is_dir && r.is_dir {
+            Ordering::Greater
+        } else {
+            l.name.cmp(&r.name)
+        }
+    }
     tree.neighbors_directed(node_idx, Direction::Outgoing)
         .filter_map(|idx| {
             tree.node_weight(idx).map(|entry| {
@@ -121,6 +141,8 @@ pub fn sorted_entries(
             MTimeDescending => r.mtime.cmp(&l.mtime),
             CountAscending => cmp_count(l, r),
             CountDescending => cmp_count(l, r).reverse(),
+            NameAscending => cmp_name(l, r),
+            NameDescending => cmp_name(l, r).reverse(),
         })
         .collect()
 }

--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -109,14 +109,14 @@ pub fn sorted_entries(
     tree.neighbors_directed(node_idx, Direction::Outgoing)
         .filter_map(|idx| {
             tree.node_weight(idx).map(|entry| {
-                let use_glob_path = glob_root.map_or(false, |glob_root| glob_root == node_idx);
+                let use_glob_path = glob_root.is_some_and(|glob_root| glob_root == node_idx);
                 let (path, exists, is_dir) = {
                     let path = path_of(tree, idx, glob_root);
                     if matches!(check, EntryCheck::Disabled) || glob_root == Some(node_idx) {
                         (path, true, entry.is_dir)
                     } else {
                         let meta = path.symlink_metadata();
-                        (path, meta.is_ok(), meta.ok().map_or(false, |m| m.is_dir()))
+                        (path, meta.is_ok(), meta.ok().is_some_and(|m| m.is_dir()))
                     }
                 };
                 EntryDataBundle {

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -332,6 +332,7 @@ impl AppState {
                     Char('M') => self.toggle_mtime_column(),
                     Char('c') => self.cycle_count_sorting(&tree_view),
                     Char('C') => self.toggle_count_column(),
+                    Char('n') => self.cycle_name_sorting(&tree_view),
                     Char('g') | Char('S') => display.byte_vis.cycle(),
                     Char('d') => self.mark_entry(
                         CursorMode::Advance,

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -146,6 +146,15 @@ impl AppState {
         );
     }
 
+    pub fn cycle_name_sorting(&mut self, tree_view: &TreeView<'_>) {
+        self.sorting.toggle_name();
+        self.entries = tree_view.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.entry_check(),
+        );
+    }
+
     pub fn toggle_mtime_column(&mut self) {
         self.toggle_column(Column::MTime);
     }

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -68,6 +68,20 @@ fn simple_user_journey_read_only() -> Result<()> {
 
     // SORTING
     {
+        // when hitting the N key
+        app.process_events(&mut terminal, into_codes("n"))?;
+        assert_eq!(
+            app.state.sorting,
+            SortMode::NameAscending,
+            "it sets the sort mode to ascending by name"
+        );
+        // when hitting the N key again
+        app.process_events(&mut terminal, into_codes("n"))?;
+        assert_eq!(
+            app.state.sorting,
+            SortMode::NameDescending,
+            "it sets the sort mode to descending by name"
+        );
         // when hitting the M key
         app.process_events(&mut terminal, into_codes("m"))?;
         assert_eq!(

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -315,9 +315,10 @@ fn simple_user_journey_read_only() -> Result<()> {
                 "it marks only a single node",
             );
             assert!(
-                app.window.mark_pane.as_ref().map_or(false, |p| p
-                    .marked()
-                    .contains_key(&previously_selected_index)),
+                app.window
+                    .mark_pane
+                    .as_ref()
+                    .is_some_and(|p| p.marked().contains_key(&previously_selected_index)),
                 "it marks the selected node"
             );
             assert_eq!(
@@ -355,9 +356,10 @@ fn simple_user_journey_read_only() -> Result<()> {
             );
 
             assert!(
-                app.window.mark_pane.as_ref().map_or(false, |p| p
-                    .marked()
-                    .contains_key(&previously_selected_index)),
+                app.window
+                    .mark_pane
+                    .as_ref()
+                    .is_some_and(|p| p.marked().contains_key(&previously_selected_index)),
                 "it leaves the first selected item marked"
             );
         }

--- a/src/interactive/widgets/footer.rs
+++ b/src/interactive/widgets/footer.rs
@@ -45,6 +45,8 @@ impl Footer {
                     SortMode::MTimeDescending => "modified descending",
                     SortMode::CountAscending => "items ascending",
                     SortMode::CountDescending => "items descending",
+                    SortMode::NameAscending => "name ascending",
+                    SortMode::NameDescending => "name descending",
                 },
                 format.display(*total_bytes),
                 entries_traversed,

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -74,7 +74,7 @@ impl GlobPane {
             self.input
                 .graphemes(true)
                 .take(self.cursor_grapheme_idx)
-                .map(|g| g.as_bytes().len())
+                .map(|g| g.len())
                 .sum::<usize>(),
             new_char,
         );

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -152,6 +152,7 @@ impl HelpPane {
                 hotkey("M", "Show/hide modified time.", None);
                 hotkey("c", "Toggle sort by entries descending/ascending.", None);
                 hotkey("C", "Show/hide entry count.", None);
+                hotkey("n", "Toggle sort by name ascending/descending.", None);
                 hotkey(
                     "g/S",
                     "Cycle through percentage display and bar options.",

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -387,7 +387,7 @@ impl BackgroundTraversal {
                     }
                 }
 
-                if self.throttle.as_ref().map_or(false, |t| t.can_update()) {
+                if self.throttle.as_ref().is_some_and(|t| t.can_update()) {
                     return Some(false);
                 }
             }


### PR DESCRIPTION
Hi! This PR closes #269 by allowing users to toggle ascending / descending sort by name using the 'n' hotkey. A couple of notes on the design here, illustrated in the screen recording below.
- When the sort is first toggled, it is ascending by default, unlike the other sort modes, which default to descending (presumably users want to sort A-Z rather than Z-A)
- Entries are sorted first by type (directories before files) and lexicographically by name within each type. My thinking here is that users are likely sorting alphabetically so that they can navigate more easily. This is in line with how other command line tools like vim's file explorer perform sort by name.
- Names are sorted lexicographically rather than with a [natural sort](https://en.wikipedia.org/wiki/Natural_sort_order) as suggested in #126. Again this seems to be in line with how other tools sort by name, and is simpler to implement.
- The name column doesn't get highlighted in green once we choose to sort on it. I had a go at implementing this but think it may be more confusing than helpful given that names are highlighted to show which entries have / haven't been marked?

https://github.com/user-attachments/assets/b9fa83f0-9db9-4f44-a450-8996e91b151d



