### PR TITLE
Avoid per-entry Windows metadata queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "wild",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ byte-unit = { version = "5.2.5", features = ["u128"] }
 petgraph = "0.8.3"
 itertools = "0.15.0"
 num_cpus = "1.10.0"
-filesize = "0.2.0"
 anyhow = "1.0.31"
 trash = { version = "5.2.0", optional = true, default-features = false, features = [
     "coinit_apartmentthreaded", "chrono"
@@ -68,6 +67,16 @@ toml = "1.1.4"
 serde = { version = "1.0", features = ["derive"] }
 dirs = "6"
 shlex = "2.0.1"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.1", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+] }
+
+[target.'cfg(not(windows))'.dependencies]
+filesize = "0.2.0"
 
 [[bin]]
 name = "dua"

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -8,19 +8,13 @@ use std::time::Duration;
 use std::{io, path::Path};
 
 #[cfg(not(windows))]
-fn size_on_disk(
-    entry: &crate::walk::RootEntry,
-    metadata: &crate::walk::RootMetadata,
-) -> io::Result<u64> {
+fn size_on_disk(entry: &crate::walk::Entry, metadata: &crate::walk::Metadata) -> io::Result<u64> {
     entry.path().size_on_disk_fast(metadata)
 }
 
 #[cfg(windows)]
 #[allow(clippy::unnecessary_wraps)]
-fn size_on_disk(
-    entry: &crate::walk::RootEntry,
-    metadata: &crate::walk::RootMetadata,
-) -> io::Result<u64> {
+fn size_on_disk(entry: &crate::walk::Entry, metadata: &crate::walk::Metadata) -> io::Result<u64> {
     Ok(if entry.file_type.is_dir() {
         0
     } else {
@@ -491,7 +485,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("file");
         std::fs::write(&path, b"content").unwrap();
-        let entry = crate::walk::RootEntry::from_path(&path).unwrap();
+        let entry = crate::walk::Entry::from_path(&path).unwrap();
         let metadata = entry.metadata.as_ref().unwrap();
         let expected = metadata.allocated_size();
         std::fs::remove_file(path).unwrap();
@@ -507,7 +501,7 @@ mod tests {
     fn windows_disk_size_preserves_zero_sized_directories() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("file"), b"content").unwrap();
-        let entry = crate::walk::RootEntry::from_path(dir.path()).unwrap();
+        let entry = crate::walk::Entry::from_path(dir.path()).unwrap();
         let metadata = entry.metadata.as_ref().unwrap();
         assert_eq!(size_on_disk(&entry, metadata).unwrap(), 0);
     }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,10 +1,32 @@
 use crate::{ByteFormat, InodeFilter, Throttle, WalkOptions, WalkResult, WalkRoot, crossdev};
 use anyhow::Result;
+#[cfg(not(windows))]
 use filesize::PathExt;
 use owo_colors::{AnsiColors as Color, OwoColorize};
 use std::path::PathBuf;
 use std::time::Duration;
 use std::{io, path::Path};
+
+#[cfg(not(windows))]
+fn size_on_disk(
+    entry: &crate::walk::RootEntry,
+    metadata: &crate::walk::RootMetadata,
+) -> io::Result<u64> {
+    entry.path().size_on_disk_fast(metadata)
+}
+
+#[cfg(windows)]
+#[allow(clippy::unnecessary_wraps)]
+fn size_on_disk(
+    entry: &crate::walk::RootEntry,
+    metadata: &crate::walk::RootMetadata,
+) -> io::Result<u64> {
+    Ok(if entry.file_type.is_dir() {
+        0
+    } else {
+        metadata.allocated_size()
+    })
+}
 
 const CLEAR_CURRENT_LINE: &str = "\x1b[2K\r";
 
@@ -106,7 +128,7 @@ pub fn aggregate(
                         if walk_options.apparent_size {
                             m.len()
                         } else {
-                            entry.path().size_on_disk_fast(m).unwrap_or_else(|_| {
+                            size_on_disk(&entry, m).unwrap_or_else(|_| {
                                 *num_errors += 1;
                                 0
                             })
@@ -462,5 +484,31 @@ mod tests {
             64,
             "the 64-byte file is still counted until a pattern matches it too"
         );
+    }
+    #[cfg(windows)]
+    #[test]
+    fn windows_disk_size_survives_removing_the_entry_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+        std::fs::write(&path, b"content").unwrap();
+        let entry = crate::walk::RootEntry::from_path(&path).unwrap();
+        let metadata = entry.metadata.as_ref().unwrap();
+        let expected = metadata.allocated_size();
+        std::fs::remove_file(path).unwrap();
+        assert_eq!(
+            size_on_disk(&entry, metadata).unwrap(),
+            expected,
+            "Windows aggregation should use the already-enumerated allocation size"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_disk_size_preserves_zero_sized_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("file"), b"content").unwrap();
+        let entry = crate::walk::RootEntry::from_path(dir.path()).unwrap();
+        let metadata = entry.metadata.as_ref().unwrap();
+        assert_eq!(size_on_disk(&entry, metadata).unwrap(), 0);
     }
 }

--- a/src/crossdev.rs
+++ b/src/crossdev.rs
@@ -15,11 +15,12 @@ pub fn is_same_device(device_id: u64, meta: &std::fs::Metadata) -> bool {
 }
 
 #[cfg(not(unix))]
-pub fn is_same_device(_device_id: u64, _meta: &std::fs::Metadata) -> bool {
+pub fn is_same_device<T>(_device_id: u64, _meta: &T) -> bool {
     true
 }
 
 #[cfg(not(unix))]
+#[allow(clippy::unnecessary_wraps)]
 pub fn init(_path: &Path) -> io::Result<u64> {
     Ok(0)
 }

--- a/src/inodefilter.rs
+++ b/src/inodefilter.rs
@@ -17,7 +17,7 @@ impl InodeFilter {
 
     #[cfg(windows)]
     /// Register file metadata and return `true` if this link should be counted.
-    pub(crate) fn add(&mut self, metadata: &crate::walk::RootMetadata) -> bool {
+    pub(crate) fn add(&mut self, metadata: &crate::walk::Metadata) -> bool {
         metadata
             .hard_link_id()
             .is_none_or(|id| self.inner.insert(id, 0).is_none())

--- a/src/inodefilter.rs
+++ b/src/inodefilter.rs
@@ -17,18 +17,10 @@ impl InodeFilter {
 
     #[cfg(windows)]
     /// Register file metadata and return `true` if this link should be counted.
-    pub(crate) fn add(&mut self, metadata: &std::fs::Metadata) -> bool {
-        use std::os::windows::fs::MetadataExt;
-
-        if let (Some(dev), Some(inode), Some(nlinks)) = (
-            metadata.volume_serial_number(),
-            metadata.file_index(),
-            metadata.number_of_links(),
-        ) {
-            self.add_dev_inode((dev as u64, inode), nlinks as u64)
-        } else {
-            true
-        }
+    pub(crate) fn add(&mut self, metadata: &crate::walk::RootMetadata) -> bool {
+        metadata
+            .hard_link_id()
+            .is_none_or(|id| self.inner.insert(id, 0).is_none())
     }
 
     #[cfg(not(any(unix, windows)))]
@@ -41,6 +33,7 @@ impl InodeFilter {
     ///
     /// Returns `true` for the first observation that should contribute to size/count,
     /// and `false` for subsequent links.
+    #[cfg(any(unix, test))]
     pub(crate) fn add_dev_inode(&mut self, dev_inode: (u64, u64), nlinks: u64) -> bool {
         if nlinks <= 1 {
             return true;

--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -168,7 +168,8 @@ pub fn sorted_entries(
                         (path, true, entry.is_dir)
                     } else {
                         let meta = path.symlink_metadata();
-                        (path, meta.is_ok(), meta.ok().is_some_and(|m| m.is_dir()))
+                        let exists = meta.is_ok();
+                        (path, exists, meta.is_ok_and(|m| m.is_dir()))
                     }
                 };
                 EntryDataBundle {

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -693,7 +693,8 @@ fn delete_directory_recursively(path: PathBuf, threads: usize) -> EntryDeletionS
         match entry {
             Ok(entry) => {
                 let entry_path = entry.path();
-                let bytes = u128::from(entry.metadata.as_ref().map_or(0, std::fs::Metadata::len));
+                let bytes =
+                    u128::from(entry.metadata.as_ref().map_or(0, |metadata| metadata.len()));
                 if entry.file_type.is_dir() {
                     // Real directory (symlinks to dirs report is_symlink, not
                     // is_dir, when follow_links is false): remove after children.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 //! Public library API for `dua` core traversal and aggregation functionality.
 //!
 //! This crate powers the `dua` binary and can also be used as a library.
-#![cfg_attr(windows, feature(windows_by_handle))]
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 #![deny(missing_docs)]
 
 mod aggregate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ mod crossdev;
 mod inodefilter;
 mod walk;
 pub use walk::{Entry as WalkEntry, Order as WalkOrder, Walk, walk};
+#[cfg(windows)]
+pub use walk::{FileType as WalkFileType, Metadata as WalkMetadata};
 
 /// Filesystem traversal, in-memory tree representation, and traversal events.
 pub mod traverse;

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -1,14 +1,13 @@
 use crate::{Throttle, WalkOptions, WalkRoot, crossdev, inodefilter::InodeFilter};
 
 use crossbeam::channel::Receiver;
+#[cfg(not(windows))]
 use filesize::PathExt;
 use petgraph::{Directed, Direction, graph::NodeIndex, stable_graph::StableGraph};
 use std::time::Instant;
 use std::{
     collections::HashMap,
-    fmt,
-    fs::Metadata,
-    io,
+    fmt, io,
     path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -130,7 +129,7 @@ impl Default for TraversalStats {
 }
 
 /// A filesystem entry waiting to be integrated into a traversal.
-pub struct TraversalEntry(crate::walk::Entry);
+pub struct TraversalEntry(crate::walk::RootEntry);
 
 /// Events emitted by a background filesystem traversal.
 pub enum TraversalEvent {
@@ -302,14 +301,20 @@ impl BackgroundTraversal {
                                 if self.walk_options.apparent_size {
                                     file_size = u128::from(m.len());
                                 } else {
-                                    file_size = u128::from(
-                                        size_on_disk(&entry.parent_path, &data.name, m)
+                                    file_size =
+                                        u128::from(
+                                            size_on_disk(
+                                                &entry.parent_path,
+                                                &data.name,
+                                                m,
+                                                data.is_dir,
+                                            )
                                             .unwrap_or_else(|_| {
                                                 self.stats.io_errors += 1;
                                                 data.metadata_io_error = true;
                                                 0
                                             }),
-                                    );
+                                        );
                                 }
                             } else {
                                 data.entry_count = Some(0);
@@ -387,14 +392,25 @@ impl BackgroundTraversal {
 
 #[cfg(not(windows))]
 /// Return disk usage for `name` on Unix-like platforms.
-fn size_on_disk(_parent: &Path, name: &Path, meta: &Metadata) -> io::Result<u64> {
+fn size_on_disk(
+    _parent: &Path,
+    name: &Path,
+    meta: &crate::walk::RootMetadata,
+    _is_dir: bool,
+) -> io::Result<u64> {
     name.size_on_disk_fast(meta)
 }
 
 #[cfg(windows)]
 /// Return disk usage for `name` on Windows platforms.
-fn size_on_disk(parent: &Path, name: &Path, meta: &Metadata) -> io::Result<u64> {
-    parent.join(name).size_on_disk_fast(meta)
+#[allow(clippy::unnecessary_wraps)]
+fn size_on_disk(
+    _parent: &Path,
+    _name: &Path,
+    meta: &crate::walk::RootMetadata,
+    is_dir: bool,
+) -> io::Result<u64> {
+    Ok(if is_dir { 0 } else { meta.allocated_size() })
 }
 
 #[cfg(test)]

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -129,7 +129,7 @@ impl Default for TraversalStats {
 }
 
 /// A filesystem entry waiting to be integrated into a traversal.
-pub struct TraversalEntry(crate::walk::RootEntry);
+pub struct TraversalEntry(crate::walk::Entry);
 
 /// Events emitted by a background filesystem traversal.
 pub enum TraversalEvent {
@@ -395,7 +395,7 @@ impl BackgroundTraversal {
 fn size_on_disk(
     _parent: &Path,
     name: &Path,
-    meta: &crate::walk::RootMetadata,
+    meta: &crate::walk::Metadata,
     _is_dir: bool,
 ) -> io::Result<u64> {
     name.size_on_disk_fast(meta)
@@ -407,7 +407,7 @@ fn size_on_disk(
 fn size_on_disk(
     _parent: &Path,
     _name: &Path,
-    meta: &crate::walk::RootMetadata,
+    meta: &crate::walk::Metadata,
     is_dir: bool,
 ) -> io::Result<u64> {
     Ok(if is_dir { 0 } else { meta.allocated_size() })

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -38,13 +38,24 @@ use std::{
     thread,
 };
 
+#[cfg(windows)]
+#[allow(unsafe_code)]
+mod windows;
+
+#[cfg(windows)]
+pub(crate) use windows::{Entry as RootEntry, Metadata as RootMetadata};
+#[cfg(not(windows))]
+pub(crate) type RootEntry = Entry;
+#[cfg(not(windows))]
+pub(crate) type RootMetadata = Metadata;
+
 /// Decides whether to traverse an entry's children for a given root index.
 /// Returning `false` prunes descendants but still emits the entry itself.
-type Descend = dyn Fn(usize, &Entry) -> bool + Send + Sync;
+type Descend<E> = dyn Fn(usize, &E) -> bool + Send + Sync;
 /// Entries obtained from one directory read.
 /// The outer error means `fs::read_dir` could not open the directory; inner errors come from
 /// reading or converting individual directory entries.
-type Batch = io::Result<Vec<io::Result<Entry>>>;
+type Batch<E> = io::Result<Vec<io::Result<E>>>;
 /// Number of directory entries grouped into each metadata job or result batch.
 /// Small chunks expose parallel work and stream wide directories while amortizing queue overhead.
 const ENTRY_CHUNK_SIZE: usize = 4;
@@ -104,10 +115,10 @@ impl Job {
 }
 
 /// Internal worker-channel events, including batches, per-root completion, and pool completion.
-enum Event {
+enum Event<E> {
     Batch {
         root_idx: usize,
-        batch: Batch,
+        batch: Batch<E>,
     },
     /// All work for this root is complete; emitted after all of its batches.
     /// Completion events for different roots may occur in any order.
@@ -124,17 +135,18 @@ enum Event {
 /// [`RootWalk`] yields `(root_idx, event)`, separating root routing from event meaning. [`Event`]
 /// cannot do this uniformly because its `Finished` variant is pool-wide and has no root index.
 pub(crate) enum RootEvent {
-    Entry(io::Result<Entry>),
+    Entry(io::Result<RootEntry>),
     Finished,
 }
 
-struct PoolShared {
+struct PoolShared<E> {
     /// Global queue that makes the initial root job available to whichever worker starts first.
     injector: Injector<Job>,
     stealers: Vec<Stealer<Job>>,
     stop: AtomicBool,
-    descend: Arc<Descend>,
-    events: SyncSender<Event>,
+    descend: Arc<Descend<E>>,
+    events: SyncSender<Event<E>>,
+    readers: Readers<E>,
     /// Number of roots with queued or running jobs.
     active_roots: AtomicUsize,
     /// Number of queued or running jobs for each root index.
@@ -150,9 +162,9 @@ struct PoolShared {
     next_wake: AtomicUsize,
 }
 
-struct Pool {
-    shared: Arc<PoolShared>,
-    events: Receiver<Event>,
+struct Pool<E> {
+    shared: Arc<PoolShared<E>>,
+    events: Receiver<Event<E>>,
     handles: Vec<thread::JoinHandle<()>>,
 }
 
@@ -162,7 +174,7 @@ pub(crate) struct RootWalk {
     /// Entries buffered for delivery, by root index.
     next: Vec<(usize, RootEvent)>,
     /// See [`Walk::pool`].
-    pool: Option<Pool>,
+    pool: Option<Pool<RootEntry>>,
 }
 
 /// A single-root directory iterator whose directory reads happen in parallel.
@@ -178,7 +190,17 @@ pub struct Walk {
     /// Owns the worker threads for as long as traversal is active.
     ///
     /// Clearing or dropping it requests shutdown, unparks every worker, and joins their threads.
-    pool: Option<Pool>,
+    pool: Option<Pool<Entry>>,
+}
+
+trait PoolEntry: Send + Sized + 'static {}
+
+#[derive(Clone, Copy)]
+struct Readers<E> {
+    completion: fn(usize, Arc<Path>, usize, &Worker<Job>, &PoolShared<E>),
+    parent_first: fn(usize, Arc<Path>, usize, &Worker<Job>, &PoolShared<E>),
+    #[cfg(not(windows))]
+    stat_completion: fn(usize, Arc<Path>, usize, Vec<fs::DirEntry>, &Worker<Job>, &PoolShared<E>),
 }
 
 /// Walk `root` without following symlinks.
@@ -199,6 +221,7 @@ pub fn walk(
                 1,
                 order,
                 Arc::new(move |_, entry| descend(entry)),
+                standard_readers(),
             );
             start_jobs(
                 &pool,
@@ -253,7 +276,7 @@ pub(crate) fn walk_roots(
     roots: impl IntoIterator<Item = (usize, PathBuf)>,
     threads: usize,
     order: Order,
-    descend: impl Fn(usize, &Entry) -> bool + Send + Sync + 'static,
+    descend: impl Fn(usize, &RootEntry) -> bool + Send + Sync + 'static,
 ) -> RootWalk {
     let roots = roots.into_iter().collect::<Vec<_>>();
     let root_count = roots
@@ -267,7 +290,7 @@ pub(crate) fn walk_roots(
     let pool = if root_jobs.is_empty() {
         None
     } else {
-        let pool = start_pool(threads.max(1), root_count, order, descend);
+        let pool = start_pool(threads.max(1), root_count, order, descend, root_readers());
         start_jobs(&pool, root_jobs);
         Some(pool)
     };
@@ -314,7 +337,7 @@ impl Iterator for RootWalk {
     }
 }
 
-impl PoolShared {
+impl<E> PoolShared<E> {
     /// Wake one worker that has announced it is idle.
     fn wake_worker(&self) {
         let len = self.idle.len();
@@ -374,7 +397,43 @@ impl Entry {
     }
 }
 
-fn start_pool(threads: usize, root_count: usize, order: Order, descend: Arc<Descend>) -> Pool {
+impl PoolEntry for Entry {}
+
+#[cfg(windows)]
+impl PoolEntry for RootEntry {}
+
+fn standard_readers() -> Readers<Entry> {
+    Readers {
+        #[cfg(windows)]
+        completion: read_dir_completion_inline,
+        #[cfg(not(windows))]
+        completion: read_dir_completion,
+        parent_first: read_dir_parent_first,
+        #[cfg(not(windows))]
+        stat_completion: stat_entries_completion,
+    }
+}
+
+#[cfg(not(windows))]
+fn root_readers() -> Readers<RootEntry> {
+    standard_readers()
+}
+
+#[cfg(windows)]
+fn root_readers() -> Readers<RootEntry> {
+    Readers {
+        completion: read_dir_windows_completion,
+        parent_first: read_dir_windows_parent_first,
+    }
+}
+
+fn start_pool<E: PoolEntry>(
+    threads: usize,
+    root_count: usize,
+    order: Order,
+    descend: Arc<Descend<E>>,
+    readers: Readers<E>,
+) -> Pool<E> {
     let workers: Vec<_> = (0..threads).map(|_| Worker::new_lifo()).collect();
     let parkers: Vec<_> = (0..threads).map(|_| Parker::new()).collect();
     let (event_tx, event_rx) = sync_channel(threads * 2);
@@ -384,6 +443,7 @@ fn start_pool(threads: usize, root_count: usize, order: Order, descend: Arc<Desc
         stop: AtomicBool::new(false),
         descend,
         events: event_tx,
+        readers,
         active_roots: AtomicUsize::new(0),
         jobs_per_root: (0..root_count).map(|_| AtomicUsize::new(0)).collect(),
         order,
@@ -418,12 +478,12 @@ fn start_pool(threads: usize, root_count: usize, order: Order, descend: Arc<Desc
 /// Returns events in stack order for [`RootWalk::next`] to pop, plus jobs requiring a worker pool.
 fn begin_walks(
     roots: impl IntoIterator<Item = (usize, PathBuf)>,
-    descend: &Descend,
+    descend: &Descend<RootEntry>,
 ) -> (Vec<(usize, RootEvent)>, Vec<Job>) {
     let mut next = Vec::new();
     let mut jobs = Vec::new();
     for (root_idx, path) in roots {
-        let entry = Entry::from_path(&path);
+        let entry = RootEntry::from_path(&path);
         let has_job = if let Ok(entry) = &entry
             && entry.file_type.is_dir()
             && descend(root_idx, entry)
@@ -448,7 +508,7 @@ fn begin_walks(
 
 /// Seed an idle pool with one initial job per active root.
 /// Initializes per-root completion accounting, queues the jobs, and wakes workers to process them.
-fn start_jobs(pool: &Pool, root_jobs: Vec<Job>) {
+fn start_jobs<E>(pool: &Pool<E>, root_jobs: Vec<Job>) {
     let wake_all = root_jobs.len() > 1;
     debug_assert_eq!(
         pool.shared.active_roots.load(AtomicOrdering::Relaxed),
@@ -479,7 +539,12 @@ fn start_jobs(pool: &Pool, root_jobs: Vec<Job>) {
     }
 }
 
-fn worker_loop(idx: usize, worker: Worker<Job>, parker: Parker, shared: Arc<PoolShared>) {
+fn worker_loop<E: PoolEntry>(
+    idx: usize,
+    worker: Worker<Job>,
+    parker: Parker,
+    shared: Arc<PoolShared<E>>,
+) {
     while !shared.stop.load(AtomicOrdering::Relaxed) {
         let found = if let Some(found) = find_job(&worker, &shared) {
             found
@@ -503,7 +568,7 @@ fn worker_loop(idx: usize, worker: Worker<Job>, parker: Parker, shared: Arc<Pool
     }
 }
 
-impl Drop for Pool {
+impl<E> Drop for Pool<E> {
     fn drop(&mut self) {
         self.shared.stop.store(true, AtomicOrdering::Relaxed);
         self.shared.wake_workers();
@@ -523,7 +588,7 @@ impl Drop for Pool {
 ///
 /// Returns the selected job and whether it was stolen from another worker; the caller uses a
 /// successful steal to wake another idle worker. Returns `None` when a full scan finds no work.
-fn find_job(worker: &Worker<Job>, shared: &PoolShared) -> Option<(Job, bool)> {
+fn find_job<E>(worker: &Worker<Job>, shared: &PoolShared<E>) -> Option<(Job, bool)> {
     loop {
         if let Some(job) = worker.pop() {
             return Some((job, false));
@@ -549,18 +614,19 @@ fn find_job(worker: &Worker<Job>, shared: &PoolShared) -> Option<(Job, bool)> {
     }
 }
 
-fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
+fn run_job<E: PoolEntry>(job: Job, worker: &Worker<Job>, shared: &PoolShared<E>) {
     match job {
         Job::ReadDir {
             root_idx: root,
             path,
             entry_depth,
         } => {
-            if matches!(shared.order, Order::Completion) {
-                read_dir_completion(root, path, entry_depth, worker, shared);
+            let reader = if matches!(shared.order, Order::Completion) {
+                shared.readers.completion
             } else {
-                read_dir_parent_first(root, path, entry_depth, worker, shared);
-            }
+                shared.readers.parent_first
+            };
+            reader(root, path, entry_depth, worker, shared);
         }
         #[cfg(not(windows))]
         Job::StatCompletion {
@@ -568,7 +634,7 @@ fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
             path,
             entry_depth,
             entries,
-        } => stat_entries_completion(root, path, entry_depth, entries, worker, shared),
+        } => (shared.readers.stat_completion)(root, path, entry_depth, entries, worker, shared),
     }
 }
 
@@ -577,90 +643,80 @@ fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
 /// are emitted directly; the directory-read job completes after all chunks are queued.
 /// This adds parallelism within wide directories when metadata calls dominate. Both traversal
 /// orders already process separate directories concurrently, so typical trees may see no speedup.
+#[cfg(not(windows))]
 fn read_dir_completion(
     root_idx: usize,
     path: Arc<Path>,
     entry_depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<Entry>,
 ) {
-    #[cfg(windows)]
-    {
-        // `DirEntry::metadata()` is populated by Windows directory enumeration and needs no
-        // additional syscall. Convert entries on this worker instead of paying to queue and steal
-        // metadata jobs, but keep publishing bounded batches so wide directories stream results.
-        read_dir_completion_inline(root_idx, path, entry_depth, worker, shared);
-    }
-
-    #[cfg(not(windows))]
-    {
-        let dir_entries = match fs::read_dir(&path) {
-            Ok(entries) => entries,
-            Err(err) => {
-                if shared
-                    .events
-                    .send(Event::Batch {
-                        root_idx,
-                        batch: Err(err),
-                    })
-                    .is_err()
-                {
-                    shared.stop.store(true, AtomicOrdering::Relaxed);
-                }
-                finish_pending(root_idx, shared);
-                return;
-            }
-        };
-        let mut chunk = Vec::with_capacity(ENTRY_CHUNK_SIZE);
-        let mut errors = Vec::new();
-        let mut has_jobs = false;
-        for entry in dir_entries {
-            match entry {
-                Ok(entry) => {
-                    chunk.push(entry);
-                    if chunk.len() == ENTRY_CHUNK_SIZE {
-                        add_pending(root_idx, 1, shared);
-                        worker.push(Job::StatCompletion {
-                            root_idx,
-                            path: Arc::clone(&path),
-                            entry_depth,
-                            entries: std::mem::replace(
-                                &mut chunk,
-                                Vec::with_capacity(ENTRY_CHUNK_SIZE),
-                            ),
-                        });
-                        has_jobs = true;
-                    }
-                }
-                Err(err) => errors.push(Err(err)),
-            }
-        }
-        if !chunk.is_empty() {
-            add_pending(root_idx, 1, shared);
-            worker.push(Job::StatCompletion {
-                root_idx,
-                path,
-                entry_depth,
-                entries: chunk,
-            });
-            has_jobs = true;
-        }
-        if has_jobs {
-            shared.wake_worker();
-        }
-        if !errors.is_empty()
-            && shared
+    let dir_entries = match fs::read_dir(&path) {
+        Ok(entries) => entries,
+        Err(err) => {
+            if shared
                 .events
                 .send(Event::Batch {
                     root_idx,
-                    batch: Ok(errors),
+                    batch: Err(err),
                 })
                 .is_err()
-        {
-            shared.stop.store(true, AtomicOrdering::Relaxed);
+            {
+                shared.stop.store(true, AtomicOrdering::Relaxed);
+            }
+            finish_pending(root_idx, shared);
+            return;
         }
-        finish_pending(root_idx, shared);
+    };
+    let mut chunk = Vec::with_capacity(ENTRY_CHUNK_SIZE);
+    let mut errors = Vec::new();
+    let mut has_jobs = false;
+    for entry in dir_entries {
+        match entry {
+            Ok(entry) => {
+                chunk.push(entry);
+                if chunk.len() == ENTRY_CHUNK_SIZE {
+                    add_pending(root_idx, 1, shared);
+                    worker.push(Job::StatCompletion {
+                        root_idx,
+                        path: Arc::clone(&path),
+                        entry_depth,
+                        entries: std::mem::replace(
+                            &mut chunk,
+                            Vec::with_capacity(ENTRY_CHUNK_SIZE),
+                        ),
+                    });
+                    has_jobs = true;
+                }
+            }
+            Err(err) => errors.push(Err(err)),
+        }
     }
+    if !chunk.is_empty() {
+        add_pending(root_idx, 1, shared);
+        worker.push(Job::StatCompletion {
+            root_idx,
+            path,
+            entry_depth,
+            entries: chunk,
+        });
+        has_jobs = true;
+    }
+    if has_jobs {
+        shared.wake_worker();
+    }
+    if !errors.is_empty()
+        && shared
+            .events
+            .send(Event::Batch {
+                root_idx,
+                batch: Ok(errors),
+            })
+            .is_err()
+    {
+        shared.stop.store(true, AtomicOrdering::Relaxed);
+    }
+    finish_pending(root_idx, shared);
 }
 
 #[cfg(windows)]
@@ -669,7 +725,7 @@ fn read_dir_completion_inline(
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<Entry>,
 ) {
     let dir_entries = match fs::read_dir(&path) {
         Ok(entries) => entries,
@@ -722,7 +778,7 @@ fn publish_completion_batch(
     entries: &mut Vec<io::Result<Entry>>,
     jobs: &mut Vec<Job>,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<Entry>,
 ) -> bool {
     add_pending(root_idx, jobs.len(), shared);
     schedule_jobs(std::mem::take(jobs), worker, shared);
@@ -744,6 +800,118 @@ fn publish_completion_batch(
     }
 }
 
+#[cfg(windows)]
+fn read_dir_windows_completion(
+    root_idx: usize,
+    path: Arc<Path>,
+    depth: usize,
+    worker: &Worker<Job>,
+    shared: &PoolShared<RootEntry>,
+) {
+    let dir_entries = match windows::ReadDir::open(path, depth) {
+        Ok(entries) => entries,
+        Err(err) => {
+            if shared
+                .events
+                .send(Event::Batch {
+                    root_idx,
+                    batch: Err(err),
+                })
+                .is_err()
+            {
+                shared.stop.store(true, AtomicOrdering::Relaxed);
+            }
+            finish_pending(root_idx, shared);
+            return;
+        }
+    };
+    let mut entries = Vec::with_capacity(ENTRY_CHUNK_SIZE);
+    let mut jobs = Vec::new();
+    for entry in dir_entries {
+        if let Ok(entry) = &entry
+            && entry.file_type.is_dir()
+            && (shared.descend)(root_idx, entry)
+        {
+            jobs.push(Job::ReadDir {
+                root_idx,
+                path: Arc::from(entry.path()),
+                entry_depth: depth + 1,
+            });
+        }
+        entries.push(entry);
+        if entries.len() == ENTRY_CHUNK_SIZE
+            && !publish_windows_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared)
+        {
+            finish_pending(root_idx, shared);
+            return;
+        }
+    }
+    if !entries.is_empty() {
+        publish_windows_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared);
+    }
+    finish_pending(root_idx, shared);
+}
+
+#[cfg(windows)]
+fn publish_windows_completion_batch(
+    root_idx: usize,
+    entries: &mut Vec<io::Result<RootEntry>>,
+    jobs: &mut Vec<Job>,
+    worker: &Worker<Job>,
+    shared: &PoolShared<RootEntry>,
+) -> bool {
+    add_pending(root_idx, jobs.len(), shared);
+    schedule_jobs(std::mem::take(jobs), worker, shared);
+    if shared
+        .events
+        .send(Event::Batch {
+            root_idx,
+            batch: Ok(std::mem::replace(
+                entries,
+                Vec::with_capacity(ENTRY_CHUNK_SIZE),
+            )),
+        })
+        .is_err()
+    {
+        shared.stop.store(true, AtomicOrdering::Relaxed);
+        false
+    } else {
+        true
+    }
+}
+
+#[cfg(windows)]
+fn read_dir_windows_parent_first(
+    root_idx: usize,
+    path: Arc<Path>,
+    depth: usize,
+    worker: &Worker<Job>,
+    shared: &PoolShared<RootEntry>,
+) {
+    let dir_entries = match windows::ReadDir::open(path, depth) {
+        Ok(entries) => entries,
+        Err(err) => {
+            finish_directory(root_idx, Err(err), Vec::new(), worker, shared);
+            return;
+        }
+    };
+    let mut jobs = Vec::new();
+    let entries = dir_entries
+        .map(|entry| {
+            entry.inspect(|entry| {
+                if entry.file_type.is_dir() && (shared.descend)(root_idx, entry) {
+                    jobs.push(Job::ReadDir {
+                        root_idx,
+                        path: Arc::from(entry.path()),
+                        entry_depth: depth + 1,
+                    });
+                }
+            })
+        })
+        .collect();
+    finish_directory(root_idx, Ok(entries), jobs, worker, shared);
+}
+
 #[cfg(not(windows))]
 fn stat_entries_completion(
     root_idx: usize,
@@ -751,7 +919,7 @@ fn stat_entries_completion(
     depth: usize,
     entries: Vec<fs::DirEntry>,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<Entry>,
 ) {
     let mut jobs = Vec::new();
     let entries = entries
@@ -795,7 +963,7 @@ fn read_dir_parent_first(
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<Entry>,
 ) {
     read_dir_inline(root_idx, path, depth, worker, shared);
 }
@@ -809,7 +977,7 @@ fn read_dir_inline(
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<Entry>,
 ) {
     let dir_entries = match fs::read_dir(&path) {
         Ok(entries) => entries,
@@ -840,12 +1008,12 @@ fn read_dir_inline(
 /// Publish a completed directory read and schedule its accepted child-directory jobs.
 /// `ParentFirst` sends the batch before exposing child jobs; `Completion` exposes child jobs first.
 /// Child jobs are counted before either action, and the current job is marked complete afterward.
-fn finish_directory(
+fn finish_directory<E>(
     root_idx: usize,
-    batch: Batch,
+    batch: Batch<E>,
     jobs: Vec<Job>,
     worker: &Worker<Job>,
-    shared: &PoolShared,
+    shared: &PoolShared<E>,
 ) {
     add_pending(root_idx, jobs.len(), shared);
 
@@ -877,13 +1045,13 @@ fn finish_directory(
     finish_pending(root_idx, shared);
 }
 
-fn add_pending(root: usize, count: usize, shared: &PoolShared) {
+fn add_pending<E>(root: usize, count: usize, shared: &PoolShared<E>) {
     shared.jobs_per_root[root].fetch_add(count, AtomicOrdering::Relaxed);
 }
 
 /// Mark one job complete for `root`.
 /// The last job emits `RootFinished`; if this was also the last active root, `Finished` follows.
-fn finish_pending(root_idx: usize, shared: &PoolShared) {
+fn finish_pending<E>(root_idx: usize, shared: &PoolShared<E>) {
     if shared.jobs_per_root[root_idx].fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
         shared.events.send(Event::RootFinished { root_idx }).ok();
         if shared.active_roots.fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
@@ -892,7 +1060,7 @@ fn finish_pending(root_idx: usize, shared: &PoolShared) {
     }
 }
 
-fn schedule_jobs(jobs: Vec<Job>, worker: &Worker<Job>, shared: &PoolShared) {
+fn schedule_jobs<E>(jobs: Vec<Job>, worker: &Worker<Job>, shared: &PoolShared<E>) {
     let has_jobs = !jobs.is_empty();
     for job in jobs {
         worker.push(job);

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -668,6 +668,11 @@ fn read_dir_completion(
     finish_pending(root_idx, shared);
 }
 
+/// Read a directory for completion-order traversal.
+///
+/// Unlike the non-Windows implementation, `windows::ReadDir` collects metadata while enumerating,
+/// so complete entries are published directly in chunks instead of being split into stealable
+/// metadata jobs. This streams wide directories but keeps their metadata work on one worker.
 #[cfg(windows)]
 fn read_dir_completion(
     root_idx: usize,
@@ -1147,10 +1152,22 @@ mod tests {
             true
         });
 
-        assert_eq!(entries.next().unwrap().unwrap().depth, 0);
-        assert_eq!(entries.next().unwrap().unwrap().depth, 1);
+        assert_eq!(
+            entries.next().unwrap().unwrap().depth,
+            0,
+            "the root entry should be yielded first"
+        );
+        assert_eq!(
+            entries.next().unwrap().unwrap().depth,
+            1,
+            "the first metadata batch should be yielded before enumeration resumes"
+        );
         continue_tx.send(()).unwrap();
         entries.for_each(drop);
-        assert_eq!(seen.load(AtomicOrdering::Relaxed), ENTRY_CHUNK_SIZE + 1);
+        assert_eq!(
+            seen.load(AtomicOrdering::Relaxed),
+            ENTRY_CHUNK_SIZE + 1,
+            "all directory entries should be inspected"
+        );
     }
 }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -195,12 +195,15 @@ pub struct Walk {
 
 trait PoolEntry: Send + Sized + 'static {}
 
+#[cfg(not(windows))]
+type StatReader<E> = fn(usize, Arc<Path>, usize, Vec<fs::DirEntry>, &Worker<Job>, &PoolShared<E>);
+
 #[derive(Clone, Copy)]
 struct Readers<E> {
     completion: fn(usize, Arc<Path>, usize, &Worker<Job>, &PoolShared<E>),
     parent_first: fn(usize, Arc<Path>, usize, &Worker<Job>, &PoolShared<E>),
     #[cfg(not(windows))]
-    stat_completion: fn(usize, Arc<Path>, usize, Vec<fs::DirEntry>, &Worker<Job>, &PoolShared<E>),
+    stat_completion: StatReader<E>,
 }
 
 /// Walk `root` without following symlinks.

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -26,8 +26,6 @@ use crossbeam::{
     sync::{Parker, Unparker},
 };
 use std::{
-    ffi::OsString,
-    fs::{self, FileType, Metadata},
     io,
     path::{Path, PathBuf},
     sync::{
@@ -38,24 +36,28 @@ use std::{
     thread,
 };
 
+#[cfg(any(not(windows), test))]
+use std::{ffi::OsString, fs};
+
+#[cfg(not(windows))]
+use std::fs::FileType;
+#[cfg(not(windows))]
+pub(crate) use std::fs::Metadata;
+
 #[cfg(windows)]
 #[allow(unsafe_code)]
 mod windows;
 
 #[cfg(windows)]
-pub(crate) use windows::{Entry as RootEntry, Metadata as RootMetadata};
-#[cfg(not(windows))]
-pub(crate) type RootEntry = Entry;
-#[cfg(not(windows))]
-pub(crate) type RootMetadata = Metadata;
+pub use windows::{Entry, FileType, Metadata};
 
 /// Decides whether to traverse an entry's children for a given root index.
 /// Returning `false` prunes descendants but still emits the entry itself.
-type Descend<E> = dyn Fn(usize, &E) -> bool + Send + Sync;
+type Descend = dyn Fn(usize, &Entry) -> bool + Send + Sync;
 /// Entries obtained from one directory read.
 /// The outer error means `fs::read_dir` could not open the directory; inner errors come from
 /// reading or converting individual directory entries.
-type Batch<E> = io::Result<Vec<io::Result<E>>>;
+type Batch = io::Result<Vec<io::Result<Entry>>>;
 /// Number of directory entries grouped into each metadata job or result batch.
 /// Small chunks expose parallel work and stream wide directories while amortizing queue overhead.
 const ENTRY_CHUNK_SIZE: usize = 4;
@@ -70,6 +72,7 @@ pub enum Order {
 }
 
 /// A filesystem entry produced by [`walk`].
+#[cfg(not(windows))]
 pub struct Entry {
     /// Distance from the walk root: `0` for the root, `1` for its children, and so on.
     pub depth: usize,
@@ -115,10 +118,10 @@ impl Job {
 }
 
 /// Internal worker-channel events, including batches, per-root completion, and pool completion.
-enum Event<E> {
+enum Event {
     Batch {
         root_idx: usize,
-        batch: Batch<E>,
+        batch: Batch,
     },
     /// All work for this root is complete; emitted after all of its batches.
     /// Completion events for different roots may occur in any order.
@@ -135,18 +138,17 @@ enum Event<E> {
 /// [`RootWalk`] yields `(root_idx, event)`, separating root routing from event meaning. [`Event`]
 /// cannot do this uniformly because its `Finished` variant is pool-wide and has no root index.
 pub(crate) enum RootEvent {
-    Entry(io::Result<RootEntry>),
+    Entry(io::Result<Entry>),
     Finished,
 }
 
-struct PoolShared<E> {
+struct PoolShared {
     /// Global queue that makes the initial root job available to whichever worker starts first.
     injector: Injector<Job>,
     stealers: Vec<Stealer<Job>>,
     stop: AtomicBool,
-    descend: Arc<Descend<E>>,
-    events: SyncSender<Event<E>>,
-    readers: Readers<E>,
+    descend: Arc<Descend>,
+    events: SyncSender<Event>,
     /// Number of roots with queued or running jobs.
     active_roots: AtomicUsize,
     /// Number of queued or running jobs for each root index.
@@ -162,9 +164,9 @@ struct PoolShared<E> {
     next_wake: AtomicUsize,
 }
 
-struct Pool<E> {
-    shared: Arc<PoolShared<E>>,
-    events: Receiver<Event<E>>,
+struct Pool {
+    shared: Arc<PoolShared>,
+    events: Receiver<Event>,
     handles: Vec<thread::JoinHandle<()>>,
 }
 
@@ -174,7 +176,7 @@ pub(crate) struct RootWalk {
     /// Entries buffered for delivery, by root index.
     next: Vec<(usize, RootEvent)>,
     /// See [`Walk::pool`].
-    pool: Option<Pool<RootEntry>>,
+    pool: Option<Pool>,
 }
 
 /// A single-root directory iterator whose directory reads happen in parallel.
@@ -190,20 +192,7 @@ pub struct Walk {
     /// Owns the worker threads for as long as traversal is active.
     ///
     /// Clearing or dropping it requests shutdown, unparks every worker, and joins their threads.
-    pool: Option<Pool<Entry>>,
-}
-
-trait PoolEntry: Send + Sized + 'static {}
-
-#[cfg(not(windows))]
-type StatReader<E> = fn(usize, Arc<Path>, usize, Vec<fs::DirEntry>, &Worker<Job>, &PoolShared<E>);
-
-#[derive(Clone, Copy)]
-struct Readers<E> {
-    completion: fn(usize, Arc<Path>, usize, &Worker<Job>, &PoolShared<E>),
-    parent_first: fn(usize, Arc<Path>, usize, &Worker<Job>, &PoolShared<E>),
-    #[cfg(not(windows))]
-    stat_completion: StatReader<E>,
+    pool: Option<Pool>,
 }
 
 /// Walk `root` without following symlinks.
@@ -224,7 +213,6 @@ pub fn walk(
                 1,
                 order,
                 Arc::new(move |_, entry| descend(entry)),
-                standard_readers(),
             );
             start_jobs(
                 &pool,
@@ -279,7 +267,7 @@ pub(crate) fn walk_roots(
     roots: impl IntoIterator<Item = (usize, PathBuf)>,
     threads: usize,
     order: Order,
-    descend: impl Fn(usize, &RootEntry) -> bool + Send + Sync + 'static,
+    descend: impl Fn(usize, &Entry) -> bool + Send + Sync + 'static,
 ) -> RootWalk {
     let roots = roots.into_iter().collect::<Vec<_>>();
     let root_count = roots
@@ -293,7 +281,7 @@ pub(crate) fn walk_roots(
     let pool = if root_jobs.is_empty() {
         None
     } else {
-        let pool = start_pool(threads.max(1), root_count, order, descend, root_readers());
+        let pool = start_pool(threads.max(1), root_count, order, descend);
         start_jobs(&pool, root_jobs);
         Some(pool)
     };
@@ -340,7 +328,7 @@ impl Iterator for RootWalk {
     }
 }
 
-impl<E> PoolShared<E> {
+impl PoolShared {
     /// Wake one worker that has announced it is idle.
     fn wake_worker(&self) {
         let len = self.idle.len();
@@ -367,6 +355,7 @@ impl<E> PoolShared<E> {
     }
 }
 
+#[cfg(not(windows))]
 impl Entry {
     /// Return the full path to this entry.
     #[must_use]
@@ -400,43 +389,7 @@ impl Entry {
     }
 }
 
-impl PoolEntry for Entry {}
-
-#[cfg(windows)]
-impl PoolEntry for RootEntry {}
-
-fn standard_readers() -> Readers<Entry> {
-    Readers {
-        #[cfg(windows)]
-        completion: read_dir_completion_inline,
-        #[cfg(not(windows))]
-        completion: read_dir_completion,
-        parent_first: read_dir_parent_first,
-        #[cfg(not(windows))]
-        stat_completion: stat_entries_completion,
-    }
-}
-
-#[cfg(not(windows))]
-fn root_readers() -> Readers<RootEntry> {
-    standard_readers()
-}
-
-#[cfg(windows)]
-fn root_readers() -> Readers<RootEntry> {
-    Readers {
-        completion: read_dir_windows_completion,
-        parent_first: read_dir_windows_parent_first,
-    }
-}
-
-fn start_pool<E: PoolEntry>(
-    threads: usize,
-    root_count: usize,
-    order: Order,
-    descend: Arc<Descend<E>>,
-    readers: Readers<E>,
-) -> Pool<E> {
+fn start_pool(threads: usize, root_count: usize, order: Order, descend: Arc<Descend>) -> Pool {
     let workers: Vec<_> = (0..threads).map(|_| Worker::new_lifo()).collect();
     let parkers: Vec<_> = (0..threads).map(|_| Parker::new()).collect();
     let (event_tx, event_rx) = sync_channel(threads * 2);
@@ -446,7 +399,6 @@ fn start_pool<E: PoolEntry>(
         stop: AtomicBool::new(false),
         descend,
         events: event_tx,
-        readers,
         active_roots: AtomicUsize::new(0),
         jobs_per_root: (0..root_count).map(|_| AtomicUsize::new(0)).collect(),
         order,
@@ -481,12 +433,12 @@ fn start_pool<E: PoolEntry>(
 /// Returns events in stack order for [`RootWalk::next`] to pop, plus jobs requiring a worker pool.
 fn begin_walks(
     roots: impl IntoIterator<Item = (usize, PathBuf)>,
-    descend: &Descend<RootEntry>,
+    descend: &Descend,
 ) -> (Vec<(usize, RootEvent)>, Vec<Job>) {
     let mut next = Vec::new();
     let mut jobs = Vec::new();
     for (root_idx, path) in roots {
-        let entry = RootEntry::from_path(&path);
+        let entry = Entry::from_path(&path);
         let has_job = if let Ok(entry) = &entry
             && entry.file_type.is_dir()
             && descend(root_idx, entry)
@@ -511,7 +463,7 @@ fn begin_walks(
 
 /// Seed an idle pool with one initial job per active root.
 /// Initializes per-root completion accounting, queues the jobs, and wakes workers to process them.
-fn start_jobs<E>(pool: &Pool<E>, root_jobs: Vec<Job>) {
+fn start_jobs(pool: &Pool, root_jobs: Vec<Job>) {
     let wake_all = root_jobs.len() > 1;
     debug_assert_eq!(
         pool.shared.active_roots.load(AtomicOrdering::Relaxed),
@@ -542,12 +494,7 @@ fn start_jobs<E>(pool: &Pool<E>, root_jobs: Vec<Job>) {
     }
 }
 
-fn worker_loop<E: PoolEntry>(
-    idx: usize,
-    worker: Worker<Job>,
-    parker: Parker,
-    shared: Arc<PoolShared<E>>,
-) {
+fn worker_loop(idx: usize, worker: Worker<Job>, parker: Parker, shared: Arc<PoolShared>) {
     while !shared.stop.load(AtomicOrdering::Relaxed) {
         let found = if let Some(found) = find_job(&worker, &shared) {
             found
@@ -571,7 +518,7 @@ fn worker_loop<E: PoolEntry>(
     }
 }
 
-impl<E> Drop for Pool<E> {
+impl Drop for Pool {
     fn drop(&mut self) {
         self.shared.stop.store(true, AtomicOrdering::Relaxed);
         self.shared.wake_workers();
@@ -591,7 +538,7 @@ impl<E> Drop for Pool<E> {
 ///
 /// Returns the selected job and whether it was stolen from another worker; the caller uses a
 /// successful steal to wake another idle worker. Returns `None` when a full scan finds no work.
-fn find_job<E>(worker: &Worker<Job>, shared: &PoolShared<E>) -> Option<(Job, bool)> {
+fn find_job(worker: &Worker<Job>, shared: &PoolShared) -> Option<(Job, bool)> {
     loop {
         if let Some(job) = worker.pop() {
             return Some((job, false));
@@ -617,19 +564,18 @@ fn find_job<E>(worker: &Worker<Job>, shared: &PoolShared<E>) -> Option<(Job, boo
     }
 }
 
-fn run_job<E: PoolEntry>(job: Job, worker: &Worker<Job>, shared: &PoolShared<E>) {
+fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
     match job {
         Job::ReadDir {
             root_idx: root,
             path,
             entry_depth,
         } => {
-            let reader = if matches!(shared.order, Order::Completion) {
-                shared.readers.completion
+            if matches!(shared.order, Order::Completion) {
+                read_dir_completion(root, path, entry_depth, worker, shared);
             } else {
-                shared.readers.parent_first
-            };
-            reader(root, path, entry_depth, worker, shared);
+                read_dir_parent_first(root, path, entry_depth, worker, shared);
+            }
         }
         #[cfg(not(windows))]
         Job::StatCompletion {
@@ -637,7 +583,7 @@ fn run_job<E: PoolEntry>(job: Job, worker: &Worker<Job>, shared: &PoolShared<E>)
             path,
             entry_depth,
             entries,
-        } => (shared.readers.stat_completion)(root, path, entry_depth, entries, worker, shared),
+        } => stat_entries_completion(root, path, entry_depth, entries, worker, shared),
     }
 }
 
@@ -652,7 +598,7 @@ fn read_dir_completion(
     path: Arc<Path>,
     entry_depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared<Entry>,
+    shared: &PoolShared,
 ) {
     let dir_entries = match fs::read_dir(&path) {
         Ok(entries) => entries,
@@ -723,93 +669,12 @@ fn read_dir_completion(
 }
 
 #[cfg(windows)]
-fn read_dir_completion_inline(
+fn read_dir_completion(
     root_idx: usize,
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared<Entry>,
-) {
-    let dir_entries = match fs::read_dir(&path) {
-        Ok(entries) => entries,
-        Err(err) => {
-            if shared
-                .events
-                .send(Event::Batch {
-                    root_idx,
-                    batch: Err(err),
-                })
-                .is_err()
-            {
-                shared.stop.store(true, AtomicOrdering::Relaxed);
-            }
-            finish_pending(root_idx, shared);
-            return;
-        }
-    };
-    let mut entries = Vec::with_capacity(ENTRY_CHUNK_SIZE);
-    let mut jobs = Vec::new();
-    for entry in dir_entries {
-        let entry = entry
-            .and_then(|entry| Entry::from_dir_entry(depth, Arc::clone(&path), entry))
-            .inspect(|entry| {
-                if entry.file_type.is_dir() && (shared.descend)(root_idx, entry) {
-                    jobs.push(Job::ReadDir {
-                        root_idx,
-                        path: Arc::from(entry.path()),
-                        entry_depth: depth + 1,
-                    });
-                }
-            });
-        entries.push(entry);
-        if entries.len() == ENTRY_CHUNK_SIZE
-            && !publish_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared)
-        {
-            finish_pending(root_idx, shared);
-            return;
-        }
-    }
-    if !entries.is_empty() {
-        publish_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared);
-    }
-    finish_pending(root_idx, shared);
-}
-
-#[cfg(windows)]
-fn publish_completion_batch(
-    root_idx: usize,
-    entries: &mut Vec<io::Result<Entry>>,
-    jobs: &mut Vec<Job>,
-    worker: &Worker<Job>,
-    shared: &PoolShared<Entry>,
-) -> bool {
-    add_pending(root_idx, jobs.len(), shared);
-    schedule_jobs(std::mem::take(jobs), worker, shared);
-    if shared
-        .events
-        .send(Event::Batch {
-            root_idx,
-            batch: Ok(std::mem::replace(
-                entries,
-                Vec::with_capacity(ENTRY_CHUNK_SIZE),
-            )),
-        })
-        .is_err()
-    {
-        shared.stop.store(true, AtomicOrdering::Relaxed);
-        false
-    } else {
-        true
-    }
-}
-
-#[cfg(windows)]
-fn read_dir_windows_completion(
-    root_idx: usize,
-    path: Arc<Path>,
-    depth: usize,
-    worker: &Worker<Job>,
-    shared: &PoolShared<RootEntry>,
+    shared: &PoolShared,
 ) {
     let dir_entries = match windows::ReadDir::open(path, depth) {
         Ok(entries) => entries,
@@ -843,25 +708,25 @@ fn read_dir_windows_completion(
         }
         entries.push(entry);
         if entries.len() == ENTRY_CHUNK_SIZE
-            && !publish_windows_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared)
+            && !publish_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared)
         {
             finish_pending(root_idx, shared);
             return;
         }
     }
     if !entries.is_empty() {
-        publish_windows_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared);
+        publish_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared);
     }
     finish_pending(root_idx, shared);
 }
 
 #[cfg(windows)]
-fn publish_windows_completion_batch(
+fn publish_completion_batch(
     root_idx: usize,
-    entries: &mut Vec<io::Result<RootEntry>>,
+    entries: &mut Vec<io::Result<Entry>>,
     jobs: &mut Vec<Job>,
     worker: &Worker<Job>,
-    shared: &PoolShared<RootEntry>,
+    shared: &PoolShared,
 ) -> bool {
     add_pending(root_idx, jobs.len(), shared);
     schedule_jobs(std::mem::take(jobs), worker, shared);
@@ -884,12 +749,12 @@ fn publish_windows_completion_batch(
 }
 
 #[cfg(windows)]
-fn read_dir_windows_parent_first(
+fn read_dir_parent_first(
     root_idx: usize,
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared<RootEntry>,
+    shared: &PoolShared,
 ) {
     let dir_entries = match windows::ReadDir::open(path, depth) {
         Ok(entries) => entries,
@@ -922,7 +787,7 @@ fn stat_entries_completion(
     depth: usize,
     entries: Vec<fs::DirEntry>,
     worker: &Worker<Job>,
-    shared: &PoolShared<Entry>,
+    shared: &PoolShared,
 ) {
     let mut jobs = Vec::new();
     let entries = entries
@@ -961,26 +826,27 @@ fn stat_entries_completion(
 /// order. Metadata within one directory is serial, although separate directories still run in
 /// parallel; this often matches completion-order performance unless wide-directory metadata is the
 /// bottleneck.
+#[cfg(not(windows))]
 fn read_dir_parent_first(
     root_idx: usize,
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared<Entry>,
+    shared: &PoolShared,
 ) {
     read_dir_inline(root_idx, path, depth, worker, shared);
 }
 
 /// Convert a directory's entries on the worker that enumerates it, then schedule its children.
 ///
-/// Parent-first traversal requires this on every platform. Completion-order traversal uses it on
-/// Windows because directory enumeration already provides metadata without another syscall.
+/// Parent-first traversal converts each entry inline to preserve ordering.
+#[cfg(not(windows))]
 fn read_dir_inline(
     root_idx: usize,
     path: Arc<Path>,
     depth: usize,
     worker: &Worker<Job>,
-    shared: &PoolShared<Entry>,
+    shared: &PoolShared,
 ) {
     let dir_entries = match fs::read_dir(&path) {
         Ok(entries) => entries,
@@ -1011,12 +877,12 @@ fn read_dir_inline(
 /// Publish a completed directory read and schedule its accepted child-directory jobs.
 /// `ParentFirst` sends the batch before exposing child jobs; `Completion` exposes child jobs first.
 /// Child jobs are counted before either action, and the current job is marked complete afterward.
-fn finish_directory<E>(
+fn finish_directory(
     root_idx: usize,
-    batch: Batch<E>,
+    batch: Batch,
     jobs: Vec<Job>,
     worker: &Worker<Job>,
-    shared: &PoolShared<E>,
+    shared: &PoolShared,
 ) {
     add_pending(root_idx, jobs.len(), shared);
 
@@ -1048,13 +914,13 @@ fn finish_directory<E>(
     finish_pending(root_idx, shared);
 }
 
-fn add_pending<E>(root: usize, count: usize, shared: &PoolShared<E>) {
+fn add_pending(root: usize, count: usize, shared: &PoolShared) {
     shared.jobs_per_root[root].fetch_add(count, AtomicOrdering::Relaxed);
 }
 
 /// Mark one job complete for `root`.
 /// The last job emits `RootFinished`; if this was also the last active root, `Finished` follows.
-fn finish_pending<E>(root_idx: usize, shared: &PoolShared<E>) {
+fn finish_pending(root_idx: usize, shared: &PoolShared) {
     if shared.jobs_per_root[root_idx].fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
         shared.events.send(Event::RootFinished { root_idx }).ok();
         if shared.active_roots.fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
@@ -1063,7 +929,7 @@ fn finish_pending<E>(root_idx: usize, shared: &PoolShared<E>) {
     }
 }
 
-fn schedule_jobs<E>(jobs: Vec<Job>, worker: &Worker<Job>, shared: &PoolShared<E>) {
+fn schedule_jobs(jobs: Vec<Job>, worker: &Worker<Job>, shared: &PoolShared) {
     let has_jobs = !jobs.is_empty();
     for job in jobs {
         worker.push(job);

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -12,12 +12,14 @@
 //!
 //! # Scheduling
 //!
-//! The root directory starts in a shared injector queue. Directory reads enqueue small metadata
-//! batches, and metadata batches enqueue accepted child directories. Every worker can run either
-//! kind of job from its local LIFO queue or steal from a peer. Each successful thief wakes another
-//! idle worker, ramping up only while work remains stealable. A worker parks when no queue has work
-//! and is unparked when new work arrives or the walk stops. The last completed job emits the
-//! finished event; dropping the iterator stops all workers, unparks them, and joins their threads.
+//! The root directory starts in a shared injector queue. On platforms where directory-entry
+//! metadata may require another syscall, directory reads enqueue small metadata batches, and
+//! metadata batches enqueue accepted child directories. Windows workers instead consume the
+//! metadata returned by directory enumeration directly and enqueue child directories immediately.
+//! Every worker can run available jobs from its local LIFO queue or steal from a peer. Each
+//! successful thief wakes another idle worker, ramping up only while work remains stealable. A
+//! worker parks when no queue has work and is unparked when new work arrives or the walk stops. The
+//! last completed job emits the finished event; dropping the iterator stops and joins all workers.
 
 use crossbeam::{
     deque::{Injector, Steal, Stealer, Worker},
@@ -43,9 +45,9 @@ type Descend = dyn Fn(usize, &Entry) -> bool + Send + Sync;
 /// The outer error means `fs::read_dir` could not open the directory; inner errors come from
 /// reading or converting individual directory entries.
 type Batch = io::Result<Vec<io::Result<Entry>>>;
-/// Number of directory entries grouped into each stealable metadata job.
-/// Small chunks expose parallel work while amortizing queueing overhead across several entries.
-const STAT_CHUNK_SIZE: usize = 4;
+/// Number of directory entries grouped into each metadata job or result batch.
+/// Small chunks expose parallel work and stream wide directories while amortizing queue overhead.
+const ENTRY_CHUNK_SIZE: usize = 4;
 
 /// Controls when entries are yielded relative to their descendants.
 #[derive(Clone, Copy)]
@@ -80,6 +82,7 @@ enum Job {
         entry_depth: usize,
     },
     /// Fetch metadata for a chunk of entries from a completed directory read.
+    #[cfg(not(windows))]
     StatCompletion {
         root_idx: usize,
         path: Arc<Path>,
@@ -93,7 +96,9 @@ impl Job {
     /// Return the index of the root path that this job belongs to.
     fn root_idx(&self) -> usize {
         match self {
-            Job::ReadDir { root_idx, .. } | Job::StatCompletion { root_idx, .. } => *root_idx,
+            Job::ReadDir { root_idx, .. } => *root_idx,
+            #[cfg(not(windows))]
+            Job::StatCompletion { root_idx, .. } => *root_idx,
         }
     }
 }
@@ -452,8 +457,9 @@ fn start_jobs(pool: &Pool, root_jobs: Vec<Job>) {
     );
     debug_assert!(
         root_jobs.iter().all(|j| match j {
-            Job::ReadDir { entry_depth, .. } | Job::StatCompletion { entry_depth, .. } =>
-                *entry_depth,
+            Job::ReadDir { entry_depth, .. } => *entry_depth,
+            #[cfg(not(windows))]
+            Job::StatCompletion { entry_depth, .. } => *entry_depth,
         } == 1),
         "the first jobs should be root jobs, so active_root counts match"
     );
@@ -556,6 +562,7 @@ fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
                 read_dir_parent_first(root, path, entry_depth, worker, shared);
             }
         }
+        #[cfg(not(windows))]
         Job::StatCompletion {
             root_idx: root,
             path,
@@ -577,6 +584,93 @@ fn read_dir_completion(
     worker: &Worker<Job>,
     shared: &PoolShared,
 ) {
+    #[cfg(windows)]
+    {
+        // `DirEntry::metadata()` is populated by Windows directory enumeration and needs no
+        // additional syscall. Convert entries on this worker instead of paying to queue and steal
+        // metadata jobs, but keep publishing bounded batches so wide directories stream results.
+        read_dir_completion_inline(root_idx, path, entry_depth, worker, shared);
+    }
+
+    #[cfg(not(windows))]
+    {
+        let dir_entries = match fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(err) => {
+                if shared
+                    .events
+                    .send(Event::Batch {
+                        root_idx,
+                        batch: Err(err),
+                    })
+                    .is_err()
+                {
+                    shared.stop.store(true, AtomicOrdering::Relaxed);
+                }
+                finish_pending(root_idx, shared);
+                return;
+            }
+        };
+        let mut chunk = Vec::with_capacity(ENTRY_CHUNK_SIZE);
+        let mut errors = Vec::new();
+        let mut has_jobs = false;
+        for entry in dir_entries {
+            match entry {
+                Ok(entry) => {
+                    chunk.push(entry);
+                    if chunk.len() == ENTRY_CHUNK_SIZE {
+                        add_pending(root_idx, 1, shared);
+                        worker.push(Job::StatCompletion {
+                            root_idx,
+                            path: Arc::clone(&path),
+                            entry_depth,
+                            entries: std::mem::replace(
+                                &mut chunk,
+                                Vec::with_capacity(ENTRY_CHUNK_SIZE),
+                            ),
+                        });
+                        has_jobs = true;
+                    }
+                }
+                Err(err) => errors.push(Err(err)),
+            }
+        }
+        if !chunk.is_empty() {
+            add_pending(root_idx, 1, shared);
+            worker.push(Job::StatCompletion {
+                root_idx,
+                path,
+                entry_depth,
+                entries: chunk,
+            });
+            has_jobs = true;
+        }
+        if has_jobs {
+            shared.wake_worker();
+        }
+        if !errors.is_empty()
+            && shared
+                .events
+                .send(Event::Batch {
+                    root_idx,
+                    batch: Ok(errors),
+                })
+                .is_err()
+        {
+            shared.stop.store(true, AtomicOrdering::Relaxed);
+        }
+        finish_pending(root_idx, shared);
+    }
+}
+
+#[cfg(windows)]
+fn read_dir_completion_inline(
+    root_idx: usize,
+    path: Arc<Path>,
+    depth: usize,
+    worker: &Worker<Job>,
+    shared: &PoolShared,
+) {
     let dir_entries = match fs::read_dir(&path) {
         Ok(entries) => entries,
         Err(err) => {
@@ -594,54 +688,63 @@ fn read_dir_completion(
             return;
         }
     };
-    let mut chunk = Vec::with_capacity(STAT_CHUNK_SIZE);
-    let mut errors = Vec::new();
-    let mut has_jobs = false;
+    let mut entries = Vec::with_capacity(ENTRY_CHUNK_SIZE);
+    let mut jobs = Vec::new();
     for entry in dir_entries {
-        match entry {
-            Ok(entry) => {
-                chunk.push(entry);
-                if chunk.len() == STAT_CHUNK_SIZE {
-                    add_pending(root_idx, 1, shared);
-                    worker.push(Job::StatCompletion {
+        let entry = entry
+            .and_then(|entry| Entry::from_dir_entry(depth, Arc::clone(&path), entry))
+            .inspect(|entry| {
+                if entry.file_type.is_dir() && (shared.descend)(root_idx, entry) {
+                    jobs.push(Job::ReadDir {
                         root_idx,
-                        path: Arc::clone(&path),
-                        entry_depth,
-                        entries: std::mem::replace(&mut chunk, Vec::with_capacity(STAT_CHUNK_SIZE)),
+                        path: Arc::from(entry.path()),
+                        entry_depth: depth + 1,
                     });
-                    has_jobs = true;
                 }
-            }
-            Err(err) => errors.push(Err(err)),
+            });
+        entries.push(entry);
+        if entries.len() == ENTRY_CHUNK_SIZE
+            && !publish_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared)
+        {
+            finish_pending(root_idx, shared);
+            return;
         }
     }
-    if !chunk.is_empty() {
-        add_pending(root_idx, 1, shared);
-        worker.push(Job::StatCompletion {
-            root_idx,
-            path,
-            entry_depth,
-            entries: chunk,
-        });
-        has_jobs = true;
-    }
-    if has_jobs {
-        shared.wake_worker();
-    }
-    if !errors.is_empty()
-        && shared
-            .events
-            .send(Event::Batch {
-                root_idx,
-                batch: Ok(errors),
-            })
-            .is_err()
-    {
-        shared.stop.store(true, AtomicOrdering::Relaxed);
+    if !entries.is_empty() {
+        publish_completion_batch(root_idx, &mut entries, &mut jobs, worker, shared);
     }
     finish_pending(root_idx, shared);
 }
 
+#[cfg(windows)]
+fn publish_completion_batch(
+    root_idx: usize,
+    entries: &mut Vec<io::Result<Entry>>,
+    jobs: &mut Vec<Job>,
+    worker: &Worker<Job>,
+    shared: &PoolShared,
+) -> bool {
+    add_pending(root_idx, jobs.len(), shared);
+    schedule_jobs(std::mem::take(jobs), worker, shared);
+    if shared
+        .events
+        .send(Event::Batch {
+            root_idx,
+            batch: Ok(std::mem::replace(
+                entries,
+                Vec::with_capacity(ENTRY_CHUNK_SIZE),
+            )),
+        })
+        .is_err()
+    {
+        shared.stop.store(true, AtomicOrdering::Relaxed);
+        false
+    } else {
+        true
+    }
+}
+
+#[cfg(not(windows))]
 fn stat_entries_completion(
     root_idx: usize,
     path: Arc<Path>,
@@ -688,6 +791,20 @@ fn stat_entries_completion(
 /// parallel; this often matches completion-order performance unless wide-directory metadata is the
 /// bottleneck.
 fn read_dir_parent_first(
+    root_idx: usize,
+    path: Arc<Path>,
+    depth: usize,
+    worker: &Worker<Job>,
+    shared: &PoolShared,
+) {
+    read_dir_inline(root_idx, path, depth, worker, shared);
+}
+
+/// Convert a directory's entries on the worker that enumerates it, then schedule its children.
+///
+/// Parent-first traversal requires this on every platform. Completion-order traversal uses it on
+/// Windows because directory enumeration already provides metadata without another syscall.
+fn read_dir_inline(
     root_idx: usize,
     path: Arc<Path>,
     depth: usize,
@@ -940,5 +1057,63 @@ mod tests {
             worker_threads.lock().unwrap().len() >= 4,
             "a wide directory should engage more than the producer and one thief"
         );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_metadata_is_collected_by_the_directory_worker() {
+        let dir = tempfile::tempdir().unwrap();
+        for idx in 0..32 {
+            fs::create_dir(dir.path().join(idx.to_string())).unwrap();
+        }
+
+        let worker_threads = Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        let seen_threads = Arc::clone(&worker_threads);
+        walk(dir.path(), 8, Order::Completion, move |entry| {
+            if entry.depth == 1 {
+                seen_threads.lock().unwrap().insert(thread::current().id());
+                thread::sleep(std::time::Duration::from_millis(2));
+            }
+            true
+        })
+        .for_each(drop);
+
+        assert_eq!(
+            worker_threads.lock().unwrap().len(),
+            1,
+            "Windows directory-entry metadata should stay on the enumerating worker"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_completion_streams_metadata_before_enumeration_finishes() {
+        let dir = tempfile::tempdir().unwrap();
+        for idx in 0..(ENTRY_CHUNK_SIZE + 1) {
+            fs::create_dir(dir.path().join(idx.to_string())).unwrap();
+        }
+
+        let (continue_tx, continue_rx) = std::sync::mpsc::sync_channel(0);
+        let continue_rx = Arc::new(std::sync::Mutex::new(continue_rx));
+        let seen = Arc::new(AtomicUsize::new(0));
+        let seen_in_worker = Arc::clone(&seen);
+        let mut entries = walk(dir.path(), 2, Order::Completion, move |entry| {
+            if entry.depth == 1
+                && seen_in_worker.fetch_add(1, AtomicOrdering::Relaxed) == ENTRY_CHUNK_SIZE
+            {
+                continue_rx
+                    .lock()
+                    .unwrap()
+                    .recv_timeout(std::time::Duration::from_secs(2))
+                    .expect("the first metadata batch should arrive before enumeration finishes");
+            }
+            true
+        });
+
+        assert_eq!(entries.next().unwrap().unwrap().depth, 0);
+        assert_eq!(entries.next().unwrap().unwrap().depth, 1);
+        continue_tx.send(()).unwrap();
+        entries.for_each(drop);
+        assert_eq!(seen.load(AtomicOrdering::Relaxed), ENTRY_CHUNK_SIZE + 1);
     }
 }

--- a/src/walk/windows.rs
+++ b/src/walk/windows.rs
@@ -24,12 +24,18 @@ use windows_sys::Win32::{
 const DIRECTORY_BUFFER_WORDS: usize = 8 * 1024;
 const NAME_SURROGATE_BIT: u32 = 0x2000_0000;
 
-pub(crate) struct Entry {
-    pub(crate) depth: usize,
-    pub(crate) file_name: OsString,
-    pub(crate) file_type: FileType,
-    pub(crate) metadata: io::Result<Metadata>,
-    pub(crate) parent_path: Arc<Path>,
+/// A filesystem entry produced by the Windows directory walker.
+pub struct Entry {
+    /// Distance from the walk root: `0` for the root, `1` for its children, and so on.
+    pub depth: usize,
+    /// File name relative to `parent_path`.
+    pub file_name: OsString,
+    /// Filesystem entry type without following symbolic links.
+    pub file_type: FileType,
+    /// Metadata obtained with directory enumeration.
+    pub metadata: io::Result<Metadata>,
+    /// Path containing this entry.
+    pub parent_path: Arc<Path>,
 }
 
 impl Entry {
@@ -96,15 +102,17 @@ impl Entry {
         })
     }
 
-    pub(crate) fn path(&self) -> PathBuf {
+    /// Return the full path to this entry.
+    #[must_use]
+    pub fn path(&self) -> PathBuf {
         self.parent_path.join(&self.file_name)
     }
 }
 
 #[derive(Clone, Copy)]
-pub(crate) struct FileType {
+/// Windows filesystem entry type derived from directory attributes and reparse tags.
+pub struct FileType {
     is_dir: bool,
-    #[cfg_attr(not(test), allow(dead_code))]
     is_symlink: bool,
 }
 
@@ -118,18 +126,28 @@ impl FileType {
         }
     }
 
-    pub(crate) fn is_dir(self) -> bool {
+    /// Return whether this entry is a directory that may be traversed.
+    #[must_use]
+    pub fn is_dir(self) -> bool {
         self.is_dir
     }
 
-    #[cfg(test)]
-    pub(crate) fn is_symlink(self) -> bool {
+    /// Return whether this entry is a regular file.
+    #[must_use]
+    pub fn is_file(self) -> bool {
+        !self.is_dir && !self.is_symlink
+    }
+
+    /// Return whether this entry is a symbolic link or junction.
+    #[must_use]
+    pub fn is_symlink(self) -> bool {
         self.is_symlink
     }
 }
 
 #[derive(Clone, Copy)]
-pub(crate) struct Metadata {
+/// Metadata supplied by Windows directory enumeration.
+pub struct Metadata {
     len: u64,
     allocated_size: u64,
     modified: SystemTime,
@@ -138,16 +156,22 @@ pub(crate) struct Metadata {
 }
 
 impl Metadata {
-    pub(crate) fn len(&self) -> u64 {
+    /// Return the logical file size.
+    #[must_use]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> u64 {
         self.len
     }
 
-    pub(crate) fn allocated_size(&self) -> u64 {
+    /// Return the number of allocated bytes.
+    #[must_use]
+    pub fn allocated_size(&self) -> u64 {
         self.allocated_size
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn modified(&self) -> io::Result<SystemTime> {
+    /// Return the last modification time.
+    pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(self.modified)
     }
 
@@ -392,9 +416,11 @@ mod tests {
 
         let file = FileType::from_attributes(FILE_ATTRIBUTE_NORMAL, 0);
         assert!(!file.is_dir());
+        assert!(file.is_file());
         assert!(!file.is_symlink());
         let dir = FileType::from_attributes(FILE_ATTRIBUTE_DIRECTORY, 0);
         assert!(dir.is_dir());
+        assert!(!dir.is_file());
         assert!(!dir.is_symlink());
         for tag in [IO_REPARSE_TAG_SYMLINK, IO_REPARSE_TAG_MOUNT_POINT] {
             let link = FileType::from_attributes(
@@ -402,6 +428,7 @@ mod tests {
                 tag,
             );
             assert!(!link.is_dir());
+            assert!(!link.is_file());
             assert!(link.is_symlink());
         }
         let cloud = FileType::from_attributes(

--- a/src/walk/windows.rs
+++ b/src/walk/windows.rs
@@ -1,0 +1,496 @@
+use std::{
+    ffi::OsString,
+    io,
+    os::windows::ffi::{OsStrExt, OsStringExt},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use windows_sys::Win32::{
+    Foundation::{
+        CloseHandle, ERROR_HANDLE_EOF, ERROR_NO_MORE_FILES, HANDLE, INVALID_HANDLE_VALUE,
+    },
+    Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, CreateFileW, FILE_ATTRIBUTE_DIRECTORY,
+        FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_ID_BOTH_DIR_INFO, FILE_LIST_DIRECTORY,
+        FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        FILE_STANDARD_INFO, FileAttributeTagInfo, FileIdBothDirectoryInfo, FileStandardInfo,
+        GetFileInformationByHandle, GetFileInformationByHandleEx, OPEN_EXISTING, SYNCHRONIZE,
+    },
+};
+
+const DIRECTORY_BUFFER_WORDS: usize = 8 * 1024;
+const NAME_SURROGATE_BIT: u32 = 0x2000_0000;
+
+pub(crate) struct Entry {
+    pub(crate) depth: usize,
+    pub(crate) file_name: OsString,
+    pub(crate) file_type: FileType,
+    pub(crate) metadata: io::Result<Metadata>,
+    pub(crate) parent_path: Arc<Path>,
+}
+
+impl Entry {
+    pub(crate) fn from_path(path: &Path) -> io::Result<Self> {
+        let handle = OwnedHandle::open(
+            path,
+            FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+            FILE_FLAG_OPEN_REPARSE_POINT,
+        )?;
+        let mut info = BY_HANDLE_FILE_INFORMATION::default();
+        // SAFETY: `handle` is owned and valid, and `info` is writable for the call's duration.
+        if unsafe { GetFileInformationByHandle(handle.0, &raw mut info) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut standard = FILE_STANDARD_INFO::default();
+        // SAFETY: the output pointer and byte count describe the initialized `standard` value.
+        if unsafe {
+            GetFileInformationByHandleEx(
+                handle.0,
+                FileStandardInfo,
+                (&raw mut standard).cast(),
+                size_of::<FILE_STANDARD_INFO>() as u32,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        let reparse_tag = if info.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            let mut tag = FILE_ATTRIBUTE_TAG_INFO::default();
+            // SAFETY: the output pointer and byte count describe the initialized `tag` value.
+            if unsafe {
+                GetFileInformationByHandleEx(
+                    handle.0,
+                    FileAttributeTagInfo,
+                    (&raw mut tag).cast(),
+                    size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+                )
+            } == 0
+            {
+                return Err(io::Error::last_os_error());
+            }
+            tag.ReparseTag
+        } else {
+            0
+        };
+        let file_type = FileType::from_attributes(info.dwFileAttributes, reparse_tag);
+        let file_id = u64::from(info.nFileIndexHigh) << 32 | u64::from(info.nFileIndexLow);
+        let metadata = Metadata {
+            len: u64::from(info.nFileSizeHigh) << 32 | u64::from(info.nFileSizeLow),
+            allocated_size: standard.AllocationSize.max(0).cast_unsigned(),
+            modified: filetime_to_system_time(
+                u64::from(info.ftLastWriteTime.dwHighDateTime) << 32
+                    | u64::from(info.ftLastWriteTime.dwLowDateTime),
+            ),
+            volume_serial: u64::from(info.dwVolumeSerialNumber),
+            file_id: (file_id != 0).then_some(file_id),
+        };
+        Ok(Self {
+            depth: 0,
+            file_name: path.file_name().unwrap_or(path.as_os_str()).to_owned(),
+            file_type,
+            metadata: Ok(metadata),
+            parent_path: Arc::from(path.parent().unwrap_or(Path::new(""))),
+        })
+    }
+
+    pub(crate) fn path(&self) -> PathBuf {
+        self.parent_path.join(&self.file_name)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct FileType {
+    is_dir: bool,
+    #[cfg_attr(not(test), allow(dead_code))]
+    is_symlink: bool,
+}
+
+impl FileType {
+    fn from_attributes(attributes: u32, reparse_tag: u32) -> Self {
+        let is_symlink =
+            attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 && reparse_tag & NAME_SURROGATE_BIT != 0;
+        Self {
+            is_dir: !is_symlink && attributes & FILE_ATTRIBUTE_DIRECTORY != 0,
+            is_symlink,
+        }
+    }
+
+    pub(crate) fn is_dir(self) -> bool {
+        self.is_dir
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_symlink(self) -> bool {
+        self.is_symlink
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct Metadata {
+    len: u64,
+    allocated_size: u64,
+    modified: SystemTime,
+    volume_serial: u64,
+    file_id: Option<u64>,
+}
+
+impl Metadata {
+    pub(crate) fn len(&self) -> u64 {
+        self.len
+    }
+
+    pub(crate) fn allocated_size(&self) -> u64 {
+        self.allocated_size
+    }
+
+    #[allow(clippy::unnecessary_wraps)]
+    pub(crate) fn modified(&self) -> io::Result<SystemTime> {
+        Ok(self.modified)
+    }
+
+    pub(crate) fn hard_link_id(&self) -> Option<(u64, u64)> {
+        self.file_id.map(|file_id| (self.volume_serial, file_id))
+    }
+}
+
+pub(crate) struct ReadDir {
+    handle: OwnedHandle,
+    buffer: Vec<u64>,
+    next_offset: Option<usize>,
+    exhausted: bool,
+    parent_path: Arc<Path>,
+    depth: usize,
+    volume_serial: u64,
+}
+
+impl ReadDir {
+    pub(crate) fn open(path: Arc<Path>, depth: usize) -> io::Result<Self> {
+        let handle = OwnedHandle::open(&path, FILE_LIST_DIRECTORY | SYNCHRONIZE, 0)?;
+        let mut info = BY_HANDLE_FILE_INFORMATION::default();
+        // SAFETY: `handle` is owned and valid, and `info` is writable for the call's duration.
+        if unsafe { GetFileInformationByHandle(handle.0, &raw mut info) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            handle,
+            buffer: vec![0; DIRECTORY_BUFFER_WORDS],
+            next_offset: None,
+            exhausted: false,
+            parent_path: path,
+            depth,
+            volume_serial: u64::from(info.dwVolumeSerialNumber),
+        })
+    }
+
+    fn refill(&mut self) -> io::Result<bool> {
+        // SAFETY: the aligned buffer is writable for its full reported byte length, and the owned
+        // directory handle remains valid while `self` lives.
+        let result = unsafe {
+            GetFileInformationByHandleEx(
+                self.handle.0,
+                FileIdBothDirectoryInfo,
+                self.buffer.as_mut_ptr().cast(),
+                (self.buffer.len() * size_of::<u64>()) as u32,
+            )
+        };
+        if result != 0 {
+            self.next_offset = Some(0);
+            return Ok(true);
+        }
+        let error = io::Error::last_os_error();
+        if matches!(
+            error.raw_os_error().map(i32::cast_unsigned),
+            Some(ERROR_NO_MORE_FILES | ERROR_HANDLE_EOF)
+        ) {
+            self.exhausted = true;
+            Ok(false)
+        } else {
+            self.exhausted = true;
+            Err(error)
+        }
+    }
+
+    fn entry_at(&self, offset: usize) -> io::Result<(Entry, Option<usize>)> {
+        const HEADER_SIZE: usize = std::mem::offset_of!(FILE_ID_BOTH_DIR_INFO, FileName);
+        let buffer_len = self.buffer.len() * size_of::<u64>();
+        if offset > buffer_len.saturating_sub(HEADER_SIZE) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Windows directory record header exceeds its buffer",
+            ));
+        }
+        // SAFETY: validation above proves the record header lies within the aligned backing
+        // allocation. Individual fields are read unaligned because record offsets need not be.
+        let info_ptr = unsafe {
+            self.buffer
+                .as_ptr()
+                .byte_add(offset)
+                .cast::<FILE_ID_BOTH_DIR_INFO>()
+        };
+        // SAFETY: `info_ptr` addresses a complete in-bounds header validated above.
+        let info = unsafe { info_ptr.read_unaligned() };
+        if info.FileNameLength % 2 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Windows directory record has an odd UTF-16 byte length",
+            ));
+        }
+        let name_len = (info.FileNameLength / 2) as usize;
+        let name_bytes = name_len.checked_mul(size_of::<u16>()).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "Windows filename is too large")
+        })?;
+        if offset
+            .checked_add(HEADER_SIZE)
+            .and_then(|start| start.checked_add(name_bytes))
+            .is_none_or(|end| end > buffer_len)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Windows directory filename exceeds its buffer",
+            ));
+        }
+        // SAFETY: the filename range was validated against the buffer above. It may be unaligned,
+        // so each UTF-16 code unit is copied with `read_unaligned` below.
+        let name_ptr = unsafe { (&raw const (*info_ptr).FileName).cast::<u16>() };
+        let name = (0..name_len)
+            // SAFETY: `idx` stays within the validated filename range.
+            .map(|idx| unsafe { name_ptr.add(idx).read_unaligned() })
+            .collect::<Vec<_>>();
+        let file_name = OsString::from_wide(&name);
+        let next_offset = if info.NextEntryOffset == 0 {
+            None
+        } else {
+            let next = offset
+                .checked_add(info.NextEntryOffset as usize)
+                .filter(|next| *next <= buffer_len.saturating_sub(HEADER_SIZE))
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Windows directory record offset exceeds its buffer",
+                    )
+                })?;
+            Some(next)
+        };
+        let file_type = FileType::from_attributes(info.FileAttributes, info.EaSize);
+        let file_id = info.FileId.cast_unsigned();
+        let file_id = (file_id != 0).then_some(file_id);
+        Ok((
+            Entry {
+                depth: self.depth,
+                file_name,
+                file_type,
+                metadata: Ok(Metadata {
+                    len: info.EndOfFile.max(0).cast_unsigned(),
+                    allocated_size: info.AllocationSize.max(0).cast_unsigned(),
+                    modified: filetime_to_system_time(info.LastWriteTime.max(0).cast_unsigned()),
+                    volume_serial: self.volume_serial,
+                    file_id,
+                }),
+                parent_path: Arc::clone(&self.parent_path),
+            },
+            next_offset,
+        ))
+    }
+}
+
+impl Iterator for ReadDir {
+    type Item = io::Result<Entry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.exhausted {
+                return None;
+            }
+            if self.next_offset.is_none() {
+                match self.refill() {
+                    Ok(true) => {}
+                    Ok(false) => return None,
+                    Err(err) => return Some(Err(err)),
+                }
+            }
+            let offset = self.next_offset.take().expect("refill provides an offset");
+            match self.entry_at(offset) {
+                Ok((entry, next_offset)) => {
+                    self.next_offset = next_offset;
+                    if entry.file_name == "." || entry.file_name == ".." {
+                        continue;
+                    }
+                    return Some(Ok(entry));
+                }
+                Err(err) => {
+                    self.exhausted = true;
+                    return Some(Err(err));
+                }
+            }
+        }
+    }
+}
+
+struct OwnedHandle(HANDLE);
+
+impl OwnedHandle {
+    fn open(path: &Path, access: u32, extra_flags: u32) -> io::Result<Self> {
+        let mut path: Vec<u16> = path.as_os_str().encode_wide().collect();
+        path.push(0);
+        // SAFETY: `path` is null-terminated and all remaining pointer arguments follow the
+        // `CreateFileW` contract. A successful handle is exclusively owned by the return value.
+        let handle = unsafe {
+            CreateFileW(
+                path.as_ptr(),
+                access,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                std::ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | extra_flags,
+                std::ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Self(handle))
+        }
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: `OwnedHandle` is created only from a successful `CreateFileW` call and closes
+        // that handle exactly once here.
+        unsafe {
+            CloseHandle(self.0);
+        }
+    }
+}
+
+fn filetime_to_system_time(ticks: u64) -> SystemTime {
+    const WINDOWS_TO_UNIX_TICKS: u64 = 116_444_736_000_000_000;
+    if ticks >= WINDOWS_TO_UNIX_TICKS {
+        UNIX_EPOCH + duration_from_ticks(ticks - WINDOWS_TO_UNIX_TICKS)
+    } else {
+        UNIX_EPOCH - duration_from_ticks(WINDOWS_TO_UNIX_TICKS - ticks)
+    }
+}
+
+fn duration_from_ticks(ticks: u64) -> Duration {
+    Duration::new(ticks / 10_000_000, ((ticks % 10_000_000) * 100) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_flags_match_windows_symlink_metadata_semantics() {
+        const FILE_ATTRIBUTE_NORMAL: u32 = 0x80;
+        const IO_REPARSE_TAG_SYMLINK: u32 = 0xA000_000C;
+        const IO_REPARSE_TAG_MOUNT_POINT: u32 = 0xA000_0003;
+        const IO_REPARSE_TAG_CLOUD: u32 = 0x9000_001A;
+
+        let file = FileType::from_attributes(FILE_ATTRIBUTE_NORMAL, 0);
+        assert!(!file.is_dir());
+        assert!(!file.is_symlink());
+        let dir = FileType::from_attributes(FILE_ATTRIBUTE_DIRECTORY, 0);
+        assert!(dir.is_dir());
+        assert!(!dir.is_symlink());
+        for tag in [IO_REPARSE_TAG_SYMLINK, IO_REPARSE_TAG_MOUNT_POINT] {
+            let link = FileType::from_attributes(
+                FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT,
+                tag,
+            );
+            assert!(!link.is_dir());
+            assert!(link.is_symlink());
+        }
+        let cloud = FileType::from_attributes(
+            FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT,
+            IO_REPARSE_TAG_CLOUD,
+        );
+        assert!(cloud.is_dir());
+        assert!(!cloud.is_symlink());
+    }
+
+    #[test]
+    fn raw_directory_entries_include_sizes_and_file_ids() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("file");
+        std::fs::write(&path, b"content").unwrap();
+        let mut entries = ReadDir::open(Arc::from(dir.path()), 1).unwrap();
+        let entry = entries.find_map(Result::ok).unwrap();
+        let metadata = entry.metadata.unwrap();
+        let direct = Entry::from_path(&path).unwrap().metadata.unwrap();
+        assert_eq!(metadata.len(), 7);
+        assert!(metadata.allocated_size() >= metadata.len());
+        assert!(metadata.hard_link_id().is_some());
+        assert_eq!(metadata.len(), direct.len());
+        assert_eq!(metadata.allocated_size(), direct.allocated_size());
+        assert_eq!(metadata.hard_link_id(), direct.hard_link_id());
+    }
+
+    #[test]
+    fn raw_directory_metadata_matches_handle_metadata_for_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("child");
+        std::fs::create_dir(&path).unwrap();
+        std::fs::write(path.join("file"), b"content").unwrap();
+
+        let entry = ReadDir::open(Arc::from(dir.path()), 1)
+            .unwrap()
+            .find_map(Result::ok)
+            .unwrap();
+        let metadata = entry.metadata.unwrap();
+        let direct = Entry::from_path(&path).unwrap().metadata.unwrap();
+        assert_eq!(metadata.len(), direct.len());
+        assert_eq!(metadata.allocated_size(), direct.allocated_size());
+        assert_eq!(metadata.hard_link_id(), direct.hard_link_id());
+    }
+
+    #[test]
+    fn root_directory_symlinks_are_not_followed() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        std::fs::create_dir(&target).unwrap();
+        match std::os::windows::fs::symlink_dir(&target, &link) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => return,
+            Err(err) => panic!("directory symlink can be created: {err}"),
+        }
+
+        let entry = Entry::from_path(&link).unwrap();
+        assert!(entry.file_type.is_symlink());
+        assert!(!entry.file_type.is_dir());
+    }
+
+    #[test]
+    fn raw_directory_entries_identify_hard_links() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = dir.path().join("original");
+        std::fs::write(&original, b"content").unwrap();
+        std::fs::hard_link(&original, dir.path().join("link")).unwrap();
+
+        let ids = ReadDir::open(Arc::from(dir.path()), 1)
+            .unwrap()
+            .map(|entry| entry.unwrap().metadata.unwrap().hard_link_id().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids[0], ids[1]);
+    }
+
+    #[test]
+    fn raw_directory_iteration_refills_its_buffer() {
+        let dir = tempfile::tempdir().unwrap();
+        for idx in 0..400 {
+            let name = format!("{idx:04}-{}", "x".repeat(100));
+            std::fs::write(dir.path().join(name), []).unwrap();
+        }
+
+        let count = ReadDir::open(Arc::from(dir.path()), 1)
+            .unwrap()
+            .map(Result::unwrap)
+            .count();
+        assert_eq!(count, 400);
+    }
+}


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] quick review, mostly windows only changes, and integration into existing walk.

----

Everything below this line was generated by Codex.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes https://github.com/Byron/dua-cli/issues/302

## Reported issue

On Windows, the parallel walker should obtain metadata directly from directory enumeration, following the optimization used by the local `gix-status/src/fscache.rs`, and avoid per-entry `stat`-like path queries.

## Behavioral summary

Both public and internal walks now consume `FILE_ID_BOTH_DIR_INFO` records directly on Windows. Each record supplies logical size, allocation size, modification time, file type, reparse tag, and file ID without reconstructing the path or issuing a metadata call for that entry.

- Default disk usage uses the enumerated allocation size for files and preserves zero-sized directory accounting.
- `--apparent-size` uses the enumerated end-of-file value.
- Hard-link filtering uses the enumerated volume/file ID.
- Name-surrogate reparse points remain non-directories and explicitly supplied root symlinks/junctions are opened without following them.
- Raw enumeration failures are reported as I/O errors; there is no slow path-based fallback.
- Windows now exposes its native entry, file-type, and metadata types as `WalkEntry`, `WalkFileType`, and `WalkMetadata`; this intentionally changes the platform's public concrete types while retaining the commonly used `path`, `is_dir`, `is_file`, `is_symlink`, `len`, and `modified` operations.
- Non-Windows platforms retain their existing `std::fs` entry metadata path.

## Performance

Measured from this worktree by alternating three release runs of `dua ../` for each build:

| Build | Median | Runs |
| --- | ---: | --- |
| Current `main` | 27.93 s | 27.93, 28.16, 26.91 s |
| This branch | 0.81 s | 0.81, 0.89, 0.80 s |

The branch is about 34.5× faster than `main` on this scan.

## Implementation

- Add a narrowly scoped Windows raw-directory backend around `GetFileInformationByHandleEx(FileIdBothDirectoryInfo)` with a 64 KiB aligned buffer.
- Use one concrete walker entry type per target; remove the marker trait, generic worker pool, reader dispatch table, and duplicate `std::fs` Windows reader.
- Keep Windows directory enumeration, metadata, and entry details isolated in `walk/windows.rs`.
- Stream completion-order records in bounded batches and schedule accepted child directories across the existing worker pool.
- Validate record bounds and unaligned UTF-16 names, preserve reparse semantics, and close owned handles reliably.
- Keep `filesize` only on non-Windows targets because Windows no longer calls it.
- The simplification patch removes 110 net lines; the complete PR is now 846 additions and 45 deletions.

## Validation

- `cargo +nightly check --all-targets`
- `cargo +nightly test --all` (94 tests passed)
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -- -D warnings`
- `cargo +nightly doc --no-deps`
- Linux target: Clippy plus all-features and no-default-features checks, including `tui-crossplatform` and `trash-move`.
- Windows regressions cover enumerated sizes and IDs, hard links, 64 KiB buffer refills, reparse tags, removed paths, zero-sized directories, root directory symlinks, and the public file-type predicates.
- Committed-hash reviews: `6cff20884079bdf9c0ea86f069cc48167f05675f`, `c9166c23080798c8158ca7208da50d8baf8088e3`, `352af73aa259032624c854dbf3a8ca22e1bd949c`, `df631a9cf3d32b8b63c9db65c959ac41fead5aed`, and `f7276b7b4903427d5c20db7fdaf1b72e6440a90e`.
