### PR TITLE
Enable precious gitignore syntax through gix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -510,8 +510,6 @@ dependencies = [
  "fern",
  "filesize",
  "gix",
- "gix-glob 0.22.1",
- "gix-path 0.10.21",
  "human_format",
  "itertools 0.14.0",
  "jiff",
@@ -569,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -702,10 +700,10 @@ dependencies = [
  "gix-dir",
  "gix-discover",
  "gix-error",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-hash",
  "gix-hashtable",
  "gix-ignore",
@@ -716,7 +714,7 @@ dependencies = [
  "gix-object",
  "gix-odb",
  "gix-pack",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-protocol",
  "gix-ref",
  "gix-refspec",
@@ -731,7 +729,7 @@ dependencies = [
  "gix-traverse",
  "gix-url",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate",
  "gix-worktree",
  "gix-worktree-state",
  "gix-worktree-stream",
@@ -771,8 +769,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
 dependencies = [
  "bstr",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-glob",
+ "gix-path",
  "gix-quote",
  "gix-trace",
  "kstring",
@@ -826,7 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
 dependencies = [
  "bstr",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "gix-trace",
  "shell-words",
@@ -854,9 +852,9 @@ checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.48.1",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
  "gix-ref",
  "gix-sec",
  "smallvec",
@@ -872,7 +870,7 @@ checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-path 0.12.1",
+ "gix-path",
  "libc",
  "thiserror",
 ]
@@ -902,7 +900,7 @@ dependencies = [
  "gix-hash",
  "gix-imara-diff",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-tempfile",
  "gix-trace",
  "gix-traverse",
@@ -922,7 +920,7 @@ dependencies = [
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-trace",
  "gix-utils",
@@ -939,7 +937,7 @@ dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-ref",
  "gix-sec",
  "thiserror",
@@ -956,23 +954,13 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa64593d1586135102307fb57fb3a9d3868b6b1f45a4da1352cce5070f8916a"
-dependencies = [
- "gix-trace",
- "libc",
-]
-
-[[package]]
-name = "gix-features"
 version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "bytes",
  "crc32fast",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-trace",
  "gix-utils",
  "libc",
@@ -996,7 +984,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "gix-packetline",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "gix-trace",
  "gix-utils",
@@ -1012,22 +1000,10 @@ checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
- "gix-features 0.48.1",
- "gix-path 0.12.1",
+ "gix-features",
+ "gix-path",
  "gix-utils",
  "thiserror",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74254992150b0a88fdb3ad47635ab649512dff2cbbefca7916bb459894fc9d56"
-dependencies = [
- "bitflags",
- "bstr",
- "gix-features 0.44.1",
- "gix-path 0.10.21",
 ]
 
 [[package]]
@@ -1038,8 +1014,8 @@ checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
  "bitflags",
  "bstr",
- "gix-features 0.48.1",
- "gix-path 0.12.1",
+ "gix-features",
+ "gix-path",
 ]
 
 [[package]]
@@ -1049,7 +1025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
- "gix-features 0.48.1",
+ "gix-features",
  "sha1-checked",
  "sha2",
  "thiserror",
@@ -1073,8 +1049,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
 dependencies = [
  "bstr",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-glob",
+ "gix-path",
  "gix-trace",
  "unicode-bom",
 ]
@@ -1086,7 +1062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
  "bstr",
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1100,14 +1076,14 @@ dependencies = [
  "filetime",
  "fnv",
  "gix-bitmap",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-traverse",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate",
  "hashbrown 0.16.0",
  "itoa",
  "libc",
@@ -1143,7 +1119,7 @@ dependencies = [
  "gix-imara-diff",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "gix-revision",
  "gix-revwalk",
@@ -1177,11 +1153,11 @@ dependencies = [
  "bstr",
  "gix-actor",
  "gix-date",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate",
  "itoa",
  "smallvec",
  "thiserror",
@@ -1194,13 +1170,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
 dependencies = [
  "arc-swap",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-pack",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-quote",
  "memmap2",
  "parking_lot",
@@ -1217,11 +1193,11 @@ dependencies = [
  "clru",
  "gix-chunk",
  "gix-error",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "memmap2",
  "smallvec",
  "thiserror",
@@ -1241,26 +1217,13 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0416b41cd00ff292af9b94b0660880c44bd2ed66828ddca9a2b333535cbb71b8"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate 0.10.1",
- "home",
- "thiserror",
-]
-
-[[package]]
-name = "gix-path"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
 dependencies = [
  "bstr",
  "gix-trace",
- "gix-validate 0.11.2",
+ "gix-validate",
  "thiserror",
 ]
 
@@ -1274,8 +1237,8 @@ dependencies = [
  "bstr",
  "gix-attributes",
  "gix-config-value",
- "gix-glob 0.26.1",
- "gix-path 0.12.1",
+ "gix-glob",
+ "gix-path",
  "thiserror",
 ]
 
@@ -1287,7 +1250,7 @@ checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-hash",
  "gix-ref",
  "gix-shallow",
@@ -1316,15 +1279,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
 dependencies = [
  "gix-actor",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-tempfile",
  "gix-utils",
- "gix-validate 0.11.2",
+ "gix-validate",
  "memmap2",
  "thiserror",
 ]
@@ -1337,10 +1300,10 @@ checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
 dependencies = [
  "bstr",
  "gix-error",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-hash",
  "gix-revision",
- "gix-validate 0.11.2",
+ "gix-validate",
  "smallvec",
  "thiserror",
 ]
@@ -1386,7 +1349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
 dependencies = [
  "bitflags",
- "gix-path 0.12.1",
+ "gix-path",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -1414,13 +1377,13 @@ dependencies = [
  "filetime",
  "gix-diff",
  "gix-dir",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-hash",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
@@ -1435,7 +1398,7 @@ checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
 dependencies = [
  "bstr",
  "gix-config",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
@@ -1469,7 +1432,7 @@ checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
 dependencies = [
  "bstr",
  "gix-command",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
@@ -1501,7 +1464,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
 dependencies = [
  "bstr",
- "gix-path 0.12.1",
+ "gix-path",
  "percent-encoding",
  "thiserror",
 ]
@@ -1515,16 +1478,6 @@ dependencies = [
  "bstr",
  "fastrand",
  "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
-dependencies = [
- "bstr",
- "thiserror",
 ]
 
 [[package]]
@@ -1545,13 +1498,13 @@ dependencies = [
  "bstr",
  "gix-attributes",
  "gix-fs",
- "gix-glob 0.26.1",
+ "gix-glob",
  "gix-hash",
  "gix-ignore",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
- "gix-validate 0.11.2",
+ "gix-path",
+ "gix-validate",
 ]
 
 [[package]]
@@ -1561,12 +1514,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
 dependencies = [
  "bstr",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-index",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-worktree",
  "io-close",
  "thiserror",
@@ -1580,12 +1533,12 @@ checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
 dependencies = [
  "gix-attributes",
  "gix-error",
- "gix-features 0.48.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-hash",
  "gix-object",
- "gix-path 0.12.1",
+ "gix-path",
  "gix-traverse",
  "parking_lot",
 ]
@@ -1638,6 +1591,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1660,15 +1616,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "human_format"
@@ -2271,7 +2218,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2510,7 +2457,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2837,7 +2784,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ include = [
 ]
 
 [features]
-default = ["tui-crossplatform", "trash-move", "git"]
-git = []
+default = ["tui-crossplatform", "trash-move"]
 tui-crossplatform = [
     "crossterm",
     "tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 
 [features]
 default = ["tui-crossplatform", "trash-move", "git"]
-git = ["dep:gix"]
+git = []
 tui-crossplatform = [
     "crossterm",
     "tui",
@@ -55,9 +55,7 @@ wild = "2.0.4"
 owo-colors = "4.0.0"
 human_format = "1.0.3"
 once_cell = "1.19"
-gix-glob = "0.22.1"
-gix-path = "0.10.10"
-gix = { version = "0.83.0", optional = true, default-features = false, features = [
+gix = { version = "0.83.0", default-features = false, features = [
     "excludes",
     "sha1",
     "sha256",

--- a/src/common.rs
+++ b/src/common.rs
@@ -286,7 +286,7 @@ impl WalkResult {
 pub fn canonicalize_ignore_dirs(ignore_dirs: &[PathBuf]) -> BTreeSet<PathBuf> {
     let dirs = ignore_dirs
         .iter()
-        .map(gix_path::realpath)
+        .map(gix::path::realpath)
         .filter_map(Result::ok)
         .collect();
     log::info!("Ignoring canonicalized {dirs:?}");
@@ -297,7 +297,7 @@ fn ignore_directory(path: &Path, ignore_dirs: &BTreeSet<PathBuf>, cwd: &Path) ->
     if ignore_dirs.is_empty() {
         return false;
     }
-    let path = gix_path::realpath_opts(path, cwd, 32);
+    let path = gix::path::realpath_opts(path, cwd, 32);
     path.map(|path| {
         let ignored = ignore_dirs.contains(&path);
         if ignored {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,11 @@ use std::path::PathBuf;
 /// ```toml
 /// format = "binary"
 ///
+/// # Git-related features to enable in interactive mode.
+/// # Supported values: true, false.
+/// # If unset, behavior defaults to enabled.
+/// # gitignore = true
+///
 /// [keys]
 /// esc_navigates_back = true
 /// ```
@@ -25,6 +30,12 @@ pub struct Config {
 
     /// Keybinding-related settings.
     pub keys: KeysConfig,
+
+    /// Whether Git-ignored entry detection is enabled.
+    ///
+    /// Supported values: `true` and `false`.
+    /// If unset, defaults to `true`.
+    pub gitignore: Option<bool>,
 }
 
 /// Keyboard interaction settings.
@@ -97,6 +108,11 @@ impl Config {
             "# Supported values: metric, binary, bytes, gb, gib, mb, mib.\n",
             "# format = \"binary\"\n",
             "#\n",
+            "# Controls whether Git-ignored entry detection is enabled in interactive mode.\n",
+            "# Supported values: true, false.\n",
+            "# If unset, behavior defaults to true.\n",
+            "# gitignore = true\n",
+            "#\n",
             "[keys]\n",
             "# If true, pressing <Esc> in the main pane ascends to the parent directory.\n",
             "# If false, <Esc> follows the default quit behavior.\n",
@@ -139,5 +155,36 @@ mod tests {
 
         assert_eq!(config.format, Some(crate::ByteFormat::MB));
         assert!(!config.keys.esc_navigates_back);
+    }
+
+    #[test]
+    fn parses_configured_gitignore() {
+        let config: Config = toml::from_str(
+            r#"
+            format = "mb"
+            gitignore = false
+
+            [keys]
+            esc_navigates_back = false
+            "#,
+        )
+        .expect("valid config");
+
+        assert_eq!(config.gitignore, Some(false));
+    }
+
+    #[test]
+    fn gitignore_defaults_to_enabled() {
+        let config: Config = toml::from_str(
+            r#"
+            format = "mb"
+
+            [keys]
+            esc_navigates_back = false
+            "#,
+        )
+        .expect("valid config");
+
+        assert_eq!(config.gitignore, None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,10 +14,15 @@ use std::path::PathBuf;
 /// ```toml
 /// format = "binary"
 ///
-/// # Git-related features to enable in interactive mode.
+/// # Controls whether Git-ignored entry detection is enabled in interactive mode.
 /// # Supported values: true, false.
-/// # If unset, behavior defaults to enabled.
+/// # If unset, behavior defaults to true.
 /// # gitignore = true
+///
+/// # Controls whether cleanup heuristics are enabled in interactive mode.
+/// # Supported values: true, false.
+/// # If unset, behavior defaults to true.
+/// # cleanup_heuristics = true
 ///
 /// [keys]
 /// esc_navigates_back = true
@@ -36,6 +41,12 @@ pub struct Config {
     /// Supported values: `true` and `false`.
     /// If unset, defaults to `true`.
     pub gitignore: Option<bool>,
+
+    /// Whether cleanup heuristics are enabled.
+    ///
+    /// Supported values: `true` and `false`.
+    /// If unset, defaults to `true`.
+    pub cleanup_heuristics: Option<bool>,
 }
 
 /// Keyboard interaction settings.
@@ -113,6 +124,11 @@ impl Config {
             "# If unset, behavior defaults to true.\n",
             "# gitignore = true\n",
             "#\n",
+            "# Controls whether cleanup heuristics are enabled in interactive mode.\n",
+            "# Supported values: true, false.\n",
+            "# If unset, behavior defaults to true.\n",
+            "# cleanup_heuristics = true\n",
+            "#\n",
             "[keys]\n",
             "# If true, pressing <Esc> in the main pane ascends to the parent directory.\n",
             "# If false, <Esc> follows the default quit behavior.\n",
@@ -186,5 +202,36 @@ mod tests {
         .expect("valid config");
 
         assert_eq!(config.gitignore, None);
+    }
+
+    #[test]
+    fn parses_configured_cleanup_heuristics() {
+        let config: Config = toml::from_str(
+            r#"
+            format = "mb"
+            cleanup_heuristics = false
+
+            [keys]
+            esc_navigates_back = false
+            "#,
+        )
+        .expect("valid config");
+
+        assert_eq!(config.cleanup_heuristics, Some(false));
+    }
+
+    #[test]
+    fn cleanup_heuristics_defaults_to_enabled() {
+        let config: Config = toml::from_str(
+            r#"
+            format = "mb"
+
+            [keys]
+            esc_navigates_back = false
+            "#,
+        )
+        .expect("valid config");
+
+        assert_eq!(config.cleanup_heuristics, None);
     }
 }

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -403,9 +403,7 @@ impl AppState {
                     Char('a') => self.mark_all_entries(MarkEntryMode::Toggle, window, &tree_view),
                     Char('t') => self.toggle_cleanup_candidates(&tree_view),
                     Char('X') => self.mark_cleanup_candidates(window, &tree_view),
-                    #[cfg(feature = "git")]
                     Char('i') => self.toggle_gitignored_entries(&tree_view),
-                    #[cfg(feature = "git")]
                     Char('I') => self.mark_gitignored_entries(window, &tree_view),
                     Char('o') | Char('l') | Enter | Right => {
                         self.enter_node_with_traversal(&tree_view)

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -576,7 +576,7 @@ impl AppState {
         &mut self,
         tree_view: &mut TreeView<'_>,
         glob_pattern: &str,
-        case: gix_glob::pattern::Case,
+        case: gix::glob::pattern::Case,
     ) {
         use FocussedPane::*;
         match glob_search(

--- a/src/interactive/app/gitignore.rs
+++ b/src/interactive/app/gitignore.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 
 use dua::traverse::TreeIndex;
+use gix::ignore::Kind;
 
 use super::{EntryDataBundle, tree_view::TreeView};
 
@@ -28,6 +29,13 @@ pub fn gitignored_entries(
         }
     }
 
+    fn open_options(trust: gix::sec::Trust) -> gix::open::Options {
+        use gix::sec::trust::DefaultForLevel;
+
+        gix::open::Options::default_for_level(trust)
+            .config_overrides(["gitoxide.parsePrecious=true"])
+    }
+
     let current_path = tree_view.path_of(view_root);
     let current_path = if current_path.as_os_str().is_empty() {
         Path::new(".").to_owned()
@@ -35,9 +43,16 @@ pub fn gitignored_entries(
         current_path
     };
 
-    let Ok(repo) = gix::discover(&current_path) else {
+    let trust_map = gix::sec::trust::Mapping {
+        full: open_options(gix::sec::Trust::Full),
+        reduced: open_options(gix::sec::Trust::Reduced),
+    };
+    let Ok(repo) =
+        gix::ThreadSafeRepository::discover_opts(&current_path, Default::default(), trust_map)
+    else {
         return BTreeSet::new();
     };
+    let repo = repo.to_thread_local();
     let Ok(cwd) = std::env::current_dir() else {
         return BTreeSet::new();
     };
@@ -62,7 +77,10 @@ pub fn gitignored_entries(
             let path = absolute_path(tree_view.path_of(entry.index), &cwd);
             let relative_path = path.strip_prefix(&workdir).ok()?;
             let platform = excludes.at_path(relative_path, Some(mode(entry))).ok()?;
-            platform.is_excluded().then_some(entry.index)
+            platform
+                .excluded_kind()
+                .is_some_and(|kind| matches!(kind, Kind::Expendable))
+                .then_some(entry.index)
         })
         .collect()
 }

--- a/src/interactive/app/gitignore.rs
+++ b/src/interactive/app/gitignore.rs
@@ -5,7 +5,6 @@ use gix::ignore::Kind;
 
 use super::{EntryDataBundle, tree_view::TreeView};
 
-#[cfg(feature = "git")]
 pub fn gitignored_entries(
     tree_view: &TreeView<'_>,
     view_root: TreeIndex,
@@ -83,13 +82,4 @@ pub fn gitignored_entries(
                 .then_some(entry.index)
         })
         .collect()
-}
-
-#[cfg(not(feature = "git"))]
-pub fn gitignored_entries(
-    _tree_view: &TreeView<'_>,
-    _view_root: TreeIndex,
-    _entries: &[EntryDataBundle],
-) -> BTreeSet<TreeIndex> {
-    BTreeSet::new()
 }

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -195,7 +195,6 @@ impl AppState {
         self.reset_message();
     }
 
-    #[cfg(feature = "git")]
     pub fn toggle_gitignored_entries(&mut self, tree_view: &TreeView<'_>) {
         self.gitignored_entries = self.gitignored_entries.is_none().then(BTreeSet::new);
         self.update_entry_annotations(tree_view);
@@ -478,7 +477,6 @@ impl AppState {
         }
     }
 
-    #[cfg(feature = "git")]
     pub fn mark_gitignored_entries(&mut self, window: &mut MainWindow, tree_view: &TreeView<'_>) {
         match self.gitignored_entries.clone() {
             Some(gitignored_entries) => self.mark_annotation_candidates(

--- a/src/interactive/app/terminal.rs
+++ b/src/interactive/app/terminal.rs
@@ -47,6 +47,9 @@ impl TerminalApp {
         if config.gitignore == Some(false) {
             state.gitignored_entries = None;
         }
+        if config.cleanup_heuristics == Some(false) {
+            state.cleanup_candidates = None;
+        }
         state.allow_entry_check = entry_check;
         let traversal = Traversal::new();
         #[cfg(test)]

--- a/src/interactive/app/terminal.rs
+++ b/src/interactive/app/terminal.rs
@@ -44,6 +44,9 @@ impl TerminalApp {
         let window = MainWindow::default();
 
         let mut state = AppState::new(walk_options, input);
+        if config.gitignore == Some(false) {
+            state.gitignored_entries = None;
+        }
         state.allow_entry_check = entry_check;
         let traversal = Traversal::new();
         #[cfg(test)]

--- a/src/interactive/app/tests/journeys_with_writes.rs
+++ b/src/interactive/app/tests/journeys_with_writes.rs
@@ -99,7 +99,8 @@ fn gitignored_entries_are_marked_with_dedicated_key() -> Result<()> {
 ignored_dir/
 ignored-link
 target/
-*.tmp
+remove.tmp
+$precious.tmp
 !keep.tmp
 ",
     )?;
@@ -107,6 +108,7 @@ target/
     fs::create_dir_all(root.join("ignored_dir"))?;
     fs::write(root.join("ignored_dir/file"), [])?;
     fs::write(root.join("remove.tmp"), [])?;
+    fs::write(root.join("precious.tmp"), [])?;
     fs::write(root.join("keep.tmp"), [])?;
     std::os::unix::fs::symlink(root.join("keep.tmp"), root.join("ignored-link"))?;
     fs::create_dir_all(root.join("target/debug"))?;
@@ -155,6 +157,7 @@ target/
             "ignored.log".to_string(),
             "ignored_dir".to_string(),
             "ignored-link".to_string(),
+            // "precious.tmp".to_string(), # precious file is notably absent from highlighted files
             "remove.tmp".to_string(),
             "target".to_string(),
         ])
@@ -215,7 +218,7 @@ target/
     assert_eq!(
         target_gitignored_names,
         BTreeSet::from(["debug".to_string(), "output.bin".to_string()]),
-        "entries inside an ignored directory are ignored as well as we use `gix::discover()`"
+        "entries inside an ignored directory are ignored as well as we use repository discovery"
     );
 
     app.process_events(&mut terminal, into_codes("u"))?;

--- a/src/interactive/app/tests/journeys_with_writes.rs
+++ b/src/interactive/app/tests/journeys_with_writes.rs
@@ -78,7 +78,7 @@ fn basic_user_journey_with_deletion() -> Result<()> {
 }
 
 #[test]
-#[cfg(all(feature = "git", not(target_os = "windows")))]
+#[cfg(unix)]
 fn gitignored_entries_are_marked_with_dedicated_key() -> Result<()> {
     let fixture = TempDir::new()?;
     let root = fixture.path();

--- a/src/interactive/app/tests/unit.rs
+++ b/src/interactive/app/tests/unit.rs
@@ -7,7 +7,7 @@ use crate::interactive::{EntryCheck, MTimeSort, SortMode, sorted_entries};
 use anyhow::Result;
 use dua::traverse::{EntryData, Traversal, Tree, TreeIndex};
 use dua::{TraversalSorting, WalkOptions};
-use gix_glob::pattern::Case;
+use gix::glob::pattern::Case;
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
 use std::time::Instant;

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -217,9 +217,7 @@ fn title(
 fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer) {
     let bound = line_bound(bound, bound.height.saturating_sub(1) as usize);
     let mut help_text = " mark-move = d | mark-toggle = space | cleanup = X".to_string();
-    if cfg!(feature = "git") {
-        help_text.push_str(" | gitignore = I");
-    }
+    help_text.push_str(" | gitignore = I");
     help_text.push_str(" | all = a ");
 
     let help_text_block_width = block_width(&help_text);

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result, anyhow};
 use bstr::BString;
 use crossterm::event::{KeyEvent, KeyEventKind};
 use dua::traverse::{Tree, TreeIndex};
-use gix_glob::pattern::Case;
+use gix::glob::pattern::Case;
 use petgraph::Direction;
 use std::borrow::Borrow;
 use tui::{
@@ -197,7 +197,7 @@ fn glob_search_neighbours(
     results: &mut Vec<TreeIndex>,
     tree: &Tree,
     root_index: TreeIndex,
-    glob: &gix_glob::Pattern,
+    glob: &gix::glob::Pattern,
     path: &mut BString,
     case: Case,
 ) {
@@ -210,13 +210,13 @@ fn glob_search_neighbours(
                 path.push(b'/');
                 Some(previous_len + 1)
             };
-            path.extend_from_slice(gix_path::into_bstr(&node.name).as_ref());
+            path.extend_from_slice(gix::path::into_bstr(&node.name).as_ref());
             if glob.matches_repo_relative_path(
                 path.as_ref(),
                 basename_start,
                 Some(node.is_dir),
                 case,
-                gix_glob::wildmatch::Mode::NO_MATCH_SLASH_LITERAL,
+                gix::glob::wildmatch::Mode::NO_MATCH_SLASH_LITERAL,
             ) {
                 results.push(node_index);
             } else {
@@ -231,9 +231,9 @@ pub fn glob_search(
     tree: &Tree,
     root_index: TreeIndex,
     glob: &str,
-    case: gix_glob::pattern::Case,
+    case: gix::glob::pattern::Case,
 ) -> Result<Vec<TreeIndex>> {
-    let glob = gix_glob::Pattern::from_bytes_without_negation(glob.as_bytes())
+    let glob = gix::glob::Pattern::from_bytes_without_negation(glob.as_bytes())
         .with_context(|| anyhow!("Glob was empty or only whitespace"))?;
     let mut results = Vec::new();
     let mut path = Default::default();

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -164,9 +164,7 @@ impl HelpPane {
                 hotkey("<Space>", t.oms_toggle, None);
                 hotkey("X", t.oms_mark_cleanup, None);
                 hotkey("t", t.oms_toggle_cleanup, None);
-                #[cfg(feature = "git")]
                 hotkey("I", t.oms_mark_gitignored, None);
-                #[cfg(feature = "git")]
                 hotkey("i", t.oms_toggle_gitignored, None);
                 hotkey("a", t.oms_toggle_all, None);
                 hotkey("/", t.oms_search, Some(t.oms_search_2));

--- a/src/interactive/widgets/i18n.rs
+++ b/src/interactive/widgets/i18n.rs
@@ -118,9 +118,7 @@ pub struct HelpText {
     pub oms_toggle: &'static str,
     pub oms_mark_cleanup: &'static str,
     pub oms_toggle_cleanup: &'static str,
-    #[cfg(feature = "git")]
     pub oms_mark_gitignored: &'static str,
-    #[cfg(feature = "git")]
     pub oms_toggle_gitignored: &'static str,
     pub oms_toggle_all: &'static str,
     pub oms_search: &'static str,
@@ -182,9 +180,7 @@ const EN: HelpText = HelpText {
     oms_toggle: "Toggle the currently selected entry.",
     oms_mark_cleanup: "Mark cleanup candidates in the current view.",
     oms_toggle_cleanup: "Toggle cleanup-candidate detection.",
-    #[cfg(feature = "git")]
     oms_mark_gitignored: "Mark Git-ignored entries in the current view.",
-    #[cfg(feature = "git")]
     oms_toggle_gitignored: "Toggle Git-ignored entry detection.",
     oms_toggle_all: "Toggle all entries.",
     oms_search: "Git-style glob search. Toggle case with 'I'.",
@@ -246,9 +242,7 @@ const JA: HelpText = HelpText {
     oms_toggle: "選択中のエントリを切り替える。",
     oms_mark_cleanup: "現在のビューのクリーンアップ候補をマークする。",
     oms_toggle_cleanup: "クリーンアップ候補の検出を切り替える。",
-    #[cfg(feature = "git")]
     oms_mark_gitignored: "現在のビューの Git 無視エントリをマークする。",
-    #[cfg(feature = "git")]
     oms_toggle_gitignored: "Git 無視エントリの検出を切り替える。",
     oms_toggle_all: "すべてのエントリを切り替える。",
     oms_search: "Git 形式の glob 検索。'I' で大文字小文字を切り替える。",


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

Remove separate `gix-glob` and `gix-path` crates and refer to them through `gix` directly. Also, add a config-override when opening the Git repository to `gitoxide.parsePrecious=true` to support precious file syntax out of the box.

## Summary

- Removed direct `gix-glob` and `gix-path` dependencies and updated call sites to use `gix::glob` and `gix::path` re-exports.
- Kept Git ignored-entry behavior behind the existing `git` feature while making `gix` the single crate dependency for the shared `gix` APIs.
- Open repository discovery for gitignored-entry detection with `gitoxide.parsePrecious=true` for both full and reduced trust levels.
- Added a regression case for `$precious.tmp` in the existing gitignored-entry journey.

## Git baseline

The reference Git checkout at `7760f83b59750c27df653c5c46d0f80e44cfe02c` has no `parsePrecious` or `ignored-and-precious` ignore syntax. This behavior is a gitoxide extension parsed by `gix-ignore` through the `$` prefix.

## Validation

- `cargo test --features git gitignored_entries_are_marked_with_dedicated_key`
- `cargo fmt --check`
- `cargo check --no-default-features`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test` was also run; 49 of 51 main tests passed, with two local fixture graph-size assertions failing due filesystem allocation-size differences unrelated to this change.

## Review

`codex review --commit 39bdf69bdc4b42f6cbfe99a448da265837b3287f` could not complete because the local Codex CLI reported a usage limit. It was not rerun for the same commit hash.