### PR TITLE
fix(tui): buffer terminal frame output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ fn main() -> Result<()> {
                     focus_change: enable_focus_change,
                 }
             };
+            let stderr = io::BufWriter::new(stderr);
             let mut terminal = Terminal::new(CrosstermBackend::new(stderr))
                 .with_context(|| "Could not instantiate terminal")?;
 


### PR DESCRIPTION
### Summary

Interactive mode could render screen updates one character at a time when the system was under load, particularly on Windows.

The Ratatui Crossterm backend was writing directly to `stderr`, so its per-cell terminal commands were not buffered before being sent to the terminal. This made intermediate frame output visible during rendering.

This change wraps the TUI’s stderr writer in `io::BufWriter`. Ratatui still flushes the backend after each completed frame, preserving timely updates while ensuring frame output is written in larger batches.

### Verification

- `cargo fmt --check`
- `cargo check`
- `cargo test --lib`
- Manually verified on Windows under load; significant improvement observed.
- Manually verified on Linux under load; significant improvement observed.