### PR TITLE
Prompt user before quitting

### DIFF
--- a/src/interactive/app/state.rs
+++ b/src/interactive/app/state.rs
@@ -46,6 +46,7 @@ pub struct AppState {
     pub root_paths: Vec<PathBuf>,
     /// If true, listed entries will be validated for presence when switching directories.
     pub allow_entry_check: bool,
+    pub pending_exit: bool,
 }
 
 impl AppState {
@@ -64,6 +65,7 @@ impl AppState {
             walk_options,
             root_paths: input,
             allow_entry_check: true,
+            pending_exit: false,
         }
     }
 }

--- a/src/interactive/widgets/footer.rs
+++ b/src/interactive/widgets/footer.rs
@@ -21,6 +21,7 @@ pub struct FooterProps {
     pub format: ByteFormat,
     pub message: Option<String>,
     pub sort_mode: SortMode,
+    pub pending_exit: bool,
 }
 
 impl Footer {
@@ -33,7 +34,20 @@ impl Footer {
             format,
             message,
             sort_mode,
+            pending_exit,
         } = props.borrow();
+
+        if *pending_exit {
+            Paragraph::new(Text::from("Press esc or q again to exit..."))
+                .style(
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .render(area, buf);
+            return;
+        }
 
         let spans = vec![
             Span::from(format!(

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -129,6 +129,7 @@ impl MainWindow {
                 traversal_start: *start,
                 elapsed: *elapsed,
                 sort_mode: state.sorting,
+                pending_exit: state.pending_exit,
             },
             footer_area,
             buffer,


### PR DESCRIPTION
Dua will quit directly when pressing esc if the focus is on the main pane. This may cause users to accidentally quit the app when they only want to dismiss some other panels. It's especially frustrating if the scan took a long time.

This PR adds a prompt that shows before quitting the app. When you pressed esc or q, the status bar will show the prompt first. To really quit, you need to press esc or q again. You can also cancel the quit operation by pressing any key else. Meanwhile, ctrl-c still quits the app directly since it's a combination key.

There is a screencast to show how it works in action:

https://github.com/user-attachments/assets/38e70df9-fd58-4a04-915e-832d7edb5154