### PR TITLE
fix: respect CARGO_HOME in install script

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -16,7 +16,7 @@ Options:
     --crate NAME    Name of the crate to install (default <repository name>)
     --tag TAG       Tag (version) of the crate to install (default <latest release>)
     --target TARGET Install the release compiled for $TARGET (default <`rustc` host>)
-    --to LOCATION   Where to install the binary (default ~/.cargo/bin)
+    --to LOCATION   Where to install the binary (default $CARGO_HOME/bin, or ~/.cargo/bin if CARGO_HOME is unset)
 EOF
 }
 
@@ -130,7 +130,7 @@ fi
 say_err "Target: $target"
 
 if [ -z $dest ]; then
-    dest="$HOME/.cargo/bin"
+    dest="${CARGO_HOME:-$HOME/.cargo}/bin"
 fi
 
 say_err "Installing to: $dest"


### PR DESCRIPTION
## Summary
- Use `${CARGO_HOME:-$HOME/.cargo}/bin` as the install script's default destination.
- Keep `--to` as an explicit override.
- Update the help text to describe the `CARGO_HOME`-aware default.

Closes #279.

## Verification
- `sh -n ci/install.sh`
- Fake `curl`/`tar` harness verified:
  - `CARGO_HOME=/tmp/custom` defaults to `/tmp/custom/bin`
  - unset `CARGO_HOME` defaults to `$HOME/.cargo/bin`
  - `--to /tmp/explicit` still overrides both
- `git diff --check`