### PR TITLE
fix: interactive error handling and footer status polish

### DIFF
--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -676,9 +676,7 @@ fn annotation_message(cleanup_count: usize, gitignored_count: usize) -> Option<S
             };
             Some(format!("{gitignored} {label} (I)"))
         }
-        (cleanup, gitignored) => {
-            Some(format!("{cleanup} cleanup, {gitignored} gitignored (X|I)"))
-        }
+        (cleanup, gitignored) => Some(format!("{cleanup} cleanup, {gitignored} gitignored (X|I)")),
     }
 }
 

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -75,9 +75,12 @@ impl CursorDirection {
 }
 
 impl AppState {
-    pub fn open_that(&self, tree_view: &TreeView<'_>) {
+    pub fn open_that(&mut self, tree_view: &TreeView<'_>) {
         if let Some(idx) = self.navigation().selected {
-            open::that(tree_view.path_of(idx)).ok();
+            let path = tree_view.path_of(idx);
+            if let Err(err) = open::that(&path) {
+                self.message = Some(format!("Failed to open {}: {err}", path.display()));
+            }
         }
     }
 
@@ -655,23 +658,28 @@ impl AppState {
 }
 
 fn annotation_message(cleanup_count: usize, gitignored_count: usize) -> Option<String> {
-    let count = cleanup_count + gitignored_count;
-    if count == 0 {
-        return None;
+    match (cleanup_count, gitignored_count) {
+        (0, 0) => None,
+        (cleanup, 0) => {
+            let label = if cleanup == 1 {
+                "cleanup candidate"
+            } else {
+                "cleanup candidates"
+            };
+            Some(format!("{cleanup} {label} (X)"))
+        }
+        (0, gitignored) => {
+            let label = if gitignored == 1 {
+                "gitignored entry"
+            } else {
+                "gitignored entries"
+            };
+            Some(format!("{gitignored} {label} (I)"))
+        }
+        (cleanup, gitignored) => {
+            Some(format!("{cleanup} cleanup, {gitignored} gitignored (X|I)"))
+        }
     }
-
-    let key_hint = match (cleanup_count > 0, gitignored_count > 0) {
-        (true, true) => "X|I",
-        (true, false) => "X",
-        (false, true) => "I",
-        (false, false) => unreachable!("count is non-zero"),
-    };
-    let label = if count == 1 {
-        "cleanup candidate"
-    } else {
-        "cleanup candidates"
-    };
-    Some(format!("{count} {label} ({key_hint})"))
 }
 
 fn io_err_to_usize(err: io::Error) -> usize {

--- a/src/interactive/app/tests/journeys_with_writes.rs
+++ b/src/interactive/app/tests/journeys_with_writes.rs
@@ -172,7 +172,7 @@ $precious.tmp
     );
     assert_eq!(
         app.state.message.as_deref(),
-        Some("6 cleanup candidates (X|I)"),
+        Some("1 cleanup, 5 gitignored (X|I)"),
         "footer message advertises both cleanup and gitignore shortcuts"
     );
     app.process_events(&mut terminal, into_codes("i"))?;
@@ -188,7 +188,7 @@ $precious.tmp
     app.process_events(&mut terminal, into_codes("i"))?;
     assert_eq!(
         app.state.message.as_deref(),
-        Some("6 cleanup candidates (X|I)"),
+        Some("1 cleanup, 5 gitignored (X|I)"),
         "gitignored entry detection can be enabled again"
     );
 

--- a/src/interactive/widgets/footer.rs
+++ b/src/interactive/widgets/footer.rs
@@ -66,11 +66,12 @@ impl Footer {
                     Some(elapsed) => format!("in {:.02}s", elapsed.as_secs_f32()),
                     None => {
                         let elapsed = traversal_start.elapsed();
-                        format!(
-                            "in {:.0}s ({:.0}/s)",
-                            elapsed.as_secs_f32(),
+                        let rate = if elapsed.is_zero() {
+                            0.0
+                        } else {
                             *entries_traversed as f32 / elapsed.as_secs_f32()
-                        )
+                        };
+                        format!("in {:.0}s ({:.0}/s)", elapsed.as_secs_f32(), rate)
                     }
                 }
             ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,17 +177,21 @@ fn main() -> Result<()> {
             io::stderr().flush().ok();
 
             // Exit 'quickly' to avoid having to not have to deal with slightly different types in the other match branches
-            std::process::exit(
-                res.map(|(walk_result, paths)| {
+            let exit_code = match res {
+                Ok((walk_result, paths)) => {
                     if let Some(paths) = paths {
                         for path in paths {
                             println!("{}", path.display())
                         }
                     }
                     walk_result.to_exit_code()
-                })
-                .unwrap_or(0),
-            );
+                }
+                Err(err) => {
+                    eprintln!("{err:#}");
+                    1
+                }
+            };
+            std::process::exit(exit_code);
         }
         Some(Aggregate {
             traversal: subcommand_traversal,


### PR DESCRIPTION
- Non-zero exit + printed error on interactive failure
- Guard footer entries/s when elapsed is 0
- Show open failures in the footer
- Label cleanup vs gitignored counts correctly