### PR TITLE
Replace atty with standard-library functionality (since Rust 1.70)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,17 +89,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,7 +360,6 @@ name = "dua-cli"
 version = "2.33.0"
 dependencies = [
  "anyhow",
- "atty",
  "bstr",
  "byte-unit",
  "chrono",
@@ -536,15 +524,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -802,7 +781,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ clap = { version = "4.0.29", features = ["derive", "env"] }
 clap_complete = "4.5.54"
 jwalk = "0.8.1"
 byte-unit = "4"
-atty = "0.2.11"
 petgraph = "0.8.3"
 itertools = "0.14.0"
 num_cpus = "1.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use clap::{CommandFactory as _, Parser};
 use dua::{TraversalSorting, canonicalize_ignore_dirs};
 use log::info;
-use std::{fs, io, io::Write, path::PathBuf, process};
+use std::{fs, io, io::IsTerminal, io::Write, path::PathBuf, process};
 
 #[cfg(feature = "tui-crossplatform")]
 use crate::interactive::input::input_channel;
@@ -16,8 +16,9 @@ mod interactive;
 mod options;
 
 fn stderr_if_tty() -> Option<io::Stderr> {
-    if atty::is(atty::Stream::Stderr) {
-        Some(io::stderr())
+    let stderr = io::stderr();
+    if stderr.is_terminal() {
+        Some(stderr)
     } else {
         None
     }
@@ -80,7 +81,7 @@ fn main() -> Result<()> {
             use crosstermion::terminal::{AlternateRawScreen, tui::new_terminal};
 
             let no_tty_msg = "Interactive mode requires a connected terminal";
-            if atty::isnt(atty::Stream::Stderr) {
+            if !io::stderr().is_terminal() {
                 return Err(anyhow!(no_tty_msg));
             }
 


### PR DESCRIPTION
Note that `atty` is now unmaintained, https://rustsec.org/advisories/RUSTSEC-2024-0375.html, and potentially unsound on Windows, https://rustsec.org/advisories/RUSTSEC-2021-0145.html.