### PR TITLE
Extract filesystem walker into dua-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "crossbeam",
  "crossterm",
  "dirs",
+ "dua-core",
  "fern",
  "filesize",
  "gix",
@@ -692,7 +693,6 @@ dependencies = [
  "log",
  "log-panics",
  "num_cpus",
- "once_cell",
  "open",
  "owo-colors",
  "petgraph",
@@ -706,6 +706,14 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "wild",
+]
+
+[[package]]
+name = "dua-core"
+version = "2.41.1"
+dependencies = [
+ "crossbeam",
+ "tempfile",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,42 @@
-[package]
-name = "dua-cli"
+[workspace]
+members = ["crates/dua-lib"]
+resolver = "3"
+
+[workspace.package]
 version = "2.41.1"
-authors = ["Sebastian Thiel <byronimo@gmail.com>"]
+authors = ["Sebastian Thiel <sebastian.thiel@icloud.com"]
 edition = "2024"
 repository = "https://github.com/Byron/dua-cli"
+license = "MIT"
+
+[workspace.dependencies]
+crossbeam = "0.8"
+tempfile = "3.27.0"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -2 }
+pedantic = { level = "warn", priority = -1 }
+enum_glob_use = "allow"
+needless_pass_by_value = "allow"
+redundant_closure_for_method_calls = "allow"
+large_enum_variant = "allow"
+missing_fields_in_debug = "allow"
+missing_errors_doc = "allow"
+cast_possible_truncation = "allow"
+cast_precision_loss = "allow"
+too_many_lines = "allow"
+format_push_string = "allow"
+fn_params_excessive_bools = "allow"
+
+[package]
+name = "dua-cli"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
 readme = "README.md"
 description = "A tool to conveniently learn about the disk usage of directories, fast!"
