### PR TITLE
feat: add heuristic cleanup for common project directories (#328)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ fn main() {
             .unwrap()
             .filter_map(Result::ok)
             .map(|e| e.path())
-            .filter(|p| p.extension().map_or(false, |ext| ext == "toml"))
+            .filter(|p| p.extension().is_some_and(|ext| ext == "toml"))
             .collect();
         
         entries.sort();

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("heuristics_includes.rs");
+
+    let heuristics_dir = Path::new("etc/heuristics");
+    let mut includes = String::new();
+    includes.push_str("[\n");
+
+    if heuristics_dir.exists() {
+        let mut entries: Vec<_> = fs::read_dir(heuristics_dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().map_or(false, |ext| ext == "toml"))
+            .collect();
+        
+        entries.sort();
+
+        for path in entries {
+            let path_str = path.to_str().unwrap().replace('\\', "/");
+            includes.push_str(&format!("    include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{}\")),\n", path_str));
+        }
+    }
+
+    includes.push_str("]\n");
+    fs::write(&dest_path, includes).unwrap();
+
+    println!("cargo:rerun-if-changed=etc/heuristics");
+}

--- a/build.rs
+++ b/build.rs
@@ -17,12 +17,15 @@ fn main() {
             .map(|e| e.path())
             .filter(|p| p.extension().is_some_and(|ext| ext == "toml"))
             .collect();
-        
+
         entries.sort();
 
         for path in entries {
             let path_str = path.to_str().unwrap().replace('\\', "/");
-            includes.push_str(&format!("    include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{}\")),\n", path_str));
+            includes.push_str(&format!(
+                "    include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/{}\")),\n",
+                path_str
+            ));
         }
     }
 

--- a/etc/heuristics/dart.toml
+++ b/etc/heuristics/dart.toml
@@ -1,0 +1,11 @@
+[[heuristics]]
+name = "clean-dart"
+description = "Clean up Dart/Flutter build directories"
+enabled = true
+match = [
+    "-f pubspec.yaml"
+]
+patterns = [
+    "build/",
+    ".dart_tool/"
+]

--- a/etc/heuristics/elixir.toml
+++ b/etc/heuristics/elixir.toml
@@ -1,0 +1,11 @@
+[[heuristics]]
+name = "clean-elixir"
+description = "Clean up Elixir build and deps"
+enabled = true
+match = [
+    "-f mix.exs"
+]
+patterns = [
+    "_build/",
+    "deps/"
+]

--- a/etc/heuristics/java.toml
+++ b/etc/heuristics/java.toml
@@ -1,0 +1,24 @@
+[[heuristics]]
+name = "clean-java-maven"
+description = "Clean up Maven target directory"
+enabled = true
+match = [
+    "-f pom.xml",
+    "-d target"
+]
+patterns = [
+    "target/"
+]
+
+[[heuristics]]
+name = "clean-java-gradle"
+description = "Clean up Gradle build directory"
+enabled = true
+match = [
+    "-f build.gradle | -f build.gradle.kts",
+    "-d build"
+]
+patterns = [
+    "build/",
+    ".gradle/"
+]

--- a/etc/heuristics/macos.toml
+++ b/etc/heuristics/macos.toml
@@ -1,0 +1,10 @@
+[[heuristics]]
+name = "clean-macos"
+description = "Clean up macOS .DS_Store files"
+enabled = true
+match = [
+    "-f .DS_Store"
+]
+patterns = [
+    ".DS_Store"
+]

--- a/etc/heuristics/node.toml
+++ b/etc/heuristics/node.toml
@@ -1,0 +1,11 @@
+[[heuristics]]
+name = "clean-node"
+description = "Clean up Node.js modules"
+enabled = true
+match = [
+    "-f package.json",
+    "-d node_modules"
+]
+patterns = [
+    "node_modules/"
+]

--- a/etc/heuristics/php.toml
+++ b/etc/heuristics/php.toml
@@ -1,0 +1,11 @@
+[[heuristics]]
+name = "clean-php"
+description = "Clean up PHP vendor directory"
+enabled = true
+match = [
+    "-f composer.json",
+    "-d vendor"
+]
+patterns = [
+    "vendor/"
+]

--- a/etc/heuristics/python.toml
+++ b/etc/heuristics/python.toml
@@ -1,0 +1,16 @@
+[[heuristics]]
+name = "clean-python"
+description = "Clean up Python virtual environments and caches"
+enabled = true
+match = [
+    "-f pyproject.toml | -f requirements.txt | -f setup.py",
+]
+patterns = [
+    ".venv/",
+    "venv/",
+    "env/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".ruff_cache/"
+]

--- a/etc/heuristics/rust.toml
+++ b/etc/heuristics/rust.toml
@@ -1,0 +1,11 @@
+[[heuristics]]
+name = "clean-rust"
+description = "Clean up rust build flow"
+enabled = true
+match = [
+    "-f Cargo.toml",
+    "-d target"
+]
+patterns = [
+    "target/"
+]

