### PR TITLE
Add provenance attestations for release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,10 @@ jobs:
     name: build-release
     needs: ["create-release"]
     runs-on: ${{ matrix.os }}
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     env:
       # For some builds, we use cross to test on 32-bit and big-endian
       # systems.
@@ -217,6 +221,11 @@ jobs:
             tar czf "$staging.tar.gz" "$staging"
             echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
           fi
+
+      - name: Attest release archive
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-path: ${{ env.ASSET }}
 
       - name: Upload release archive
         uses: actions/upload-release-asset@v1.0.1

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Release archives include build provenance attestations. After downloading an arc
 was built by this repository with the [GitHub CLI](https://cli.github.com/):
 
 ```sh
-gh attestation verify ./dua-v2.29.0-aarch64-apple-darwin.tar.gz --repo Byron/dua-cli
+gh attestation verify ./dua-v2.39.1-aarch64-apple-darwin.tar.gz --repo Byron/dua-cli
 ```
 
 [releases]: https://github.com/Byron/dua-cli/releases

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ winget install Byron.dua-cli
 
 See the [releases section][releases] for manual installation of a binary, pre-built for many platforms.
 
+Release archives include build provenance attestations. After downloading an archive, verify that it
+was built by this repository with the [GitHub CLI](https://cli.github.com/):
+
+```sh
+gh attestation verify ./dua-v2.29.0-aarch64-apple-darwin.tar.gz --repo Byron/dua-cli
+```
+
 [releases]: https://github.com/Byron/dua-cli/releases
 
 #### Cargo


### PR DESCRIPTION
## Summary

Fixes #324.

- Grant the release build job the OIDC and attestation permissions required by
  GitHub artifact attestations.
- Attest each platform archive before it is uploaded to the release.
- Document how users can verify a downloaded archive with the GitHub CLI.

The action is pinned to the full commit SHA for `actions/attest` v4.2.1.

## Test plan

- Parsed `.github/workflows/release.yml` with Ruby's YAML parser.
- Ran `git diff --check`.

This PR was prepared with AI assistance and validated with the checks above.
