### PR TITLE
fix: degrade entries title on narrow terminals

### DIFF
--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -61,7 +61,7 @@ impl TreeView<'_> {
         )
     }
 
-    pub fn current_path(&self, view_root: TreeIndex) -> String {
+    pub fn current_path(&self, view_root: TreeIndex) -> PathBuf {
         current_path(&self.traversal.tree, view_root, self.glob_tree_root)
     }
 
@@ -124,12 +124,11 @@ fn current_path(
     tree: &petgraph::stable_graph::StableGraph<EntryData, ()>,
     root: petgraph::stable_graph::NodeIndex,
     glob_root: Option<TreeIndex>,
-) -> String {
-    match path_of(tree, root, glob_root).to_string_lossy().to_string() {
-        ref p if p.is_empty() => Path::new(".")
+) -> PathBuf {
+    match path_of(tree, root, glob_root) {
+        ref p if p.as_os_str().is_empty() => Path::new(".")
             .canonicalize()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| String::from(".")),
+            .unwrap_or_else(|_| PathBuf::from(".")),
         p => p,
     }
 }

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -13,6 +13,7 @@ use dua::traverse::TreeIndex;
 use itertools::Itertools;
 use std::borrow::{Borrow, Cow};
 use std::collections::{BTreeSet, HashSet};
+use std::path::{Component, Path, PathBuf};
 use std::time::SystemTime;
 use tui::{
     buffer::Buffer,
@@ -22,12 +23,12 @@ use tui::{
     widgets::{Block, Borders, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget},
 };
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Inputs used to render the entries pane.
 pub struct EntriesProps<'a> {
     /// Path shown in the entries pane title.
-    pub current_path: String,
+    pub current_path: PathBuf,
     /// Size display mode used for byte and percentage columns.
     pub display: DisplayOptions,
     /// Currently selected tree entry, if one is selected.
@@ -83,12 +84,14 @@ impl Entries {
             .map(|f| (f.entry_count.unwrap_or(1), f.size))
             .reduce(|a, b| (a.0 + b.0, a.1 + b.1))
             .unwrap_or_default();
+        let title_width_inside_borders = area.width.saturating_sub(2) as usize;
         let title = title(
             current_path,
             entries.len(),
             recursive_item_count,
             *display,
             item_size,
+            title_width_inside_borders,
         );
         let title_block = title_block(&title, *border_style);
         let inner_area = title_block.inner(area);
@@ -199,19 +202,240 @@ fn title_block(title: &str, border_style: Style) -> Block<'_> {
         .borders(Borders::ALL)
 }
 
+/// Build the entries pane title within `title_width_cells` terminal cells.
+///
+/// `title_width_cells` is the available display width for the title text itself,
+/// after excluding the surrounding block borders.
 fn title(
-    current_path: &str,
+    current_path: &Path,
     item_count: usize,
     recursive_item_count: u64,
     display: DisplayOptions,
     size: u128,
+    title_width_cells: usize,
 ) -> String {
-    format!(
-        " {} ({item_count} visible, {} total, {}) ",
-        current_path,
+    let statistics = format!(
+        "({item_count} visible, {} total, {})",
         COUNT.format(recursive_item_count as f64),
         display.byte_format.display(size)
-    )
+    );
+    let title = format!(" {path} {statistics} ", path = current_path.display());
+    if title.width() <= title_width_cells {
+        return title;
+    }
+
+    path_title(current_path, title_width_cells)
+}
+
+fn path_title(current_path: &Path, width: usize) -> String {
+    let padding = 2;
+    match width {
+        0 => String::new(),
+        width if width <= padding => {
+            shorten_input(current_path.to_string_lossy(), width).into_owned()
+        }
+        width => {
+            let path = compact_path(current_path, width - padding);
+            let title = format!(" {path} ");
+            if title.width() <= width {
+                title
+            } else {
+                shorten_input(Cow::Owned(title), width).into_owned()
+            }
+        }
+    }
+}
+
+/// Shorten a display path to fit `width` cells by preserving path structure when possible.
+///
+/// Unlike `shorten_input`, this understands `Path` components and prefers replacing
+/// a consecutive run of middle components with a `[N]` marker. Root and prefix
+/// components are preserved; only ordinary path components are candidates for removal.
+///
+/// If the path cannot be parsed into components, or no component-removal candidate fits,
+/// this falls back to `shorten_input`.
+///
+/// `width` is the maximum display width in terminal cells, not bytes or characters.
+///
+/// - `/a/b/c/d` at width 7 -> `/a[2]d`
+/// - `a/b/c/d` at width 6 -> `a[2]d`
+/// - `12345678` at width 3 -> `1…8`
+fn compact_path(current_path: &Path, width: usize) -> Cow<'_, str> {
+    let current_path_display = current_path.to_string_lossy();
+    if current_path_display.width() <= width {
+        return current_path_display;
+    }
+
+    let Some(path) = DisplayPath::new(current_path) else {
+        return shorten_input(current_path_display, width);
+    };
+
+    let keep_ends = true;
+    path.compact_by_removing_components(width, keep_ends)
+        .or_else(|| path.compact_by_removing_components(width, !keep_ends))
+        .map(Cow::Owned)
+        .unwrap_or_else(|| shorten_input(current_path_display, width))
+}
+
+/// Parsed path data reused while evaluating component-removal candidates.
+///
+/// This keeps root/prefix text, removable components, component display widths,
+/// and total path width together so each compaction candidate can be scored
+/// without repeatedly walking the path or recalculating unchanged widths.
+struct DisplayPath<'a> {
+    prefix: String,
+    separator: char,
+    components: Vec<Cow<'a, str>>,
+    component_width_prefix_sum: Vec<usize>,
+    width: usize,
+}
+
+impl<'a> DisplayPath<'a> {
+    fn new(path: &'a Path) -> Option<Self> {
+        let separator = std::path::MAIN_SEPARATOR;
+        let mut prefix = String::new();
+        let mut components = Vec::new();
+
+        for component in path.components() {
+            match component {
+                Component::Prefix(prefix_component) => {
+                    prefix.push_str(&prefix_component.as_os_str().to_string_lossy());
+                }
+                Component::RootDir => {
+                    prefix.push(separator);
+                }
+                Component::CurDir => components.push(Cow::Borrowed(".")),
+                Component::ParentDir => components.push(Cow::Borrowed("..")),
+                Component::Normal(component) => {
+                    components.push(component.to_string_lossy());
+                }
+            }
+        }
+        if components.len() < 2 {
+            return None;
+        }
+
+        let mut component_width_prefix_sum = Vec::with_capacity(components.len() + 1);
+        component_width_prefix_sum.push(0);
+        for component in &components {
+            component_width_prefix_sum
+                .push(component_width_prefix_sum.last().copied().unwrap() + component.width());
+        }
+        let width = prefix.width()
+            + component_width_prefix_sum.last().copied().unwrap()
+            + separator.width().unwrap_or(1) * (components.len() - 1);
+
+        Some(DisplayPath {
+            prefix,
+            separator,
+            components,
+            component_width_prefix_sum,
+            width,
+        })
+    }
+
+    /// Return the best path candidate that fits `width` by replacing components with `[N]`.
+    ///
+    /// Root and prefix components are always kept. When `keep_ends` is true, the
+    /// first and last removable components are also kept visible and only a middle
+    /// run may be replaced. When false, the removed run may include either
+    /// removable end, which is a fallback for very narrow widths.
+    fn compact_by_removing_components(&self, width: usize, keep_ends: bool) -> Option<String> {
+        let component_count = self.components.len();
+        let path_center = component_count as isize - 1;
+        let (first_start, last_start) = if keep_ends {
+            (1, component_count.checked_sub(2)?)
+        } else {
+            (0, component_count.checked_sub(1)?)
+        };
+        if last_start == 0 {
+            return None;
+        }
+
+        let mut best = None;
+        for start in first_start..=last_start {
+            let first_end = start + 1;
+            let last_end = if keep_ends {
+                component_count - 1
+            } else {
+                component_count
+            };
+            if first_end > last_end || self.candidate_width(start, last_end) > width {
+                continue;
+            }
+
+            // Find the shortest removable run that fits. For a fixed `start`,
+            // increasing `end` removes more components, so candidate width is
+            // monotonic non-increasing.
+            let mut lower = first_end;
+            let mut upper = last_end;
+            while lower < upper {
+                let middle = lower + (upper - lower) / 2;
+                if self.candidate_width(start, middle) <= width {
+                    upper = middle;
+                } else {
+                    lower = middle + 1;
+                }
+            }
+
+            let end = lower;
+            let removed_components = end - start;
+            let removed_center = (start * 2 + removed_components - 1) as isize;
+            let center_distance = (removed_center - path_center).abs();
+            let candidate_width = self.candidate_width(start, end);
+            if best.as_ref().is_none_or(
+                |(_, _, best_removed_components, best_distance, best_width)| {
+                    (removed_components, center_distance, candidate_width)
+                        < (*best_removed_components, *best_distance, *best_width)
+                },
+            ) {
+                best = Some((
+                    start,
+                    end,
+                    removed_components,
+                    center_distance,
+                    candidate_width,
+                ));
+            }
+        }
+
+        best.map(|(start, end, _, _, _)| self.candidate(start, end))
+    }
+
+    fn candidate_width(&self, start: usize, end: usize) -> usize {
+        fn marker_width(removed_components: usize) -> usize {
+            2 + removed_components.ilog10() as usize + 1
+        }
+
+        let removed_components = end - start;
+        let removed_component_width =
+            self.component_width_prefix_sum[end] - self.component_width_prefix_sum[start];
+        let removed_separator_width = self.separator.width().unwrap_or(1)
+            * ((removed_components - 1)
+                + usize::from(start > 0)
+                + usize::from(end < self.components.len()));
+        self.width - removed_component_width - removed_separator_width
+            + marker_width(removed_components)
+    }
+
+    fn candidate(&self, start: usize, end: usize) -> String {
+        fn push_components(out: &mut String, separator: char, components: &[Cow<'_, str>]) {
+            for (idx, component) in components.iter().enumerate() {
+                if idx > 0 {
+                    out.push(separator);
+                }
+                out.push_str(component);
+            }
+        }
+
+        let mut out = String::new();
+        out.push_str(&self.prefix);
+        push_components(&mut out, self.separator, &self.components[..start]);
+        let removed_components = end - start;
+        out.push_str(&format!("[{removed_components}]"));
+        push_components(&mut out, self.separator, &self.components[end..]);
+        out
+    }
 }
 
 fn draw_bottom_right_help(bound: Rect, buf: &mut Buffer) {
@@ -423,68 +647,214 @@ fn show_count_column(sort_mode: &SortMode, show_columns: &HashSet<Column>) -> bo
     ) || show_columns.contains(&Column::Count)
 }
 