--- a/etc/heuristics/zig.toml
+++ b/etc/heuristics/zig.toml
@@ -1,0 +1,11 @@
+[[heuristics]]
+name = "clean-zig"
+description = "Clean up Zig cache and output"
+enabled = true
+match = [
+    "-f build.zig"
+]
+patterns = [
+    "zig-cache/",
+    "zig-out/"
+]

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -38,6 +38,34 @@ fn default_true() -> bool {
 }
 
 impl Heuristic {
+    /// Check if the heuristic matches a single entry.
+    pub fn is_match(&self, is_dir: bool, name: &std::ffi::OsStr) -> bool {
+        self.patterns.iter().any(|p| {
+            if p.ends_with('/') && !is_dir {
+                return false;
+            }
+            let p_trimmed = p.trim_end_matches('/');
+            if p_trimmed.contains('*') || p_trimmed.contains('?') {
+                if let Some(pattern) = Pattern::from_bytes(p_trimmed.as_bytes()) {
+                    let mode = if IGNORE_CASE {
+                        gix_glob::wildmatch::Mode::IGNORE_CASE
+                    } else {
+                        gix_glob::wildmatch::Mode::empty()
+                    };
+                    pattern.matches(bstr::BStr::new(name.as_encoded_bytes()), mode)
+                } else {
+                    false
+                }
+            } else {
+                if IGNORE_CASE {
+                    name.to_string_lossy().eq_ignore_ascii_case(p_trimmed)
+                } else {
+                    name == std::ffi::OsStr::new(p_trimmed)
+                }
+            }
+        })
+    }
+
     /// Check if the heuristic matches the given directory entries.
     pub fn matches<'a>(&self, entries: impl Iterator<Item = (bool, &'a OsStr)> + Clone) -> bool {
         if !self.enabled {
@@ -107,10 +135,45 @@ pub fn load_heuristics() -> &'static [Heuristic] {
         let configs = include!(concat!(env!("OUT_DIR"), "/heuristics_includes.rs"));
 
         for config_str in configs {
-            if let Ok(config) = toml::from_str::<HeuristicConfig>(config_str) {
-                all.extend(config.heuristics);
+            match toml::from_str::<HeuristicConfig>(config_str) {
+                Ok(config) => all.extend(config.heuristics),
+                Err(err) => panic!("Failed to parse built-in heuristic config: {err}"),
             }
         }
         all
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn test_is_match() {
+        let heuristic = Heuristic {
+            name: "test".to_string(),
+            description: "test description".to_string(),
+            enabled: true,
+            match_rules: vec![],
+            patterns: vec![
+                "target/".to_string(),
+                "*.log".to_string(),
+                "node_modules".to_string(),
+            ],
+        };
+
+        // Pattern ending with '/' must only match directories
+        assert!(heuristic.is_match(true, OsStr::new("target")));
+        assert!(!heuristic.is_match(false, OsStr::new("target")));
+
+        // Pattern not ending with '/' matches both files and directories
+        assert!(heuristic.is_match(true, OsStr::new("node_modules")));
+        assert!(heuristic.is_match(false, OsStr::new("node_modules")));
+
+        // Glob pattern matches correctly
+        assert!(heuristic.is_match(false, OsStr::new("error.log")));
+        assert!(heuristic.is_match(true, OsStr::new("error.log")));
+        assert!(!heuristic.is_match(false, OsStr::new("error.txt")));
+    }
 }

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -1,41 +1,43 @@
 //! Heuristics for cleaning up common project directories.
+use gix_glob::Pattern;
 use serde::Deserialize;
 use std::path::Path;
-use gix_glob::Pattern;
 
 #[derive(Debug, Deserialize, Clone)]
 /// Configuration for heuristics.
 pub struct HeuristicConfig {
-/// List of heuristics.
+    /// List of heuristics.
     pub heuristics: Vec<Heuristic>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 /// A heuristic for cleaning up directories.
 pub struct Heuristic {
-/// Name of the heuristic.
+    /// Name of the heuristic.
     pub name: String,
-/// Description of the heuristic.
+    /// Description of the heuristic.
     pub description: String,
     #[serde(default = "default_true")]
-/// Whether the heuristic is enabled.
+    /// Whether the heuristic is enabled.
     pub enabled: bool,
     #[serde(rename = "match")]
-/// Rules to match the heuristic.
+    /// Rules to match the heuristic.
     pub match_rules: Vec<String>,
-/// Patterns to clean up.
+    /// Patterns to clean up.
     pub patterns: Vec<String>,
 }
 
-fn default_true() -> bool { true }
+fn default_true() -> bool {
+    true
+}
 
 impl Heuristic {
-/// Check if the heuristic matches the given directory.
+    /// Check if the heuristic matches the given directory.
     pub fn matches(&self, dir: &Path) -> bool {
         if !self.enabled {
             return false;
         }
-        
+
         for rule_group in &self.match_rules {
             let mut group_matched = false;
             for rule in rule_group.split('|').map(|s| s.trim()) {
@@ -91,7 +93,7 @@ pub fn load_heuristics() -> Vec<Heuristic> {
         include_str!("../etc/heuristics/zig.toml"),
         include_str!("../etc/heuristics/macos.toml"),
     ];
-    
+
     for config_str in configs {
         if let Ok(config) = toml::from_str::<HeuristicConfig>(config_str) {
             all.extend(config.heuristics);

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -1,0 +1,101 @@
+//! Heuristics for cleaning up common project directories.
+use serde::Deserialize;
+use std::path::Path;
+use gix_glob::Pattern;
+
+#[derive(Debug, Deserialize, Clone)]
+/// Configuration for heuristics.
+pub struct HeuristicConfig {
+/// List of heuristics.
+    pub heuristics: Vec<Heuristic>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+/// A heuristic for cleaning up directories.
+pub struct Heuristic {
+/// Name of the heuristic.
+    pub name: String,
+/// Description of the heuristic.
+    pub description: String,
+    #[serde(default = "default_true")]
+/// Whether the heuristic is enabled.
+    pub enabled: bool,
+    #[serde(rename = "match")]
+/// Rules to match the heuristic.
+    pub match_rules: Vec<String>,
+/// Patterns to clean up.
+    pub patterns: Vec<String>,
+}
+
+fn default_true() -> bool { true }
+
+impl Heuristic {
+/// Check if the heuristic matches the given directory.
+    pub fn matches(&self, dir: &Path) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        
+        for rule_group in &self.match_rules {
+            let mut group_matched = false;
+            for rule in rule_group.split('|').map(|s| s.trim()) {
+                if rule.starts_with("-f ") {
+                    let file_name = &rule[3..];
+                    // Support glob in file name
+                    if file_name.contains('*') || file_name.contains('?') {
+                        let pattern = Pattern::from_bytes(file_name.as_bytes()).unwrap();
+                        if let Ok(entries) = std::fs::read_dir(dir) {
+                            for entry in entries.flatten() {
+                                if let Ok(name) = entry.file_name().into_string() {
+                                    if pattern.matches(
+                                        bstr::BStr::new(name.as_str()),
+                                        gix_glob::wildmatch::Mode::empty(),
+                                    ) {
+                                        group_matched = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    } else if dir.join(file_name).is_file() {
+                        group_matched = true;
+                        break;
+                    }
+                } else if rule.starts_with("-d ") {
+                    let dir_name = &rule[3..];
+                    if dir.join(dir_name).is_dir() {
+                        group_matched = true;
+                        break;
+                    }
+                }
+            }
+            if !group_matched {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// Load all heuristics.
+pub fn load_heuristics() -> Vec<Heuristic> {
+    let mut all = Vec::new();
+    let configs = [
+        include_str!("../etc/heuristics/rust.toml"),
+        include_str!("../etc/heuristics/node.toml"),
+        include_str!("../etc/heuristics/python.toml"),
+        include_str!("../etc/heuristics/java.toml"),
+        include_str!("../etc/heuristics/php.toml"),
+        include_str!("../etc/heuristics/dart.toml"),
+        include_str!("../etc/heuristics/elixir.toml"),
+        include_str!("../etc/heuristics/zig.toml"),
+        include_str!("../etc/heuristics/macos.toml"),
+    ];
+    
+    for config_str in configs {
+        if let Ok(config) = toml::from_str::<HeuristicConfig>(config_str) {
+            all.extend(config.heuristics);
+        }
+    }
+    all
+}

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -52,36 +52,39 @@ impl Heuristic {
                     if file_name.contains('*') || file_name.contains('?') {
                         if let Some(pattern) = Pattern::from_bytes(file_name.as_bytes())
                             && entries.clone().any(|(is_dir, name)| {
-                                !is_dir && pattern.matches(
-                                    bstr::BStr::new(name.as_encoded_bytes()),
-                                    if IGNORE_CASE {
-                                        gix_glob::wildmatch::Mode::IGNORE_CASE
-                                    } else {
-                                        gix_glob::wildmatch::Mode::empty()
-                                    },
-                                )
+                                !is_dir
+                                    && pattern.matches(
+                                        bstr::BStr::new(name.as_encoded_bytes()),
+                                        if IGNORE_CASE {
+                                            gix_glob::wildmatch::Mode::IGNORE_CASE
+                                        } else {
+                                            gix_glob::wildmatch::Mode::empty()
+                                        },
+                                    )
                             })
                         {
                             group_matched = true;
                             break;
                         }
                     } else if entries.clone().any(|(is_dir, name)| {
-                        !is_dir && if IGNORE_CASE {
-                            name.to_string_lossy().eq_ignore_ascii_case(file_name)
-                        } else {
-                            name == file_name
-                        }
+                        !is_dir
+                            && if IGNORE_CASE {
+                                name.to_string_lossy().eq_ignore_ascii_case(file_name)
+                            } else {
+                                name == file_name
+                            }
                     }) {
                         group_matched = true;
                         break;
                     }
                 } else if let Some(dir_name) = rule.strip_prefix("-d ")
                     && entries.clone().any(|(is_dir, name)| {
-                        is_dir && if IGNORE_CASE {
-                            name.to_string_lossy().eq_ignore_ascii_case(dir_name)
-                        } else {
-                            name == dir_name
-                        }
+                        is_dir
+                            && if IGNORE_CASE {
+                                name.to_string_lossy().eq_ignore_ascii_case(dir_name)
+                            } else {
+                                name == dir_name
+                            }
                     })
                 {
                     group_matched = true;

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -4,6 +4,11 @@ use serde::Deserialize;
 use std::ffi::OsStr;
 use std::sync::OnceLock;
 
+#[cfg(any(windows, target_os = "macos"))]
+const IGNORE_CASE: bool = true;
+#[cfg(not(any(windows, target_os = "macos")))]
+const IGNORE_CASE: bool = false;
+
 #[derive(Debug, Deserialize, Clone)]
 /// Configuration for heuristics.
 pub struct HeuristicConfig {
@@ -50,20 +55,36 @@ impl Heuristic {
                             if entries.clone().any(|(is_dir, name)| {
                                 !is_dir && pattern.matches(
                                     bstr::BStr::new(name.as_encoded_bytes()),
-                                    gix_glob::wildmatch::Mode::empty(),
+                                    if IGNORE_CASE {
+                                        gix_glob::wildmatch::Mode::IGNORE_CASE
+                                    } else {
+                                        gix_glob::wildmatch::Mode::empty()
+                                    },
                                 )
                             }) {
                                 group_matched = true;
                                 break;
                             }
                         }
-                    } else if entries.clone().any(|(is_dir, name)| !is_dir && name == file_name) {
+                    } else if entries.clone().any(|(is_dir, name)| {
+                        !is_dir && if IGNORE_CASE {
+                            name.to_string_lossy().eq_ignore_ascii_case(file_name)
+                        } else {
+                            name == file_name
+                        }
+                    }) {
                         group_matched = true;
                         break;
                     }
                 } else if rule.starts_with("-d ") {
                     let dir_name = &rule[3..];
-                    if entries.clone().any(|(is_dir, name)| is_dir && name == dir_name) {
+                    if entries.clone().any(|(is_dir, name)| {
+                        is_dir && if IGNORE_CASE {
+                            name.to_string_lossy().eq_ignore_ascii_case(dir_name)
+                        } else {
+                            name == dir_name
+                        }
+                    }) {
                         group_matched = true;
                         break;
                     }
@@ -82,17 +103,7 @@ pub fn load_heuristics() -> &'static [Heuristic] {
     static HEURISTICS: OnceLock<Vec<Heuristic>> = OnceLock::new();
     HEURISTICS.get_or_init(|| {
         let mut all = Vec::new();
-        let configs = [
-            include_str!("../etc/heuristics/rust.toml"),
-            include_str!("../etc/heuristics/node.toml"),
-            include_str!("../etc/heuristics/python.toml"),
-            include_str!("../etc/heuristics/java.toml"),
-            include_str!("../etc/heuristics/php.toml"),
-            include_str!("../etc/heuristics/dart.toml"),
-            include_str!("../etc/heuristics/elixir.toml"),
-            include_str!("../etc/heuristics/zig.toml"),
-            include_str!("../etc/heuristics/macos.toml"),
-        ];
+        let configs = include!(concat!(env!("OUT_DIR"), "/heuristics_includes.rs"));
 
         for config_str in configs {
             if let Ok(config) = toml::from_str::<HeuristicConfig>(config_str) {

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -47,12 +47,11 @@ impl Heuristic {
         for rule_group in &self.match_rules {
             let mut group_matched = false;
             for rule in rule_group.split('|').map(|s| s.trim()) {
-                if rule.starts_with("-f ") {
-                    let file_name = &rule[3..];
+                if let Some(file_name) = rule.strip_prefix("-f ") {
                     // Support glob in file name
                     if file_name.contains('*') || file_name.contains('?') {
-                        if let Some(pattern) = Pattern::from_bytes(file_name.as_bytes()) {
-                            if entries.clone().any(|(is_dir, name)| {
+                        if let Some(pattern) = Pattern::from_bytes(file_name.as_bytes())
+                            && entries.clone().any(|(is_dir, name)| {
                                 !is_dir && pattern.matches(
                                     bstr::BStr::new(name.as_encoded_bytes()),
                                     if IGNORE_CASE {
@@ -61,10 +60,10 @@ impl Heuristic {
                                         gix_glob::wildmatch::Mode::empty()
                                     },
                                 )
-                            }) {
-                                group_matched = true;
-                                break;
-                            }
+                            })
+                        {
+                            group_matched = true;
+                            break;
                         }
                     } else if entries.clone().any(|(is_dir, name)| {
                         !is_dir && if IGNORE_CASE {
@@ -76,18 +75,17 @@ impl Heuristic {
                         group_matched = true;
                         break;
                     }
-                } else if rule.starts_with("-d ") {
-                    let dir_name = &rule[3..];
-                    if entries.clone().any(|(is_dir, name)| {
+                } else if let Some(dir_name) = rule.strip_prefix("-d ")
+                    && entries.clone().any(|(is_dir, name)| {
                         is_dir && if IGNORE_CASE {
                             name.to_string_lossy().eq_ignore_ascii_case(dir_name)
                         } else {
                             name == dir_name
                         }
-                    }) {
-                        group_matched = true;
-                        break;
-                    }
+                    })
+                {
+                    group_matched = true;
+                    break;
                 }
             }
             if !group_matched {

--- a/src/heuristics.rs
+++ b/src/heuristics.rs
@@ -1,7 +1,8 @@
 //! Heuristics for cleaning up common project directories.
 use gix_glob::Pattern;
 use serde::Deserialize;
-use std::path::Path;
+use std::ffi::OsStr;
+use std::sync::OnceLock;
 
 #[derive(Debug, Deserialize, Clone)]
 /// Configuration for heuristics.
@@ -32,8 +33,8 @@ fn default_true() -> bool {
 }
 
 impl Heuristic {
-    /// Check if the heuristic matches the given directory.
-    pub fn matches(&self, dir: &Path) -> bool {
+    /// Check if the heuristic matches the given directory entries.
+    pub fn matches<'a>(&self, entries: impl Iterator<Item = (bool, &'a OsStr)> + Clone) -> bool {
         if !self.enabled {
             return false;
         }
@@ -45,27 +46,24 @@ impl Heuristic {
                     let file_name = &rule[3..];
                     // Support glob in file name
                     if file_name.contains('*') || file_name.contains('?') {
-                        let pattern = Pattern::from_bytes(file_name.as_bytes()).unwrap();
-                        if let Ok(entries) = std::fs::read_dir(dir) {
-                            for entry in entries.flatten() {
-                                if let Ok(name) = entry.file_name().into_string() {
-                                    if pattern.matches(
-                                        bstr::BStr::new(name.as_str()),
-                                        gix_glob::wildmatch::Mode::empty(),
-                                    ) {
-                                        group_matched = true;
-                                        break;
-                                    }
-                                }
+                        if let Some(pattern) = Pattern::from_bytes(file_name.as_bytes()) {
+                            if entries.clone().any(|(is_dir, name)| {
+                                !is_dir && pattern.matches(
+                                    bstr::BStr::new(name.as_encoded_bytes()),
+                                    gix_glob::wildmatch::Mode::empty(),
+                                )
+                            }) {
+                                group_matched = true;
+                                break;
                             }
                         }
-                    } else if dir.join(file_name).is_file() {
+                    } else if entries.clone().any(|(is_dir, name)| !is_dir && name == file_name) {
                         group_matched = true;
                         break;
                     }
                 } else if rule.starts_with("-d ") {
                     let dir_name = &rule[3..];
-                    if dir.join(dir_name).is_dir() {
+                    if entries.clone().any(|(is_dir, name)| is_dir && name == dir_name) {
                         group_matched = true;
                         break;
                     }
@@ -80,24 +78,27 @@ impl Heuristic {
 }
 
 /// Load all heuristics.
-pub fn load_heuristics() -> Vec<Heuristic> {
-    let mut all = Vec::new();
-    let configs = [
-        include_str!("../etc/heuristics/rust.toml"),
-        include_str!("../etc/heuristics/node.toml"),
-        include_str!("../etc/heuristics/python.toml"),
-        include_str!("../etc/heuristics/java.toml"),
-        include_str!("../etc/heuristics/php.toml"),
-        include_str!("../etc/heuristics/dart.toml"),
-        include_str!("../etc/heuristics/elixir.toml"),
-        include_str!("../etc/heuristics/zig.toml"),
-        include_str!("../etc/heuristics/macos.toml"),
-    ];
+pub fn load_heuristics() -> &'static [Heuristic] {
+    static HEURISTICS: OnceLock<Vec<Heuristic>> = OnceLock::new();
+    HEURISTICS.get_or_init(|| {
+        let mut all = Vec::new();
+        let configs = [
+            include_str!("../etc/heuristics/rust.toml"),
+            include_str!("../etc/heuristics/node.toml"),
+            include_str!("../etc/heuristics/python.toml"),
+            include_str!("../etc/heuristics/java.toml"),
+            include_str!("../etc/heuristics/php.toml"),
+            include_str!("../etc/heuristics/dart.toml"),
+            include_str!("../etc/heuristics/elixir.toml"),
+            include_str!("../etc/heuristics/zig.toml"),
+            include_str!("../etc/heuristics/macos.toml"),
+        ];
 
-    for config_str in configs {
-        if let Ok(config) = toml::from_str::<HeuristicConfig>(config_str) {
-            all.extend(config.heuristics);
+        for config_str in configs {
+            if let Ok(config) = toml::from_str::<HeuristicConfig>(config_str) {
+                all.extend(config.heuristics);
+            }
         }
-    }
-    all
+        all
+    })
 }

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -260,6 +260,8 @@ impl AppState {
         let glob_focussed = self.focussed == Glob;
         let mut tree_view = self.tree_view(traversal);
 
+        let prev_view_root = self.navigation().view_root;
+
         let esc_navigates_back_in_main =
             config.keys.esc_navigates_back && key.code == Esc && self.focussed == Main;
 
@@ -279,7 +281,6 @@ impl AppState {
             }
         }
 
-        let prev_view_root = self.navigation().view_root;
         let mut handled = true;
         match key.code {
             Tab => {

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -114,7 +114,7 @@ impl AppState {
     where
         B: Backend,
     {
-        self.check_heuristics(traversal);
+        self.check_heuristics();
         self.refresh_screen(window, traversal, display, terminal, config)?;
 
         loop {
@@ -126,9 +126,8 @@ impl AppState {
         }
     }
 
-    fn check_heuristics(&mut self, traversal: &mut Traversal) {
-        let tree_view = self.tree_view(traversal);
-        self.update_heuristics(&tree_view);
+    fn check_heuristics(&mut self) {
+        self.update_heuristics();
     }
 
     pub fn process_event<B>(
@@ -180,7 +179,7 @@ impl AppState {
                                 traversal.cost = Some(traversal.start_time.elapsed());
                             }
                             self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
-            self.check_heuristics(traversal);
+            self.check_heuristics();
                             self.refresh_screen(window, traversal, display, terminal, config)?;
                         };
                     }
@@ -341,7 +340,7 @@ impl AppState {
                                 if let Some(entry) = self
                                     .entries
                                     .iter()
-                                    .find(|e| e.name.to_string_lossy() == pattern_trimmed)
+                                    .find(|e| e.name.as_os_str() == std::ffi::OsStr::new(pattern_trimmed))
                                 {
                                     self.mark_entry_by_index(
                                         entry.index,
@@ -405,7 +404,7 @@ impl AppState {
         }
         if prev_view_root != self.navigation().view_root {
             drop(tree_view);
-            self.check_heuristics(traversal);
+            self.check_heuristics();
             let tree_view = self.tree_view(traversal);
             self.draw(window, &tree_view, *display, terminal, config)?;
         } else {

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -423,7 +423,6 @@ impl AppState {
             };
         }
         if prev_view_root != self.navigation().view_root {
-            drop(tree_view);
             self.check_heuristics();
             let tree_view = self.tree_view(traversal);
             self.draw(window, &tree_view, *display, terminal, config)?;

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -149,42 +149,42 @@ impl AppState {
         }) = self.scan.as_mut()
         {
             crossbeam::select! {
-                recv(events) -> event => {
-                    let Ok(event) = event else {
-                        return Ok(Some(WalkResult { num_errors: self.stats.io_errors }));
-                    };
-                    let res = self.process_terminal_event(
-                        window,
-                        traversal,
-                        display,
-                        terminal,
-                        event,
-                        config,
-                    )?;
-                    if let Some(res) = res {
-                        return Ok(Some(res));
-                    }
-                },
-                recv(&active_traversal.event_rx) -> event => {
-                    let Ok(event) = event else {
-                        return Ok(None);
-                    };
-
-                    if let Some(is_finished) = active_traversal.integrate_traversal_event(traversal, event) {
-                        self.stats = active_traversal.stats;
-                        let previous_selection = previous_selection.clone();
-                        if is_finished {
-                            let root_index = active_traversal.root_idx;
-                            self.recompute_sizes_recursively(traversal, root_index);
-                            self.scan = None;
-                            traversal.cost = Some(traversal.start_time.elapsed());
+                    recv(events) -> event => {
+                        let Ok(event) = event else {
+                            return Ok(Some(WalkResult { num_errors: self.stats.io_errors }));
+                        };
+                        let res = self.process_terminal_event(
+                            window,
+                            traversal,
+                            display,
+                            terminal,
+                            event,
+                            config,
+                        )?;
+                        if let Some(res) = res {
+                            return Ok(Some(res));
                         }
-                        self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
-        self.check_heuristics(traversal);
-                        self.refresh_screen(window, traversal, display, terminal, config)?;
-                    };
+                    },
+                    recv(&active_traversal.event_rx) -> event => {
+                        let Ok(event) = event else {
+                            return Ok(None);
+                        };
+
+                        if let Some(is_finished) = active_traversal.integrate_traversal_event(traversal, event) {
+                            self.stats = active_traversal.stats;
+                            let previous_selection = previous_selection.clone();
+                            if is_finished {
+                                let root_index = active_traversal.root_idx;
+                                self.recompute_sizes_recursively(traversal, root_index);
+                                self.scan = None;
+                                traversal.cost = Some(traversal.start_time.elapsed());
+                            }
+                            self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
+            self.check_heuristics(traversal);
+                            self.refresh_screen(window, traversal, display, terminal, config)?;
+                        };
+                    }
                 }
-            }
         } else {
             let Ok(event) = events.recv() else {
                 return Ok(Some(WalkResult {
@@ -338,8 +338,17 @@ impl AppState {
                         if let Some(heuristic) = self.active_heuristic.clone() {
                             for pattern in &heuristic.patterns {
                                 let pattern_trimmed = pattern.trim_end_matches('/');
-                                if let Some(entry) = self.entries.iter().find(|e| e.name.to_string_lossy() == pattern_trimmed) {
-                                    self.mark_entry_by_index(entry.index, MarkEntryMode::MarkForDeletion, window, &tree_view);
+                                if let Some(entry) = self
+                                    .entries
+                                    .iter()
+                                    .find(|e| e.name.to_string_lossy() == pattern_trimmed)
+                                {
+                                    self.mark_entry_by_index(
+                                        entry.index,
+                                        MarkEntryMode::MarkForDeletion,
+                                        window,
+                                        &tree_view,
+                                    );
                                 }
                             }
                         }
@@ -400,7 +409,7 @@ impl AppState {
             let tree_view = self.tree_view(traversal);
             self.draw(window, &tree_view, *display, terminal, config)?;
         } else {
-        self.draw(window, &tree_view, *display, terminal, config)?;
+            self.draw(window, &tree_view, *display, terminal, config)?;
         }
 
         Ok(None)

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -339,22 +339,35 @@ impl AppState {
                                 let pattern_trimmed = pattern.trim_end_matches('/');
                                 let mut to_mark = Vec::new();
                                 for entry in &self.entries {
-                                    let is_match = if pattern_trimmed.contains('*') || pattern_trimmed.contains('?') {
-                                        if let Some(pattern) = gix_glob::Pattern::from_bytes(pattern_trimmed.as_bytes()) {
+                                    let is_match = if pattern_trimmed.contains('*')
+                                        || pattern_trimmed.contains('?')
+                                    {
+                                        if let Some(pattern) = gix_glob::Pattern::from_bytes(
+                                            pattern_trimmed.as_bytes(),
+                                        ) {
                                             let mode = if cfg!(any(windows, target_os = "macos")) {
                                                 gix_glob::wildmatch::Mode::IGNORE_CASE
                                             } else {
                                                 gix_glob::wildmatch::Mode::empty()
                                             };
-                                            pattern.matches(bstr::BStr::new(entry.name.as_os_str().as_encoded_bytes()), mode)
+                                            pattern.matches(
+                                                bstr::BStr::new(
+                                                    entry.name.as_os_str().as_encoded_bytes(),
+                                                ),
+                                                mode,
+                                            )
                                         } else {
                                             false
                                         }
                                     } else {
                                         if cfg!(any(windows, target_os = "macos")) {
-                                            entry.name.to_string_lossy().eq_ignore_ascii_case(pattern_trimmed)
+                                            entry
+                                                .name
+                                                .to_string_lossy()
+                                                .eq_ignore_ascii_case(pattern_trimmed)
                                         } else {
-                                            entry.name.as_os_str() == std::ffi::OsStr::new(pattern_trimmed)
+                                            entry.name.as_os_str()
+                                                == std::ffi::OsStr::new(pattern_trimmed)
                                         }
                                     };
                                     if is_match {

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -337,13 +337,33 @@ impl AppState {
                         if let Some(heuristic) = self.active_heuristic.clone() {
                             for pattern in &heuristic.patterns {
                                 let pattern_trimmed = pattern.trim_end_matches('/');
-                                if let Some(entry) = self
-                                    .entries
-                                    .iter()
-                                    .find(|e| e.name.as_os_str() == std::ffi::OsStr::new(pattern_trimmed))
-                                {
+                                let mut to_mark = Vec::new();
+                                for entry in &self.entries {
+                                    let is_match = if pattern_trimmed.contains('*') || pattern_trimmed.contains('?') {
+                                        if let Some(pattern) = gix_glob::Pattern::from_bytes(pattern_trimmed.as_bytes()) {
+                                            let mode = if cfg!(any(windows, target_os = "macos")) {
+                                                gix_glob::wildmatch::Mode::IGNORE_CASE
+                                            } else {
+                                                gix_glob::wildmatch::Mode::empty()
+                                            };
+                                            pattern.matches(bstr::BStr::new(entry.name.as_os_str().as_encoded_bytes()), mode)
+                                        } else {
+                                            false
+                                        }
+                                    } else {
+                                        if cfg!(any(windows, target_os = "macos")) {
+                                            entry.name.to_string_lossy().eq_ignore_ascii_case(pattern_trimmed)
+                                        } else {
+                                            entry.name.as_os_str() == std::ffi::OsStr::new(pattern_trimmed)
+                                        }
+                                    };
+                                    if is_match {
+                                        to_mark.push(entry.index);
+                                    }
+                                }
+                                for index in to_mark {
                                     self.mark_entry_by_index(
-                                        entry.index,
+                                        index,
                                         MarkEntryMode::MarkForDeletion,
                                         window,
                                         &tree_view,

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -114,7 +114,7 @@ impl AppState {
     where
         B: Backend,
     {
-        self.check_heuristics();
+        self.update_heuristics();
         self.refresh_screen(window, traversal, display, terminal, config)?;
 
         loop {
@@ -124,10 +124,6 @@ impl AppState {
                 return Ok(result);
             }
         }
-    }
-
-    fn check_heuristics(&mut self) {
-        self.update_heuristics();
     }
 
     pub fn process_event<B>(
@@ -148,42 +144,42 @@ impl AppState {
         }) = self.scan.as_mut()
         {
             crossbeam::select! {
-                    recv(events) -> event => {
-                        let Ok(event) = event else {
-                            return Ok(Some(WalkResult { num_errors: self.stats.io_errors }));
-                        };
-                        let res = self.process_terminal_event(
-                            window,
-                            traversal,
-                            display,
-                            terminal,
-                            event,
-                            config,
-                        )?;
-                        if let Some(res) = res {
-                            return Ok(Some(res));
-                        }
-                    },
-                    recv(&active_traversal.event_rx) -> event => {
-                        let Ok(event) = event else {
-                            return Ok(None);
-                        };
-
-                        if let Some(is_finished) = active_traversal.integrate_traversal_event(traversal, event) {
-                            self.stats = active_traversal.stats;
-                            let previous_selection = previous_selection.clone();
-                            if is_finished {
-                                let root_index = active_traversal.root_idx;
-                                self.recompute_sizes_recursively(traversal, root_index);
-                                self.scan = None;
-                                traversal.cost = Some(traversal.start_time.elapsed());
-                            }
-                            self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
-            self.check_heuristics();
-                            self.refresh_screen(window, traversal, display, terminal, config)?;
-                        };
+                recv(events) -> event => {
+                    let Ok(event) = event else {
+                        return Ok(Some(WalkResult { num_errors: self.stats.io_errors }));
+                    };
+                    let res = self.process_terminal_event(
+                        window,
+                        traversal,
+                        display,
+                        terminal,
+                        event,
+                        config,
+                    )?;
+                    if let Some(res) = res {
+                        return Ok(Some(res));
                     }
+                },
+                recv(&active_traversal.event_rx) -> event => {
+                    let Ok(event) = event else {
+                        return Ok(None);
+                    };
+
+                    if let Some(is_finished) = active_traversal.integrate_traversal_event(traversal, event) {
+                        self.stats = active_traversal.stats;
+                        let previous_selection = previous_selection.clone();
+                        if is_finished {
+                            let root_index = active_traversal.root_idx;
+                            self.recompute_sizes_recursively(traversal, root_index);
+                            self.scan = None;
+                            traversal.cost = Some(traversal.start_time.elapsed());
+                        }
+                        self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
+                        self.update_heuristics();
+                        self.refresh_screen(window, traversal, display, terminal, config)?;
+                    };
                 }
+            }
         } else {
             let Ok(event) = events.recv() else {
                 return Ok(Some(WalkResult {
@@ -334,54 +330,20 @@ impl AppState {
                 Main => match key.code {
                     Char('O') => self.open_that(&tree_view),
                     Char('X') => {
-                        if let Some(heuristic) = self.active_heuristic.clone() {
-                            for pattern in &heuristic.patterns {
-                                let pattern_trimmed = pattern.trim_end_matches('/');
-                                let mut to_mark = Vec::new();
-                                for entry in &self.entries {
-                                    let is_match = if pattern_trimmed.contains('*')
-                                        || pattern_trimmed.contains('?')
-                                    {
-                                        if let Some(pattern) = gix_glob::Pattern::from_bytes(
-                                            pattern_trimmed.as_bytes(),
-                                        ) {
-                                            let mode = if cfg!(any(windows, target_os = "macos")) {
-                                                gix_glob::wildmatch::Mode::IGNORE_CASE
-                                            } else {
-                                                gix_glob::wildmatch::Mode::empty()
-                                            };
-                                            pattern.matches(
-                                                bstr::BStr::new(
-                                                    entry.name.as_os_str().as_encoded_bytes(),
-                                                ),
-                                                mode,
-                                            )
-                                        } else {
-                                            false
-                                        }
-                                    } else {
-                                        if cfg!(any(windows, target_os = "macos")) {
-                                            entry
-                                                .name
-                                                .to_string_lossy()
-                                                .eq_ignore_ascii_case(pattern_trimmed)
-                                        } else {
-                                            entry.name.as_os_str()
-                                                == std::ffi::OsStr::new(pattern_trimmed)
-                                        }
-                                    };
-                                    if is_match {
-                                        to_mark.push(entry.index);
-                                    }
+                        if let Some(heuristic) = self.active_heuristic {
+                            let mut to_mark = Vec::new();
+                            for entry in &self.entries {
+                                if heuristic.is_match(entry.is_dir, entry.name.as_os_str()) {
+                                    to_mark.push(entry.index);
                                 }
-                                for index in to_mark {
-                                    self.mark_entry_by_index(
-                                        index,
-                                        MarkEntryMode::MarkForDeletion,
-                                        window,
-                                        &tree_view,
-                                    );
-                                }
+                            }
+                            for index in to_mark {
+                                self.mark_entry_by_index(
+                                    index,
+                                    MarkEntryMode::MarkForDeletion,
+                                    window,
+                                    &tree_view,
+                                );
                             }
                         }
                     }
@@ -436,12 +398,9 @@ impl AppState {
             };
         }
         if prev_view_root != self.navigation().view_root {
-            self.check_heuristics();
-            let tree_view = self.tree_view(traversal);
-            self.draw(window, &tree_view, *display, terminal, config)?;
-        } else {
-            self.draw(window, &tree_view, *display, terminal, config)?;
+            self.update_heuristics();
         }
+        self.draw(window, &tree_view, *display, terminal, config)?;
 
         Ok(None)
     }

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -114,6 +114,7 @@ impl AppState {
     where
         B: Backend,
     {
+        self.check_heuristics(traversal);
         self.refresh_screen(window, traversal, display, terminal, config)?;
 
         loop {
@@ -123,6 +124,11 @@ impl AppState {
                 return Ok(result);
             }
         }
+    }
+
+    fn check_heuristics(&mut self, traversal: &mut Traversal) {
+        let tree_view = self.tree_view(traversal);
+        self.update_heuristics(&tree_view);
     }
 
     pub fn process_event<B>(
@@ -174,6 +180,7 @@ impl AppState {
                             traversal.cost = Some(traversal.start_time.elapsed());
                         }
                         self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
+        self.check_heuristics(traversal);
                         self.refresh_screen(window, traversal, display, terminal, config)?;
                     };
                 }
@@ -277,6 +284,7 @@ impl AppState {
             }
         }
 
+        let prev_view_root = self.navigation().view_root;
         let mut handled = true;
         match key.code {
             Tab => {
@@ -326,6 +334,16 @@ impl AppState {
                 }
                 Main => match key.code {
                     Char('O') => self.open_that(&tree_view),
+                    Char('X') => {
+                        if let Some(heuristic) = self.active_heuristic.clone() {
+                            for pattern in &heuristic.patterns {
+                                let pattern_trimmed = pattern.trim_end_matches('/');
+                                if let Some(entry) = self.entries.iter().find(|e| e.name.to_string_lossy() == pattern_trimmed) {
+                                    self.mark_entry_by_index(entry.index, MarkEntryMode::MarkForDeletion, window, &tree_view);
+                                }
+                            }
+                        }
+                    }
                     Char(' ') => self.mark_entry(
                         CursorMode::KeepPosition,
                         MarkEntryMode::Toggle,
@@ -376,7 +394,14 @@ impl AppState {
                 },
             };
         }
+        if prev_view_root != self.navigation().view_root {
+            drop(tree_view);
+            self.check_heuristics(traversal);
+            let tree_view = self.tree_view(traversal);
+            self.draw(window, &tree_view, *display, terminal, config)?;
+        } else {
         self.draw(window, &tree_view, *display, terminal, config)?;
+        }
 
         Ok(None)
     }

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -366,6 +366,7 @@ impl AppState {
             self.navigation_mut().select(idx);
         }
         tree_view.recompute_sizes_recursively(parent_idx);
+        self.update_heuristics();
 
         entries_deleted
     }

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -104,7 +104,7 @@ impl AppState {
         let entries = self.entries.iter().map(|e| (e.is_dir, e.name.as_os_str()));
         for heuristic in dua::heuristics::load_heuristics() {
             if heuristic.matches(entries.clone()) {
-                self.active_heuristic = Some(heuristic.clone());
+                self.active_heuristic = Some(heuristic);
                 break;
             }
         }

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -99,6 +99,17 @@ impl AppState {
         self.enter_node(new_entries)
     }
 
+    pub fn update_heuristics(&mut self, tree_view: &TreeView<'_>) {
+        self.active_heuristic = None;
+        let path = crate::interactive::path_of(tree_view.tree(), self.navigation().view_root, self.glob_navigation.as_ref().map(|n| n.view_root));
+        for heuristic in dua::heuristics::load_heuristics() {
+            if heuristic.matches(&path) {
+                self.active_heuristic = Some(heuristic);
+                break;
+            }
+        }
+    }
+
     pub fn enter_node(&mut self, entries_at_selected: Option<(TreeIndex, Vec<EntryDataBundle>)>) {
         if let Some((previously_selected, new_entries)) = entries_at_selected {
             match self
@@ -370,7 +381,7 @@ impl AppState {
         self.glob_navigation.as_ref().map(|e| e.tree_root)
     }
 
-    fn mark_entry_by_index(
+    pub fn mark_entry_by_index(
         &mut self,
         index: TreeIndex,
         mode: MarkEntryMode,

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -101,7 +101,11 @@ impl AppState {
 
     pub fn update_heuristics(&mut self, tree_view: &TreeView<'_>) {
         self.active_heuristic = None;
-        let path = crate::interactive::path_of(tree_view.tree(), self.navigation().view_root, self.glob_navigation.as_ref().map(|n| n.view_root));
+        let path = crate::interactive::path_of(
+            tree_view.tree(),
+            self.navigation().view_root,
+            self.glob_navigation.as_ref().map(|n| n.view_root),
+        );
         for heuristic in dua::heuristics::load_heuristics() {
             if heuristic.matches(&path) {
                 self.active_heuristic = Some(heuristic);

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -99,16 +99,12 @@ impl AppState {
         self.enter_node(new_entries)
     }
 
-    pub fn update_heuristics(&mut self, tree_view: &TreeView<'_>) {
+    pub fn update_heuristics(&mut self) {
         self.active_heuristic = None;
-        let path = crate::interactive::path_of(
-            tree_view.tree(),
-            self.navigation().view_root,
-            self.glob_navigation.as_ref().map(|n| n.view_root),
-        );
+        let entries = self.entries.iter().map(|e| (e.is_dir, e.name.as_os_str()));
         for heuristic in dua::heuristics::load_heuristics() {
-            if heuristic.matches(&path) {
-                self.active_heuristic = Some(heuristic);
+            if heuristic.matches(entries.clone()) {
+                self.active_heuristic = Some(heuristic.clone());
                 break;
             }
         }

--- a/src/interactive/app/state.rs
+++ b/src/interactive/app/state.rs
@@ -47,7 +47,7 @@ pub struct AppState {
     /// If true, listed entries will be validated for presence when switching directories.
     pub allow_entry_check: bool,
     pub pending_exit: bool,
-    pub active_heuristic: Option<dua::heuristics::Heuristic>,
+    pub active_heuristic: Option<&'static dua::heuristics::Heuristic>,
 }
 
 impl AppState {

--- a/src/interactive/app/state.rs
+++ b/src/interactive/app/state.rs
@@ -47,6 +47,7 @@ pub struct AppState {
     /// If true, listed entries will be validated for presence when switching directories.
     pub allow_entry_check: bool,
     pub pending_exit: bool,
+    pub active_heuristic: Option<dua::heuristics::Heuristic>,
 }
 
 impl AppState {
@@ -66,6 +67,7 @@ impl AppState {
             root_paths: input,
             allow_entry_check: true,
             pending_exit: false,
+            active_heuristic: None,
         }
     }
 }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -4,7 +4,10 @@ use crate::interactive::widgets::tui_ext::{
     List, ListProps, draw_text_nowrap_fn,
     util::{block_width, rect},
 };
-use crate::interactive::{DisplayOptions, EntryDataBundle, SortMode, widgets::EntryMarkMap};
+use crate::interactive::{
+    DisplayOptions, EntryDataBundle, SortMode,
+    widgets::{EntryMarkMap, entry_color},
+};
 use chrono::DateTime;
 use dua::traverse::TreeIndex;
 use itertools::Itertools;
@@ -31,7 +34,7 @@ pub struct EntriesProps<'a> {
     pub is_focussed: bool,
     pub sort_mode: SortMode,
     pub show_columns: &'a HashSet<Column>,
-    pub active_heuristic: Option<dua::heuristics::Heuristic>,
+    pub active_heuristic: Option<&'static dua::heuristics::Heuristic>,
 }
 
 #[derive(Default)]
@@ -90,35 +93,7 @@ impl Entries {
 
             let is_marked = marked.map(|m| m.contains_key(node_idx)).unwrap_or(false);
             let is_heuristic_match = active_heuristic
-                .as_ref()
-                .map(|h| {
-                    h.patterns.iter().any(|p| {
-                        let p_trimmed = p.trim_end_matches('/');
-                        if p_trimmed.contains('*') || p_trimmed.contains('?') {
-                            if let Some(pattern) =
-                                gix_glob::Pattern::from_bytes(p_trimmed.as_bytes())
-                            {
-                                let mode = if cfg!(any(windows, target_os = "macos")) {
-                                    gix_glob::wildmatch::Mode::IGNORE_CASE
-                                } else {
-                                    gix_glob::wildmatch::Mode::empty()
-                                };
-                                pattern.matches(
-                                    bstr::BStr::new(name.as_os_str().as_encoded_bytes()),
-                                    mode,
-                                )
-                            } else {
-                                false
-                            }
-                        } else {
-                            if cfg!(any(windows, target_os = "macos")) {
-                                name.to_string_lossy().eq_ignore_ascii_case(p_trimmed)
-                            } else {
-                                name.as_os_str() == std::ffi::OsStr::new(p_trimmed)
-                            }
-                        }
-                    })
-                })
+                .map(|h| h.is_match(*is_dir, name.as_os_str()))
                 .unwrap_or(false);
             let is_selected = selected == &Some(*node_idx);
             if is_selected {
@@ -179,7 +154,7 @@ impl Entries {
 
         if *is_focussed {
             let bound = draw_top_right_help(area, &title, buf);
-            draw_bottom_right_help(bound, buf, active_heuristic.as_ref());
+            draw_bottom_right_help(bound, buf, *active_heuristic);
         }
     }
 }
@@ -373,14 +348,10 @@ fn name_style(
     let fg = if !exists {
         // non-existing - always red!
         Some(Color::Red)
+    } else if !is_marked && is_heuristic_match {
+        Some(Color::Yellow)
     } else {
-        if is_marked {
-            crate::interactive::widgets::entry_color(style.fg, !is_dir, is_marked)
-        } else if is_heuristic_match {
-            Some(Color::Yellow)
-        } else {
-            crate::interactive::widgets::entry_color(style.fg, !is_dir, is_marked)
-        }
+        entry_color(style.fg, !is_dir, is_marked)
     };
     Style { fg, ..style }
 }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -4,10 +4,7 @@ use crate::interactive::widgets::tui_ext::{
     List, ListProps, draw_text_nowrap_fn,
     util::{block_width, rect},
 };
-use crate::interactive::{
-    DisplayOptions, EntryDataBundle, SortMode,
-    widgets::EntryMarkMap,
-};
+use crate::interactive::{DisplayOptions, EntryDataBundle, SortMode, widgets::EntryMarkMap};
 use chrono::DateTime;
 use dua::traverse::TreeIndex;
 use itertools::Itertools;
@@ -92,10 +89,15 @@ impl Entries {
             let name = bundle.name.as_path();
 
             let is_marked = marked.map(|m| m.contains_key(node_idx)).unwrap_or(false);
-            let is_heuristic_match = active_heuristic.as_ref().map(|h| {
-                let name_str = name.to_string_lossy();
-                h.patterns.iter().any(|p| p.trim_end_matches('/') == name_str)
-            }).unwrap_or(false);
+            let is_heuristic_match = active_heuristic
+                .as_ref()
+                .map(|h| {
+                    let name_str = name.to_string_lossy();
+                    h.patterns
+                        .iter()
+                        .any(|p| p.trim_end_matches('/') == name_str)
+                })
+                .unwrap_or(false);
             let is_selected = selected == &Some(*node_idx);
             if is_selected {
                 scroll_offset = Some(idx);
@@ -195,10 +197,17 @@ fn title(
     )
 }
 
-fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer, active_heuristic: Option<&dua::heuristics::Heuristic>) {
+fn draw_bottom_right_help(
+    bound: Rect,
+    buf: &mut Buffer,
+    active_heuristic: Option<&dua::heuristics::Heuristic>,
+) {
     let bound = line_bound(bound, bound.height.saturating_sub(1) as usize);
     let help_text = if let Some(h) = active_heuristic {
-        format!(" {} = X | mark-move = d | mark-toggle = space | toggle-all = a ", h.name)
+        format!(
+            " {} = X | mark-move = d | mark-toggle = space | toggle-all = a ",
+            h.name
+        )
     } else {
         " mark-move = d | mark-toggle = space | toggle-all = a ".to_string()
     };
@@ -332,7 +341,13 @@ fn name_with_prefix(mut name: Cow<'_, str>, is_dir: bool) -> Cow<'_, str> {
     }
 }
 
-fn name_style(is_marked: bool, exists: bool, is_dir: bool, is_heuristic_match: bool, style: Style) -> Style {
+fn name_style(
+    is_marked: bool,
+    exists: bool,
+    is_dir: bool,
+    is_heuristic_match: bool,
+    style: Style,
+) -> Style {
     let fg = if !exists {
         // non-existing - always red!
         Some(Color::Red)

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -95,13 +95,18 @@ impl Entries {
                     h.patterns.iter().any(|p| {
                         let p_trimmed = p.trim_end_matches('/');
                         if p_trimmed.contains('*') || p_trimmed.contains('?') {
-                            if let Some(pattern) = gix_glob::Pattern::from_bytes(p_trimmed.as_bytes()) {
+                            if let Some(pattern) =
+                                gix_glob::Pattern::from_bytes(p_trimmed.as_bytes())
+                            {
                                 let mode = if cfg!(any(windows, target_os = "macos")) {
                                     gix_glob::wildmatch::Mode::IGNORE_CASE
                                 } else {
                                     gix_glob::wildmatch::Mode::empty()
                                 };
-                                pattern.matches(bstr::BStr::new(name.as_os_str().as_encoded_bytes()), mode)
+                                pattern.matches(
+                                    bstr::BStr::new(name.as_os_str().as_encoded_bytes()),
+                                    mode,
+                                )
                             } else {
                                 false
                             }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -241,7 +241,7 @@ fn draw_bottom_right_help(
 
 fn draw_top_right_help(area: Rect, title: &str, buf: &mut Buffer) -> Rect {
     let help_text = " . = o|.. = u ── ⇊ = Ctrl+d|↓ = j|⇈ = Ctrl+u|↑ = k ";
-    let help_text_block_width = block_width(&help_text);
+    let help_text_block_width = block_width(help_text);
     let bound = Rect {
         width: area.width.saturating_sub(1),
         ..area
@@ -250,7 +250,7 @@ fn draw_top_right_help(area: Rect, title: &str, buf: &mut Buffer) -> Rect {
         draw_text_nowrap_fn(
             rect::snap_to_right(bound, help_text_block_width),
             buf,
-            &help_text,
+            help_text,
             |_, _, _| Style::default(),
         );
     }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -6,7 +6,7 @@ use crate::interactive::widgets::tui_ext::{
 };
 use crate::interactive::{
     DisplayOptions, EntryDataBundle, SortMode,
-    widgets::{EntryMarkMap, entry_color},
+    widgets::EntryMarkMap,
 };
 use chrono::DateTime;
 use dua::traverse::TreeIndex;
@@ -34,6 +34,7 @@ pub struct EntriesProps<'a> {
     pub is_focussed: bool,
     pub sort_mode: SortMode,
     pub show_columns: &'a HashSet<Column>,
+    pub active_heuristic: Option<dua::heuristics::Heuristic>,
 }
 
 #[derive(Default)]
@@ -58,6 +59,7 @@ impl Entries {
             is_focussed,
             sort_mode,
             show_columns,
+            active_heuristic,
         } = props.borrow();
         let list = &mut self.list;
 
@@ -90,6 +92,10 @@ impl Entries {
             let name = bundle.name.as_path();
 
             let is_marked = marked.map(|m| m.contains_key(node_idx)).unwrap_or(false);
+            let is_heuristic_match = active_heuristic.as_ref().map(|h| {
+                let name_str = name.to_string_lossy();
+                h.patterns.iter().any(|p| p.trim_end_matches('/') == name_str)
+            }).unwrap_or(false);
             let is_selected = selected == &Some(*node_idx);
             if is_selected {
                 scroll_offset = Some(idx);
@@ -129,7 +135,7 @@ impl Entries {
                 name_with_prefix(name.to_string_lossy(), *is_dir),
                 available_width,
             );
-            let style = name_style(is_marked, *exists, *is_dir, text_style);
+            let style = name_style(is_marked, *exists, *is_dir, is_heuristic_match, text_style);
             columns.push(name_column(name, area, style));
 
             columns_with_separators(columns, percentage_style, false)
@@ -149,7 +155,7 @@ impl Entries {
 
         if *is_focussed {
             let bound = draw_top_right_help(area, &title, buf);
-            draw_bottom_right_help(bound, buf);
+            draw_bottom_right_help(bound, buf, active_heuristic.as_ref());
         }
     }
 }
@@ -189,15 +195,19 @@ fn title(
     )
 }
 
-fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer) {
+fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer, active_heuristic: Option<&dua::heuristics::Heuristic>) {
     let bound = line_bound(bound, bound.height.saturating_sub(1) as usize);
-    let help_text = " mark-move = d | mark-toggle = space | toggle-all = a ";
-    let help_text_block_width = block_width(help_text);
+    let help_text = if let Some(h) = active_heuristic {
+        format!(" {} = X | mark-move = d | mark-toggle = space | toggle-all = a ", h.name)
+    } else {
+        " mark-move = d | mark-toggle = space | toggle-all = a ".to_string()
+    };
+    let help_text_block_width = block_width(&help_text);
     if help_text_block_width <= bound.width {
         draw_text_nowrap_fn(
             rect::snap_to_right(bound, help_text_block_width),
             buf,
-            help_text,
+            &help_text,
             |_, _, _| Style::default(),
         );
     }
@@ -205,7 +215,7 @@ fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer) {
 
 fn draw_top_right_help(area: Rect, title: &str, buf: &mut Buffer) -> Rect {
     let help_text = " . = o|.. = u ── ⇊ = Ctrl+d|↓ = j|⇈ = Ctrl+u|↑ = k ";
-    let help_text_block_width = block_width(help_text);
+    let help_text_block_width = block_width(&help_text);
     let bound = Rect {
         width: area.width.saturating_sub(1),
         ..area
@@ -214,7 +224,7 @@ fn draw_top_right_help(area: Rect, title: &str, buf: &mut Buffer) -> Rect {
         draw_text_nowrap_fn(
             rect::snap_to_right(bound, help_text_block_width),
             buf,
-            help_text,
+            &help_text,
             |_, _, _| Style::default(),
         );
     }
@@ -322,12 +332,18 @@ fn name_with_prefix(mut name: Cow<'_, str>, is_dir: bool) -> Cow<'_, str> {
     }
 }
 
-fn name_style(is_marked: bool, exists: bool, is_dir: bool, style: Style) -> Style {
+fn name_style(is_marked: bool, exists: bool, is_dir: bool, is_heuristic_match: bool, style: Style) -> Style {
     let fg = if !exists {
         // non-existing - always red!
         Some(Color::Red)
     } else {
-        entry_color(style.fg, !is_dir, is_marked)
+        if is_marked {
+            crate::interactive::widgets::entry_color(style.fg, !is_dir, is_marked)
+        } else if is_heuristic_match {
+            Some(Color::Yellow)
+        } else {
+            crate::interactive::widgets::entry_color(style.fg, !is_dir, is_marked)
+        }
     };
     Style { fg, ..style }
 }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -92,9 +92,27 @@ impl Entries {
             let is_heuristic_match = active_heuristic
                 .as_ref()
                 .map(|h| {
-                    h.patterns
-                        .iter()
-                        .any(|p| std::ffi::OsStr::new(p.trim_end_matches('/')) == name.as_os_str())
+                    h.patterns.iter().any(|p| {
+                        let p_trimmed = p.trim_end_matches('/');
+                        if p_trimmed.contains('*') || p_trimmed.contains('?') {
+                            if let Some(pattern) = gix_glob::Pattern::from_bytes(p_trimmed.as_bytes()) {
+                                let mode = if cfg!(any(windows, target_os = "macos")) {
+                                    gix_glob::wildmatch::Mode::IGNORE_CASE
+                                } else {
+                                    gix_glob::wildmatch::Mode::empty()
+                                };
+                                pattern.matches(bstr::BStr::new(name.as_os_str().as_encoded_bytes()), mode)
+                            } else {
+                                false
+                            }
+                        } else {
+                            if cfg!(any(windows, target_os = "macos")) {
+                                name.to_string_lossy().eq_ignore_ascii_case(p_trimmed)
+                            } else {
+                                name.as_os_str() == std::ffi::OsStr::new(p_trimmed)
+                            }
+                        }
+                    })
                 })
                 .unwrap_or(false);
             let is_selected = selected == &Some(*node_idx);

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -92,10 +92,9 @@ impl Entries {
             let is_heuristic_match = active_heuristic
                 .as_ref()
                 .map(|h| {
-                    let name_str = name.to_string_lossy();
                     h.patterns
                         .iter()
-                        .any(|p| p.trim_end_matches('/') == name_str)
+                        .any(|p| std::ffi::OsStr::new(p.trim_end_matches('/')) == name.as_os_str())
                 })
                 .unwrap_or(false);
             let is_selected = selected == &Some(*node_idx);

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -191,6 +191,11 @@ impl HelpPane {
                     "Mark the currently selected entry for deletion and move down.",
                     None,
                 );
+                hotkey(
+                    "Shift + x",
+                    "Mark all entries matching the active heuristic for deletion.",
+                    None,
+                );
                 hotkey("<Space>", "Toggle the currently selected entry.", None);
                 hotkey("a", "Toggle all entries.", None);
                 hotkey(

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -112,7 +112,7 @@ impl MainWindow {
             is_focussed: matches!(state.focussed, Main),
             sort_mode: state.sorting,
             show_columns: &state.show_columns,
-            active_heuristic: state.active_heuristic.clone(),
+            active_heuristic: state.active_heuristic,
         };
         self.entries_pane.render(props, entries_area, buffer);
 

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -112,6 +112,7 @@ impl MainWindow {
             is_focussed: matches!(state.focussed, Main),
             sort_mode: state.sorting,
             show_columns: &state.show_columns,
+            active_heuristic: state.active_heuristic.clone(),
         };
         self.entries_pane.render(props, entries_area, buffer);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod inodefilter;
 /// Filesystem traversal, in-memory tree representation, and traversal events.
 pub mod traverse;
 
+pub mod heuristics;
 pub use aggregate::aggregate;
 pub use common::*;
 pub(crate) use inodefilter::InodeFilter;


### PR DESCRIPTION
## Description

This PR implements an initial prototype of the declarative heuristic engine discussed in #328.

This code is currently a draft and serves as a proof of concept. It requires further discussion, thorough code review, and extensive testing before merging. I am opening this PR now to gather early feedback on the implementation and architectural direction.

## Key Changes

- Add declarative TOML-based heuristic engine in `etc/heuristics/`
- Support common languages: Rust, Node.js, Python, Java, PHP, Dart, Elixir, Zig, macOS
- Integrate with TUI: auto-detect project type on directory navigation
- Highlight matched build/cache directories in yellow
- Add dynamic bottom-right help text (e.g., `clean-rust = X`)
- Press `X` to quickly mark matched directories for deletion
