### PR TITLE
Fix: Directories themselves do not contribute to size like they do in du

### DIFF
--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -52,8 +52,7 @@ pub fn aggregate(
                 Ok(entry) => {
                     let file_size = match entry.client_state {
                         Some(Ok(ref m))
-                            if !m.is_dir()
-                                && (walk_options.count_hard_links || inodes.add(m))
+                            if (walk_options.count_hard_links || inodes.add(m))
                                 && (walk_options.cross_filesystems
                                     || crossdev::is_same_device(device_id, m)) =>
                         {

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -234,12 +234,12 @@ pub fn sample_01_tree() -> Tree {
     {
         let mut add_node = make_add_node(&mut tree);
         #[cfg(not(windows))]
-        let root_size = 1259070;
+        let root_size = 1275454;
         #[cfg(windows)]
         let root_size = 1259069;
-        let rn = add_node("", root_size, 10, None);
+        let rn = add_node("", root_size, 14, None);
         {
-            let sn = add_node(&fixture_str("sample-01"), root_size, 10, Some(rn));
+            let sn = add_node(&fixture_str("sample-01"), root_size, 14, Some(rn));
             {
                 add_node(".hidden.666", 666, 0, Some(sn));
                 add_node("a", 256, 0, Some(sn));
@@ -248,16 +248,26 @@ pub fn sample_01_tree() -> Tree {
                 add_node("c.lnk", 1, 0, Some(sn));
                 #[cfg(windows)]
                 add_node("c.lnk", 0, 0, Some(sn));
-                let dn = add_node("dir", 1258024, 5, Some(sn));
+
+                #[cfg(not(windows))]
+                let dn = add_node("dir", 1270312, 8, Some(sn));
+                #[cfg(windows)]
+                let dn = add_node("dir", 1258024, 8, Some(sn));
                 {
                     add_node("1000bytes", 1000, 0, Some(dn));
                     add_node("dir-a.1mb", 1_000_000, 0, Some(dn));
                     add_node("dir-a.kb", 1024, 0, Some(dn));
-                    let en = add_node("empty-dir", 0, 1, Some(dn));
+                    #[cfg(not(windows))]
+                    let en = add_node("empty-dir", 4096, 2, Some(dn));
+                    #[cfg(windows)]
+                    let en = add_node("empty-dir", 0, 2, Some(dn));
                     {
                         add_node(".gitkeep", 0, 0, Some(en));
                     }
-                    let sub = add_node("sub", 256_000, 1, Some(dn));
+                    #[cfg(not(windows))]
+                    let sub = add_node("sub", 260_096, 2, Some(dn));
+                    #[cfg(windows)]
+                    let sub = add_node("sub", 256_000, 2, Some(dn));
                     {
                         add_node("dir-sub-a.256kb", 256_000, 0, Some(sub));
                     }
@@ -274,8 +284,11 @@ pub fn sample_02_tree(use_native_separator: bool) -> (Tree, TreeIndex) {
     let root_index: TreeIndex;
     {
         let mut add_node = make_add_node(&mut tree);
+        #[cfg(not(windows))]
+        let root_size = 17924;
+        #[cfg(windows)]
         let root_size = 1540;
-        root_index = add_node("", root_size, 6, None);
+        root_index = add_node("", root_size, 10, None);
         {
             let sn = add_node(
                 format!(
@@ -288,21 +301,30 @@ pub fn sample_02_tree(use_native_separator: bool) -> (Tree, TreeIndex) {
                 )
                 .as_str(),
                 root_size,
-                6,
+                10,
                 Some(root_index),
             );
             {
                 add_node("a", 256, 0, Some(sn));
                 add_node("b", 1, 0, Some(sn));
-                let dn = add_node("dir", 1283, 4, Some(sn));
+                #[cfg(not(windows))]
+                let dn = add_node("dir", 13571, 7, Some(sn));
+                #[cfg(windows)]
+                let dn = add_node("dir", 1283, 7, Some(sn));
                 {
                     add_node("c", 257, 0, Some(dn));
                     add_node("d", 2, 0, Some(dn));
-                    let en = add_node("empty-dir", 0, 1, Some(dn));
+                    #[cfg(not(windows))]
+                    let en = add_node("empty-dir", 4096, 2, Some(dn));
+                    #[cfg(windows)]
+                    let en = add_node("empty-dir", 0, 2, Some(dn));
                     {
                         add_node(".gitkeep", 0, 0, Some(en));
                     }
-                    let sub = add_node("sub", 1024, 1, Some(dn));
+                    #[cfg(not(windows))]
+                    let sub = add_node("sub", 5120, 2, Some(dn));
+                    #[cfg(windows)]
+                    let sub = add_node("sub", 1024, 2, Some(dn));
                     {
                         add_node("e", 1024, 0, Some(sub));
                     }
@@ -331,5 +353,5 @@ pub fn make_add_node(
 }
 
 pub fn debug(item: impl fmt::Debug) -> String {
-    format!("{item:?}")
+    format!("{item:#?}")
 }


### PR DESCRIPTION
Hi! This closes #262 where directory inode sizes are mistakenly being excluded from total disk usage calculations. This PR brings the behaviour of `dua` in line with that of `du` in both aggregate (`f44e19d`) and interactive (`ef1833a`) modes.

For example, given a directory tree structured as followed
```
/test_dir/
  ├── file1.txt (1KB)
  ├── empty_dir/
  └── populated_dir/
      └── file2.txt (2KB)
```
dua currently outputs
![image](https://github.com/user-attachments/assets/8e1f1bce-f918-4e87-98e8-c55ec49ebb9d)
With these changes:
![image](https://github.com/user-attachments/assets/187cf447-e604-4f6b-80fb-c3c5169388a2)

 Some notes on the changes made:
- In aggregate mode it suffices simply to remove the `!m.is_dir()` condition when traversing, as directory metadata can be handled just the same as non-directory file metadata
- In interactive mode, the changes are slightly more complex due to how entry size is recursively computed. We have existing logic for computing the size of a directory based solely on its contents (not counting the directory entry itself). In order to account for this entry size in the final total, I have added an `own_size` field to the `EntryData` struct, which stores the size just of the directory entry itself. Then, when updating our tree of `EntryData` nodes (in the `set_entry_info_or_panic` function), we simply add `own_size` to the total size of the directory's contents, which is computed just as before.
- No special cases  are needed to account for the --apparent-size flag. Following the lead of `du`, all directories are reported as consuming up a full block on disk regardless of whether reporting apparent size or disk usage.
-  Changing how entry counts are displayed: in interactive mode we are now displaying directory nodes in the entry_count as well as non-directory files. This makes it clearer that directory entry sizes are included in the calculations of the totals reported.