-license = "MIT"
+license.workspace = true
 include = [
     "src/**/*",
     "Cargo.*",
@@ -28,6 +58,7 @@ tui-crossplatform = [
 trash-move = ["trash"]
 
 [dependencies]
+dua-core = { path = "crates/dua-lib", version = "2.41.1" }
 clap = { version = "4.0.29", features = ["derive", "env"] }
 clap_complete = "4.5.54"
 byte-unit = { version = "5.2.5", features = ["u128"] }
@@ -51,7 +82,6 @@ open = { version = "5.0", optional = true }
 wild = "2.0.4"
 owo-colors = "4.0.0"
 human_format = "1.0.3"
-once_cell = "1.19"
 gix = { version = "0.86.0", default-features = false, features = [
     "excludes",
     "sha1",
@@ -62,18 +92,11 @@ fern = "0.7.1"
 jiff = "0.2.18"
 log = "0.4.20"
 log-panics = { version = "2", features = ["with-backtrace"] }
-crossbeam = "0.8"
+crossbeam.workspace = true
 toml = "1.1.4"
 serde = { version = "1.0", features = ["derive"] }
 dirs = "6"
 shlex = "2.0.1"
-
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.1", features = [
-    "Win32_Foundation",
-    "Win32_Security",
-    "Win32_Storage_FileSystem",
-] }
 
 [target.'cfg(not(windows))'.dependencies]
 filesize = "0.2.0"
@@ -95,19 +118,7 @@ build-override = { opt-level = 3 }
 
 [dev-dependencies]
 pretty_assertions = "1.0.0"
-tempfile = "3.27.0"
+tempfile.workspace = true
 
-[lints.clippy]
-all = { level = "warn", priority = -2 }
-pedantic = { level = "warn", priority = -1 }
-enum_glob_use = "allow"
-needless_pass_by_value = "allow"
-redundant_closure_for_method_calls = "allow"
-large_enum_variant = "allow"
-missing_fields_in_debug = "allow"
-missing_errors_doc = "allow"
-cast_possible_truncation = "allow"
-cast_precision_loss = "allow"
-too_many_lines = "allow"
-format_push_string = "allow"
-fn_params_excessive_bools = "allow"
+[lints]
+workspace = true

--- a/crates/dua-lib/CHANGELOG.md
+++ b/crates/dua-lib/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+The first release of the directory walk implementation of the `dua-cli`, to allow its usage in other places as well.
+
+### Commit Statistics
+
+<csr-read-only-do-not-edit/>
+
+ - 1 commit contributed to the release.
+ - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
+ - 0 issues like '(#ID)' were seen in commit messages
+
+### Commit Details
+
+<csr-read-only-do-not-edit/>
+
+<details><summary>view details</summary>
+
+ * **Uncategorized**
+    - Extract filesystem walker into dua-lib ([`3b1c8cf`](https://github.com/Byron/dua-cli/commit/3b1c8cfbf206d92f60a33049dd741251024a027f))
+</details>
+

--- a/crates/dua-lib/CHANGELOG.md
+++ b/crates/dua-lib/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 2.41.1 (2026-08-05)
 
 The first release of the directory walk implementation of the `dua-cli`, to allow its usage in other places as well.
 
@@ -13,7 +13,7 @@ The first release of the directory walk implementation of the `dua-cli`, to allo
 
 <csr-read-only-do-not-edit/>
 
- - 1 commit contributed to the release.
+ - 2 commits contributed to the release.
  - 0 commits were understood as [conventional](https://www.conventionalcommits.org).
  - 0 issues like '(#ID)' were seen in commit messages
 
@@ -24,6 +24,7 @@ The first release of the directory walk implementation of the `dua-cli`, to allo
 <details><summary>view details</summary>
 
  * **Uncategorized**
+    - Prepare changelog prior to `dua-core` release ([`965ce7c`](https://github.com/Byron/dua-cli/commit/965ce7cdbca6f4d8954e2f45d1967f4df786ddb1))
     - Extract filesystem walker into dua-lib ([`3b1c8cf`](https://github.com/Byron/dua-cli/commit/3b1c8cfbf206d92f60a33049dd741251024a027f))
 </details>
 

--- a/crates/dua-lib/Cargo.toml
+++ b/crates/dua-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dua-core"
-version.workspace = true
+version = "2.41.1"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/dua-lib/Cargo.toml
+++ b/crates/dua-lib/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "dua-core"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+description = "Fast parallel filesystem traversal iterators"
+license.workspace = true
+
+[dependencies]
+crossbeam.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.1", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+] }
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/dua-lib/src/lib.rs
+++ b/crates/dua-lib/src/lib.rs
@@ -20,12 +20,15 @@
 //! successful thief wakes another idle worker, ramping up only while work remains stealable. A
 //! worker parks when no queue has work and is unparked when new work arrives or the walk stops. The
 //! last completed job emits the finished event; dropping the iterator stops and joins all workers.
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
 
 use crossbeam::{
     deque::{Injector, Steal, Stealer, Worker},
     sync::{Parker, Unparker},
 };
 use std::{
+    collections::HashMap,
     io,
     path::{Path, PathBuf},
     sync::{
@@ -40,9 +43,7 @@ use std::{
 use std::{ffi::OsString, fs};
 
 #[cfg(not(windows))]
-use std::fs::FileType;
-#[cfg(not(windows))]
-pub(crate) use std::fs::Metadata;
+pub use std::fs::{FileType, Metadata};
 
 #[cfg(windows)]
 #[allow(unsafe_code)]
@@ -137,8 +138,10 @@ enum Event {
 /// instead of being yielded; `Finished` therefore means only that the associated root completed.
 /// [`RootWalk`] yields `(root_idx, event)`, separating root routing from event meaning. [`Event`]
 /// cannot do this uniformly because its `Finished` variant is pool-wide and has no root index.
-pub(crate) enum RootEvent {
+pub enum RootEvent {
+    /// An entry or filesystem error produced while walking the root.
     Entry(io::Result<Entry>),
+    /// All entries for the root have been emitted.
     Finished,
 }
 
@@ -153,7 +156,7 @@ struct PoolShared {
     active_roots: AtomicUsize,
     /// Number of queued or running jobs for each root index.
     /// A counter reaching zero emits that root's [`Event::RootFinished`].
-    jobs_per_root: Vec<AtomicUsize>,
+    jobs_per_root: HashMap<usize, AtomicUsize>,
     order: Order,
     /// Handles used to wake workers, indexed by worker number.
     unparkers: Vec<Unparker>,
@@ -172,7 +175,7 @@ struct Pool {
 
 /// A multi-root iterator yielding each root index with entry and per-root completion events.
 /// Unlike [`Walk`], it preserves root identity and exposes when each root finishes.
-pub(crate) struct RootWalk {
+pub struct RootWalk {
     /// Entries buffered for delivery, by root index.
     next: Vec<(usize, RootEvent)>,
     /// See [`Walk::pool`].
@@ -210,7 +213,7 @@ pub fn walk(
             let path = Arc::from(entry.path());
             let pool = start_pool(
                 threads.max(1),
-                1,
+                HashMap::from([(0, AtomicUsize::new(0))]),
                 order,
                 Arc::new(move |_, entry| descend(entry)),
             );
@@ -263,25 +266,32 @@ impl Iterator for Walk {
 
 /// Walk multiple indexed roots without following symlinks.
 /// Unlike [`walk`], this preserves each root index and yields its completion as a [`RootEvent`].
-pub(crate) fn walk_roots(
+///
+/// # Panics
+///
+/// Panics if two roots have the same index.
+pub fn walk_roots(
     roots: impl IntoIterator<Item = (usize, PathBuf)>,
     threads: usize,
     order: Order,
     descend: impl Fn(usize, &Entry) -> bool + Send + Sync + 'static,
 ) -> RootWalk {
     let roots = roots.into_iter().collect::<Vec<_>>();
-    let root_count = roots
+    let jobs_per_root = roots
         .iter()
-        .map(|(root_idx, _)| *root_idx)
-        .max()
-        .unwrap_or(0)
-        + 1;
+        .map(|(root_idx, _)| (*root_idx, AtomicUsize::new(0)))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(
+        jobs_per_root.len(),
+        roots.len(),
+        "root indices must be unique"
+    );
     let descend = Arc::new(descend);
     let (next, root_jobs) = begin_walks(roots, descend.as_ref());
     let pool = if root_jobs.is_empty() {
         None
     } else {
-        let pool = start_pool(threads.max(1), root_count, order, descend);
+        let pool = start_pool(threads.max(1), jobs_per_root, order, descend);
         start_jobs(&pool, root_jobs);
         Some(pool)
     };
@@ -363,7 +373,8 @@ impl Entry {
         self.parent_path.join(&self.file_name)
     }
 
-    fn from_path(path: &Path) -> io::Result<Self> {
+    /// Create an entry from a filesystem path.
+    pub fn from_path(path: &Path) -> io::Result<Self> {
         let metadata = fs::symlink_metadata(path)?;
         Ok(Self {
             depth: 0,
@@ -389,7 +400,12 @@ impl Entry {
     }
 }
 
-fn start_pool(threads: usize, root_count: usize, order: Order, descend: Arc<Descend>) -> Pool {
+fn start_pool(
+    threads: usize,
+    jobs_per_root: HashMap<usize, AtomicUsize>,
+    order: Order,
+    descend: Arc<Descend>,
+) -> Pool {
     let workers: Vec<_> = (0..threads).map(|_| Worker::new_lifo()).collect();
     let parkers: Vec<_> = (0..threads).map(|_| Parker::new()).collect();
     let (event_tx, event_rx) = sync_channel(threads * 2);
@@ -400,7 +416,7 @@ fn start_pool(threads: usize, root_count: usize, order: Order, descend: Arc<Desc
         descend,
         events: event_tx,
         active_roots: AtomicUsize::new(0),
-        jobs_per_root: (0..root_count).map(|_| AtomicUsize::new(0)).collect(),
+        jobs_per_root,
         order,
         unparkers: parkers
             .iter()
@@ -920,13 +936,13 @@ fn finish_directory(
 }
 
 fn add_pending(root: usize, count: usize, shared: &PoolShared) {
-    shared.jobs_per_root[root].fetch_add(count, AtomicOrdering::Relaxed);
+    shared.jobs_per_root[&root].fetch_add(count, AtomicOrdering::Relaxed);
 }
 
 /// Mark one job complete for `root`.
 /// The last job emits `RootFinished`; if this was also the last active root, `Finished` follows.
 fn finish_pending(root_idx: usize, shared: &PoolShared) {
-    if shared.jobs_per_root[root_idx].fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
+    if shared.jobs_per_root[&root_idx].fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
         shared.events.send(Event::RootFinished { root_idx }).ok();
         if shared.active_roots.fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
             shared.events.send(Event::Finished).ok();
@@ -1131,7 +1147,7 @@ mod tests {
     #[test]
     fn windows_completion_streams_metadata_before_enumeration_finishes() {
         let dir = tempfile::tempdir().unwrap();
-        for idx in 0..(ENTRY_CHUNK_SIZE + 1) {
+        for idx in 0..=ENTRY_CHUNK_SIZE {
             fs::create_dir(dir.path().join(idx.to_string())).unwrap();
         }
 

--- a/crates/dua-lib/src/windows.rs
+++ b/crates/dua-lib/src/windows.rs
@@ -1,3 +1,5 @@
+//! Windows filesystem enumeration support.
+
 use std::{
     ffi::OsString,
     io,
@@ -39,7 +41,8 @@ pub struct Entry {
 }
 
 impl Entry {
-    pub(crate) fn from_path(path: &Path) -> io::Result<Self> {
+    /// Create an entry from a filesystem path.
+    pub fn from_path(path: &Path) -> io::Result<Self> {
         let handle = OwnedHandle::open(
             path,
             FILE_READ_ATTRIBUTES | SYNCHRONIZE,
@@ -175,7 +178,9 @@ impl Metadata {
         Ok(self.modified)
     }
 
-    pub(crate) fn hard_link_id(&self) -> Option<(u64, u64)> {
+    /// Return the volume and file identifiers used to recognize hard links.
+    #[must_use]
+    pub fn hard_link_id(&self) -> Option<(u64, u64)> {
         self.file_id.map(|file_id| (self.volume_serial, file_id))
     }
 }

--- a/crates/dua-lib/tests/dua.rs
+++ b/crates/dua-lib/tests/dua.rs
@@ -1,0 +1,69 @@
+use std::{collections::BTreeSet, fs, path::PathBuf};
+
+use dua_core::{Order, RootEvent, walk, walk_roots};
+
+#[test]
+fn walkers_are_available_to_consumers() {
+    let dir = tempfile::tempdir().unwrap();
+    let roots = [dir.path().join("a"), dir.path().join("b")];
+    for root in &roots {
+        fs::create_dir_all(root.join("child")).unwrap();
+    }
+
+    let paths = walk(&roots[0], 2, Order::ParentFirst, |_| true)
+        .map(|entry| {
+            entry
+                .unwrap()
+                .path()
+                .strip_prefix(&roots[0])
+                .unwrap()
+                .into()
+        })
+        .collect::<BTreeSet<PathBuf>>();
+    assert_eq!(paths, [PathBuf::new(), PathBuf::from("child")].into());
+
+    let events = walk_roots(
+        roots.iter().cloned().enumerate(),
+        2,
+        Order::Completion,
+        |_, _| true,
+    )
+    .collect::<Vec<_>>();
+    for root_idx in 0..roots.len() {
+        let last_entry = events
+            .iter()
+            .rposition(|(idx, event)| *idx == root_idx && matches!(event, RootEvent::Entry(_)))
+            .unwrap();
+        let finished = events
+            .iter()
+            .position(|(idx, event)| *idx == root_idx && matches!(event, RootEvent::Finished))
+            .unwrap();
+        assert!(last_entry < finished);
+    }
+}
+
+#[test]
+fn sparse_root_indices_do_not_size_internal_storage() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    let events = walk_roots(
+        [(usize::MAX, file.path().to_owned())],
+        1,
+        Order::Completion,
+        |_, _| true,
+    )
+    .collect::<Vec<_>>();
+    assert!(events.iter().all(|(root_idx, _)| *root_idx == usize::MAX));
+    assert!(matches!(events.last(), Some((_, RootEvent::Finished))));
+}
+
+#[test]
+#[should_panic(expected = "root indices must be unique")]
+fn duplicate_root_indices_are_rejected() {
+    let file = tempfile::NamedTempFile::new().unwrap();
+    walk_roots(
+        [(7, file.path().to_owned()), (7, file.path().to_owned())],
+        1,
+        Order::Completion,
+        |_, _| true,
+    );
+}

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -689,7 +689,7 @@ fn delete_directory_recursively(path: PathBuf, threads: usize) -> EntryDeletionS
     let mut dirs: Vec<(PathBuf, u128, usize)> = Vec::new();
     let mut files: Vec<(PathBuf, u128)> = Vec::new();
 
-    for entry in dua::walk(&path, threads, dua::WalkOrder::Completion, |_| true) {
+    for entry in dua_core::walk(&path, threads, dua_core::Order::Completion, |_| true) {
         match entry {
             Ok(entry) => {
                 let entry_path = entry.path();

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -89,7 +89,7 @@ fn delete_recursive(path: impl AsRef<Path>) -> Result<()> {
     let mut files: Vec<_> = Vec::new();
     let mut dirs: Vec<_> = Vec::new();
 
-    for entry in dua::walk(path.as_ref(), 1, dua::WalkOrder::Completion, |_| true) {
+    for entry in dua_core::walk(path.as_ref(), 1, dua_core::Order::Completion, |_| true) {
         let entry = entry?;
         let p = entry.path();
         if entry.file_type.is_dir() {
@@ -114,7 +114,7 @@ fn delete_recursive(path: impl AsRef<Path>) -> Result<()> {
 }
 
 fn copy_recursive(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> Result<(), Error> {
-    for entry in dua::walk(src.as_ref(), 1, dua::WalkOrder::ParentFirst, |_| true) {
+    for entry in dua_core::walk(src.as_ref(), 1, dua_core::Order::ParentFirst, |_| true) {
         let entry = entry?;
         let entry_path = entry.path();
         entry_path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,7 @@ mod config;
 pub use config::Config;
 mod crossdev;
 mod inodefilter;
-mod walk;
-pub use walk::{Entry as WalkEntry, Order as WalkOrder, Walk, walk};
-#[cfg(windows)]
-pub use walk::{FileType as WalkFileType, Metadata as WalkMetadata};
+pub(crate) use dua_core as walk;
 
 /// Filesystem traversal, in-memory tree representation, and traversal events.
 pub mod traverse;


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Reported issue

Extract the `walk` and `walk_roots` iterators into the standalone `dua-lib` crate, in the `crates` subdirectory. The top-level crate becomes the workspace crate, that also consumes the new library crate.

## Summary

- turn the repository into a Cargo workspace with lockstep package metadata
- move the parallel filesystem walker and its Windows implementation into the publishable `dua-lib` crate
- expose `walk`, `walk_roots`, and their iterator/event/entry types from `dua-lib`
- consume `dua-lib` from `dua-cli` and intentionally remove the old `dua` walker re-exports
- support arbitrary sparse root indices without index-sized allocation and reject duplicate indices

## Validation

- `cargo test --workspace --all-features`
- `cargo test --workspace --no-default-features --features dua-cli/trash-move`
- `make check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace --target aarch64-pc-windows-msvc`
- `cargo clippy -p dua-lib --all-targets --target aarch64-pc-windows-msvc -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo package -p dua-lib --allow-dirty`

## Notes

- `dua-lib` must be published before a future packaged `dua-cli` release can resolve its registry dependency.
- The existing shell journey for a broken symlink root still expects failure, while current `dua` reports the symlink as a zero-byte entry; this behavior was reproduced independently and was not changed here.
- Codex review found and prompted the sparse-root-index fix. The required review of the refreshed commit ran once but exited without emitting a final verdict after completing its inspection and tests.