-/// Note that this implementation isn't correct as `width` is the amount of blocks to display,
-/// which is not what we are actually counting when adding graphemes to the output string.
+/// Shorten arbitrary text by keeping terminal-cell-budgeted pieces from the start and end.
+///
+/// This is the path-agnostic fallback used when structured compaction via
+/// `compact_path` is not possible. It does not understand separators or path
+/// prefixes; it only inserts an ellipsis between the retained leading and trailing
+/// graphemes.
+///
+/// `width` is the maximum display width in terminal cells, not bytes or characters.
+///
+/// # Examples
+///
+/// - `12345678` at width 7 -> `123…678`
+/// - `12345678` at width 3 -> `1…8`
+/// - `12345678` at width 2 -> `…`
+/// - `你好😁你好` at width 5 -> `你…好`
 fn shorten_input(input: Cow<'_, str>, width: usize) -> Cow<'_, str> {
     const ELLIPSIS: char = '…';
-    const ELLIPSIS_LEN: usize = 1;
     const EXTENDED: bool = true;
 
-    let total_count = input.width();
-    if total_count <= width {
+    if input.width() <= width {
         return input;
     }
 
-    if ELLIPSIS_LEN > width {
+    let ellipsis_width = ELLIPSIS.width().unwrap_or(1);
+    if ellipsis_width > width {
         return Cow::Borrowed("");
     }
+    if width == ellipsis_width {
+        return Cow::Owned(ELLIPSIS.to_string());
+    }
 
-    let graphemes_per_half = (width - ELLIPSIS_LEN) / 2;
+    let retained_width = width - ellipsis_width;
+    if retained_width < 2 {
+        return Cow::Owned(ELLIPSIS.to_string());
+    }
 
-    let mut out = String::with_capacity(width);
-    let mut g = input.graphemes(EXTENDED);
+    let prefix_width = retained_width / 2 + retained_width % 2;
+    let suffix_width = retained_width / 2;
+    let graphemes: Vec<_> = input.graphemes(EXTENDED).collect();
+    let prefix_end = grapheme_boundary_fitting_width(
+        graphemes
+            .iter()
+            .enumerate()
+            .map(|(idx, grapheme)| (idx + 1, *grapheme)),
+        0,
+        prefix_width,
+    );
+    let suffix_start = grapheme_boundary_fitting_width(
+        (prefix_end..graphemes.len())
+            .rev()
+            .map(|idx| (idx, graphemes[idx])),
+        graphemes.len(),
+        suffix_width,
+    );
+    let split_budget_fits_no_graphemes = prefix_end == 0 && suffix_start == graphemes.len();
+    let (prefix_end, suffix_start) = if split_budget_fits_no_graphemes {
+        (
+            grapheme_boundary_fitting_width(
+                graphemes
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, grapheme)| (idx + 1, *grapheme)),
+                0,
+                retained_width,
+            ),
+            graphemes.len(),
+        )
+    } else {
+        (prefix_end, suffix_start)
+    };
 
-    out.extend(g.by_ref().take(graphemes_per_half));
+    let mut out = String::new();
+    out.extend(graphemes[..prefix_end].iter().copied());
     out.push(ELLIPSIS);
-    out.extend(g.skip(total_count - graphemes_per_half * 2));
+    out.extend(graphemes[suffix_start..].iter().copied());
 
     Cow::Owned(out)
+}
+
+fn grapheme_boundary_fitting_width<'a>(
+    graphemes: impl IntoIterator<Item = (usize, &'a str)>,
+    initial_boundary: usize,
+    width: usize,
+) -> usize {
+    let mut used_width = 0;
+    let mut boundary = initial_boundary;
+    for (next_boundary, grapheme) in graphemes {
+        let grapheme_width = grapheme.width();
+        if used_width + grapheme_width > width {
+            break;
+        }
+        used_width += grapheme_width;
+        boundary = next_boundary;
+    }
+    boundary
 }
 
 #[cfg(test)]
 mod entries_test {
     use std::collections::HashSet;
+    use std::path::Path;
 
-    use super::{name_style, shorten_input, show_mtime_column};
+    use super::{name_style, shorten_input, show_mtime_column, title as entry_title};
     use crate::interactive::widgets::Column;
     use crate::interactive::{MTimeSort, SortMode};
+    use dua::ByteFormat;
     use tui::style::{Color, Modifier, Style};
+    use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn test_shorten_string_middle() {
         let numbers = "12345678";
-        let graphemes = "你好😁你好";
-        for (input, target_length, expected) in [
+        let graphemes = "你好😁世界";
+        for (input, target_width, expected) in [
             (numbers, 8, numbers),
             (numbers, 7, "123…678"),
             (numbers, 3, "1…8"),
             (numbers, 2, "…"),
             (numbers, 1, "…"),
             (numbers, 0, ""),
-            // multi-block strings are handled incorrectly, but at least it doesn't crash.
             (graphemes, 0, ""),
             (graphemes, 1, "…"),
             (graphemes, 3, "你…"),
             (graphemes, 4, "你…"),
-            (graphemes, 5, "你好…"),
-            (graphemes, 6, "你好…"),
-            (graphemes, 7, "你好😁…"),
-            (graphemes, 8, "你好😁…"),
-            (graphemes, 9, "你好😁你…"),
-            (graphemes, 10, "你好😁你好"),
+            (graphemes, 5, "你…界"),
+            (graphemes, 6, "你…界"),
+            (graphemes, 7, "你…界"),
+            (graphemes, 8, "你好…界"),
+            (graphemes, 9, "你好…世界"),
+            (graphemes, 10, "你好😁世界"),
         ] {
-            assert_eq!(shorten_input(input.into(), target_length), expected);
+            let actual = shorten_input(input.into(), target_width);
+            assert_eq!(actual, expected);
+            assert!(actual.as_ref().width() <= target_width);
         }
+    }
+
+    #[test]
+    fn title_drops_statistics_before_shortening_path() {
+        let path = "a/b/c";
+        assert_eq!(title(path, path.len() + 2), " a/b/c ");
+    }
+
+    #[test]
+    fn title_shows_stats_if_possible() {
+        assert_eq!(
+            title("项目/资料", 42),
+            " 项目/资料 (4 visible, 43 total, 1.42 GB) "
+        );
+    }
+
+    #[test]
+    fn title_drops_statistics_for_wide_unicode_path() {
+        assert_eq!(title("项目/资料", 41), " 项目/资料 ");
+    }
+
+    #[test]
+    fn title_degrades_path_by_removing_fewest_consecutive_components() {
+        assert_eq!(title("a/b/c/d", 8), " a[2]d ");
+    }
+
+    #[test]
+    fn title_degrades_unicode_path_components_by_display_width() {
+        assert_eq!(title("项目/😀😀😀😀/资料/📦", 12), " 项目[2]📦 ");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn title_preserves_root_dir() {
+        assert_eq!(title("/a/b/c/d", 9), " /a[2]d ");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn title_degrades_backslash_separated_paths() {
+        assert_eq!(title("a\\b\\c\\d", 8), " a[2]d ");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn title_keeps_unix_backslashes_as_component_text() {
+        assert_eq!(title("foo\\bar/baz/qux", 15), " foo\\bar[1]qux ");
+    }
+
+    #[test]
+    fn title_treats_drive_like_text_as_relative_component() {
+        assert_eq!(title("C:\\long/bar/baz/qux", 17), " C:\\long[2]qux ");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn path_degradation_selects_the_shortest_sufficient_run() {
+        assert_eq!(
+            title("short/very-long-component/tiny/end", 19),
+            " short[1]tiny/end "
+        );
+    }
+
+    fn title(path: impl AsRef<Path>, title_width_cells: usize) -> String {
+        let display = crate::interactive::DisplayOptions::new(ByteFormat::Metric);
+        entry_title(
+            path.as_ref(),
+            4,
+            43,
+            display,
+            1_420_000_000,
+            title_width_cells,
+        )
     }
 
     #[test]

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -9,6 +9,7 @@ use crate::interactive::{
 use Constraint::*;
 use FocussedPane::*;
 use std::borrow::Borrow;
+use std::path::PathBuf;
 use tui::buffer::Buffer;
 use tui::{
     layout::{Constraint, Direction, Layout, Rect},
@@ -17,7 +18,7 @@ use tui::{
 };
 
 pub struct MainWindowProps<'a> {
-    pub current_path: String,
+    pub current_path: PathBuf,
     pub entries_traversed: u64,
     pub total_bytes: u128,
     pub start: std::time::Instant,


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

Improve how the top-bar is dealing with small terminal sizes by degrading gracefully. The statistics e.g. "(4 visible, 43 total, 1.42 GB)" should disappear if the current path needs the space. Once it touches the right border, the path itself should degenerate, and remove X consecutive path components from the middle of the path, for instance "a/b/c/d" degenerates to "/a[2]c". Add some smarts about chosing which consecutive components to truncate so that the fewest amounts of consecutiive  components are cut.

## Summary

- Make the entries pane title width-aware so the statistics disappear before the current path is compacted.
- Compact over path components with `[N]`, choosing the shortest consecutive removal window that fits, with a fallback to existing grapheme shortening.
- Preserve Unix, Windows drive, UNC, and verbatim Windows path prefixes correctly, including Unix filenames containing backslashes.

## Validation

- `cargo test entries_test --features tui-crossplatform`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `git diff --check`
- `make check-pre-push` partially passed: formatting, clippy, and the cargo check matrix passed; `cargo test --all` failed in pre-existing fixture-size-sensitive traversal tests unrelated to this change: `it_can_handle_ending_traversal_reaching_top_but_skipping_levels` and `it_can_handle_ending_traversal_without_reaching_the_top`.

## Review

- Codex review for final commit `002e53ef71a8a856396b6fc77c302fe4a3059a2d` reported no actionable correctness issues.
