### PR TITLE
fix: outdated link to NixOS package search

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ sudo pacman -S dua-cli
 ```
 
 #### NixOS
-https://search.nixos.org/packages?channel=23.11&show=dua&from=0&size=50&sort=relevance&type=packages&query=dua
+https://search.nixos.org/packages?query=dua
 
 Nix-shell (temporary)
 


### PR DESCRIPTION
Channel 23.11 was for Nov. 2023.
This update removes explicitly specifying a channel in the query, defaulting to the current latest stable NixOS nixpkgs channel (at the time of writing `25.11`