### PR TITLE
fix: respect CARGO_HOME in install.sh

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -16,7 +16,7 @@ Options:
     --crate NAME    Name of the crate to install (default <repository name>)
     --tag TAG       Tag (version) of the crate to install (default <latest release>)
     --target TARGET Install the release compiled for $TARGET (default <`rustc` host>)
-    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+    --to LOCATION   Where to install the binary (default $CARGO_HOME/bin or ~/.cargo/bin)
 EOF
 }
 
@@ -130,7 +130,7 @@ fi
 say_err "Target: $target"
 
 if [ -z $dest ]; then
-    dest="$HOME/.cargo/bin"
+    dest="${CARGO_HOME:-$HOME/.cargo}/bin"
 fi
 
 say_err "Installing to: $dest"

--- a/tests/snapshots/failure-install-script-defaults-to-cargo-home
+++ b/tests/snapshots/failure-install-script-defaults-to-cargo-home
@@ -1,0 +1,7 @@
+install.sh: GitHub repository: https://github.com/Byron/dua-cli
+install.sh: Crate: dua
+install.sh: Tag: v2.29.0
+install.sh: Target: does-not-exist
+install.sh: Installing to: /tmp/dua-cargo-home/bin
+install.sh: Downloading: https://github.com/Byron/dua-cli/releases/download/v2.29.0/dua-v2.29.0-does-not-exist.tar.gz
+stub tar failure

--- a/tests/snapshots/failure-install-script-defaults-to-home-cargo-bin
+++ b/tests/snapshots/failure-install-script-defaults-to-home-cargo-bin
@@ -1,0 +1,7 @@
+install.sh: GitHub repository: https://github.com/Byron/dua-cli
+install.sh: Crate: dua
+install.sh: Tag: v2.29.0
+install.sh: Target: does-not-exist
+install.sh: Installing to: /tmp/dua-install-home/.cargo/bin
+install.sh: Downloading: https://github.com/Byron/dua-cli/releases/download/v2.29.0/dua-v2.29.0-does-not-exist.tar.gz
+stub tar failure

--- a/tests/stateless-journey.sh
+++ b/tests/stateless-journey.sh
@@ -113,3 +113,41 @@ WITH_FAILURE=1
     }
   )
 )
+
+(with "the install script"
+  (sandbox
+    mkdir fakebin
+    cat > fakebin/curl <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+    cat > fakebin/tar <<'EOF'
+#!/bin/sh
+echo "stub tar failure" >&2
+exit 1
+EOF
+    chmod +x fakebin/curl fakebin/tar
+    rm -rf /tmp/dua-install-home /tmp/dua-cargo-home
+    it "uses CARGO_HOME for the default install location" && {
+      WITH_SNAPSHOT="$snapshot/failure-install-script-defaults-to-cargo-home" \
+      PATH="$PWD/fakebin:$PATH" \
+      HOME=/tmp/dua-install-home \
+      CARGO_HOME=/tmp/dua-cargo-home \
+      expect_run ${WITH_FAILURE} sh "$root/../ci/install.sh" \
+        --git Byron/dua-cli \
+        --crate dua \
+        --tag v2.29.0 \
+        --target does-not-exist
+    }
+    it "falls back to HOME/.cargo/bin when CARGO_HOME is unset" && {
+      WITH_SNAPSHOT="$snapshot/failure-install-script-defaults-to-home-cargo-bin" \
+      PATH="$PWD/fakebin:$PATH" \
+      HOME=/tmp/dua-install-home \
+      expect_run ${WITH_FAILURE} sh "$root/../ci/install.sh" \
+        --git Byron/dua-cli \
+        --crate dua \
+        --tag v2.29.0 \
+        --target does-not-exist
+    }
+  )
+)


### PR DESCRIPTION
Fixes #279.

Before this change, omitting `--to` always defaulted the installer to `$HOME/.cargo/bin`, even when `CARGO_HOME` was set. That made the documented installer path disagree with the user's configured Cargo home.

This updates the default destination to use `$CARGO_HOME/bin` when `CARGO_HOME` is set, and keeps the existing `$HOME/.cargo/bin` fallback otherwise. The journey test coverage now exercises both branches with fixed `HOME`/`CARGO_HOME` values.

Validation:
- manual repro with fake `HOME`/`CARGO_HOME` before and after the change
- `./tests/stateless-journey.sh ./target/debug/dua`
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --all` still failed locally in two unrelated interactive size assertions on this macOS environment