### PR TITLE
feat: add codespell configuration and refactor to avoid false-positives

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./target,./Cargo.lock,./CHANGELOG.md,./tests/fixtures,./tests/snapshots
+ignore-words-list = ratatui

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
             use crosstermion::terminal::{AlternateRawScreen, tui::new_terminal};
 
             let no_tty_msg = "Interactive mode requires a connected terminal";
-            if atty::isnt(atty::Stream::Stderr) {
+            if !atty::is(atty::Stream::Stderr) {
                 return Err(anyhow!(no_tty_msg));
             }
 


### PR DESCRIPTION
- Add .codespellrc with skips for generated/fixture directories and ignore "ratatui"
- Replace atty::isnt with "!atty::is" in src/main.rs to prevent codespell false-positive
- Ensures future spellcheck runs are clean and consistent

Author: rezky_nightky <with dot rezky at gmail dot com>
Repository: dua-cli
Branch: main
Signing: GPG (4B65AAC2)
HashAlgo: BLAKE3

[ Block Metadata ]
BlockHash: fdaf1aa8511ed4c6aaf3c26310490da90b3bc01a77a881ce167dcf9bf0b2100b PrevHash: d956c41c522908b7e9799b784bb880f189baf5fd66dc28e6bb38abb6945d32db PatchHash: 7b21823b21e9a28056032c6d316cef70ae9f83c42c1ae2342b6f330bad829ae5

FilesChanged: 2
Lines: +4 / -1

Timestamp: 2026-01-06T09:31:46Z
Signature1: a7a9d9bf9bbae69d1a1a46cb94de76d3095636931bf8471fd89f788d73b9ea54
Signature2: f860af29934f0228805313fc08bf6a74dab6cbd42af845a7068094cad53fad8d