### PR TITLE
fix: sanitize control characters in marked path output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,17 @@ impl Drop for InteractiveTerminalGuard {
     }
 }
 
+/// Replaces control characters (which can include terminal escape
+/// sequences) with the Unicode replacement character. A marked entry's
+/// path has no character restrictions, and is printed to the real
+/// terminal after the TUI has already released terminal control,
+/// bypassing ratatui's own protective rendering entirely.
+fn sanitize_for_display(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+        .collect()
+}
+
 fn main() -> Result<()> {
     #[cfg(feature = "tui-crossplatform")]
     use options::Command::Interactive;
@@ -176,7 +187,7 @@ fn main() -> Result<()> {
                 Ok((walk_result, paths)) => {
                     if let Some(paths) = paths {
                         for path in paths {
-                            println!("{}", path.display());
+                            println!("{}", sanitize_for_display(&path.display().to_string()));
                         }
                     }
                     walk_result.to_exit_code()

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,14 +60,17 @@ impl Drop for InteractiveTerminalGuard {
 }
 
 /// Replaces control characters (which can include terminal escape
-/// sequences) with the Unicode replacement character. A marked entry's
-/// path has no character restrictions, and is printed to the real
-/// terminal after the TUI has already released terminal control,
-/// bypassing ratatui's own protective rendering entirely.
-fn sanitize_for_display(s: &str) -> String {
-    s.chars()
-        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
-        .collect()
+/// sequences) with the Unicode replacement character if `stdout_is_terminal`.
+fn marked_path_for_output(path: &Path, stdout_is_terminal: bool) -> std::borrow::Cow<'_, str> {
+    let path = path.to_string_lossy();
+    if stdout_is_terminal {
+        path.chars()
+            .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+            .collect::<String>()
+            .into()
+    } else {
+        path
+    }
 }
 
 fn main() -> Result<()> {
@@ -186,8 +189,9 @@ fn main() -> Result<()> {
             let exit_code = match res {
                 Ok((walk_result, paths)) => {
                     if let Some(paths) = paths {
+                        let stdout_is_terminal = io::stdout().is_terminal();
                         for path in paths {
-                            println!("{}", sanitize_for_display(&path.display().to_string()));
+                            println!("{}", marked_path_for_output(&path, stdout_is_terminal));
                         }
                     }
                     walk_result.to_exit_code()
@@ -470,9 +474,25 @@ fn write_default_config_file(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{merge_traversal_args, write_default_config_file};
+    use super::{marked_path_for_output, merge_traversal_args, write_default_config_file};
     use std::fs;
     use std::path::PathBuf;
+
+    #[test]
+    fn marked_paths_are_only_sanitized_for_terminals() {
+        let path = std::path::Path::new("marked\t\x1b[31m");
+
+        assert_eq!(
+            marked_path_for_output(path, false),
+            "marked\t\x1b[31m",
+            "TAB and ESC control characters are preserved for redirected output"
+        );
+        assert_eq!(
+            marked_path_for_output(path, true),
+            "marked��[31m",
+            "TAB and ESC control characters are sanitized for terminal output"
+        );
+    }
 
     #[test]
     fn write_default_config_file_overwrites_existing_config() {


### PR DESCRIPTION
Fixes #365.

dua-cli's interactive TUI is built on ratatui, which protects the paths it renders on screen. But marking a file for deletion and then quitting prints that file's path directly to the terminal after the TUI has already released terminal control, bypassing ratatui's protective rendering entirely. A scanned file's name has no character restrictions, so a crafted file name can inject terminal escape sequences into the printed path.

Adds sanitize_for_display (src/main.rs), replacing control characters with the Unicode replacement character, applied at the sole print site for marked paths.

Verified against a file named using a raw OSC title-set escape sequence, marking it and quitting, output captured via tmux's raw pty pipe and inspected as a hex dump. Confirmed no regression with a normal file name. Full test suite (72 tests) passes.