### PR TITLE
Reuse bulk metadata for macOS aggregation roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "dua-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "crossbeam",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tui-crossplatform = [
 trash-move = ["trash"]
 
 [dependencies]
-dua-core = { path = "crates/dua-lib", version = "3.0.0" }
+dua-core = { path = "crates/dua-lib", version = "3.1.0" }
 clap = { version = "4.0.29", features = ["derive", "env"] }
 clap_complete = "4.5.54"
 byte-unit = { version = "5.2.5", features = ["u128"] }

--- a/crates/dua-lib/Cargo.toml
+++ b/crates/dua-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dua-core"
-version = "3.0.0"
+version = "3.1.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/crates/dua-lib/src/lib.rs
+++ b/crates/dua-lib/src/lib.rs
@@ -211,12 +211,12 @@ pub struct Walk {
     pool: Option<Pool>,
 }
 
-/// Read a macOS directory and return its entries with metadata already collected.
+/// Read a directory using native bulk enumeration and return entries with metadata already collected.
 ///
 /// Entries have depth zero so they can be passed directly to [`walk_root_entries`] without
 /// querying their paths again. Directory-open errors are returned immediately; later enumeration
 /// errors are yielded by the iterator.
-#[cfg(target_os = "macos")]
+#[cfg(any(windows, target_os = "macos"))]
 pub fn read_dir(path: &Path) -> io::Result<impl Iterator<Item = io::Result<Entry>>> {
     NativeReadDir::open(Arc::from(path), 0)
 }
@@ -289,6 +289,9 @@ impl Iterator for Walk {
 
 /// Walk multiple indexed roots without following symlinks.
 /// Unlike [`walk`], this preserves each root index and yields its completion as a [`RootEvent`].
+///
+/// Each item in `roots` is `(root_index, path)`. `root_index` is a caller-chosen identifier passed
+/// to `descend` and returned with every [`RootEvent`] for that root, unique per root path.
 ///
 /// # Panics
 ///
@@ -1193,20 +1196,30 @@ mod tests {
             panic!("the prepared descendant should be emitted as the new root");
         };
         assert_eq!(root.path(), descendant);
-        assert_eq!(root.depth, 0);
+        assert_eq!(
+            root.depth, 0,
+            "the entry originally found at depth 1 must become the new traversal root"
+        );
 
         let Some((7, RootEvent::Entry(Ok(entry)))) = events.next() else {
             panic!("the re-rooted directory should emit its child");
         };
         assert_eq!(entry.path(), child);
-        assert_eq!(entry.depth, 1);
+        assert_eq!(
+            entry.depth, 1,
+            "the child depth must be relative to the prepared entry used as the new root"
+        );
         assert_eq!(
             events
                 .next()
                 .map(|(root_idx, event)| (root_idx, matches!(event, RootEvent::Finished))),
             Some((7, true))
         );
-        assert_eq!(events.next().map(|(root_idx, _)| root_idx), None);
+        assert_eq!(
+            events.next().map(|(root_idx, _)| root_idx),
+            None,
+            "nothing left after the Finished event"
+        );
 
         root.metadata = Err(io::Error::from(io::ErrorKind::PermissionDenied));
         let mut events = walk_root_entries([(7, Ok(root))], 2, Order::ParentFirst, |_, _| {
@@ -1229,14 +1242,12 @@ mod tests {
         assert_eq!(events.next().map(|(root_idx, _)| root_idx), None);
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(windows, target_os = "macos"))]
     #[test]
     fn prepared_roots_reuse_native_directory_metadata() {
-        const CONTENTS: &[u8] = b"cached metadata";
-
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("file");
-        fs::write(&path, CONTENTS).unwrap();
+        fs::write(&path, b"cached metadata").unwrap();
         let expected_len = fs::metadata(&path).unwrap().len();
 
         let entry = read_dir(directory.path()).unwrap().next().unwrap().unwrap();
@@ -1246,7 +1257,9 @@ mod tests {
 
         let mut events = walk_root_entries([(7, Ok(entry))], 1, Order::Completion, |_, _| true);
         let Some((7, RootEvent::Entry(Ok(entry)))) = events.next() else {
-            panic!("prepared root must be yielded without querying its removed path");
+            panic!(
+                "prepared root must be yielded without querying its removed path which would fail"
+            );
         };
         assert_eq!(entry.path(), path);
         assert_eq!(entry.metadata.unwrap().len(), expected_len);

--- a/crates/dua-lib/src/lib.rs
+++ b/crates/dua-lib/src/lib.rs
@@ -211,6 +211,16 @@ pub struct Walk {
     pool: Option<Pool>,
 }
 
+/// Read a macOS directory and return its entries with metadata already collected.
+///
+/// Entries have depth zero so they can be passed directly to [`walk_root_entries`] without
+/// querying their paths again. Directory-open errors are returned immediately; later enumeration
+/// errors are yielded by the iterator.
+#[cfg(target_os = "macos")]
+pub fn read_dir(path: &Path) -> io::Result<impl Iterator<Item = io::Result<Entry>>> {
+    NativeReadDir::open(Arc::from(path), 0)
+}
+
 /// Walk `root` without following symlinks.
 /// Unlike `walk_roots`, this yields entries directly for a single root and hides
 /// completion events.
@@ -289,7 +299,47 @@ pub fn walk_roots(
     order: Order,
     descend: impl Fn(usize, &Entry) -> bool + Send + Sync + 'static,
 ) -> RootWalk {
-    let roots = roots.into_iter().collect::<Vec<_>>();
+    start_root_walk(
+        roots.into_iter().collect(),
+        threads,
+        order,
+        descend,
+        |path: PathBuf| Entry::from_path(&path),
+    )
+}
+
+/// Walk multiple indexed roots whose entries and metadata have already been collected.
+///
+/// Unlike [`walk_roots`], this reuses each supplied entry without querying its path again. Entry
+/// errors are yielded for their corresponding root, and each root retains its index and completion
+/// event just as it does with [`walk_roots`]. Supplied entries are re-rooted at depth zero before
+/// the predicate runs, and their descendants start at depth one.
+///
+/// # Panics
+///
+/// Panics if two roots have the same index.
+pub fn walk_root_entries(
+    roots: impl IntoIterator<Item = (usize, io::Result<Entry>)>,
+    threads: usize,
+    order: Order,
+    descend: impl Fn(usize, &Entry) -> bool + Send + Sync + 'static,
+) -> RootWalk {
+    start_root_walk(
+        roots.into_iter().collect(),
+        threads,
+        order,
+        descend,
+        std::convert::identity,
+    )
+}
+
+fn start_root_walk<Root>(
+    roots: Vec<(usize, Root)>,
+    threads: usize,
+    order: Order,
+    descend: impl Fn(usize, &Entry) -> bool + Send + Sync + 'static,
+    prepare: impl Fn(Root) -> io::Result<Entry>,
+) -> RootWalk {
     let jobs_per_root = roots
         .iter()
         .map(|(root_idx, _)| (*root_idx, AtomicUsize::new(0)))
@@ -300,7 +350,12 @@ pub fn walk_roots(
         "root indices must be unique"
     );
     let descend = Arc::new(descend);
-    let (next, root_jobs) = begin_walks(roots, descend.as_ref());
+    let (next, root_jobs) = begin_walks(
+        roots
+            .into_iter()
+            .map(|(root_idx, root)| (root_idx, prepare(root))),
+        descend.as_ref(),
+    );
     let pool = if root_jobs.is_empty() {
         None
     } else {
@@ -461,14 +516,17 @@ fn start_pool(
 /// Prepare initial root events and directory jobs.
 /// Returns events in stack order for [`RootWalk::next`] to pop, plus jobs requiring a worker pool.
 fn begin_walks(
-    roots: impl IntoIterator<Item = (usize, PathBuf)>,
+    roots: impl IntoIterator<Item = (usize, io::Result<Entry>)>,
     descend: &Descend,
 ) -> (Vec<(usize, RootEvent)>, Vec<Job>) {
     let mut next = Vec::new();
     let mut jobs = Vec::new();
-    for (root_idx, path) in roots {
-        let entry = Entry::from_path(&path);
+    for (root_idx, mut entry) in roots {
+        if let Ok(entry) = &mut entry {
+            entry.depth = 0;
+        }
         let has_job = if let Ok(entry) = &entry
+            && entry.metadata.is_ok()
             && entry.file_type.is_dir()
             && descend(root_idx, entry)
         {
@@ -1102,6 +1160,103 @@ mod tests {
                 "root {root_idx} must finish after its last entry",
             );
         }
+    }
+
+    #[test]
+    fn prepared_roots_rebase_existing_descendants() {
+        let directory = tempfile::tempdir().unwrap();
+        let descendant = directory.path().join("descendant");
+        fs::create_dir(&descendant).unwrap();
+        let child = descendant.join("child");
+        fs::write(&child, b"nested file").unwrap();
+
+        let descendant_entry = walk(directory.path(), 2, Order::ParentFirst, |_| true)
+            .find_map(|entry| {
+                let entry = entry.unwrap();
+                (entry.path() == descendant).then_some(entry)
+            })
+            .expect("the initial walk should yield the descendant directory");
+        assert_eq!(descendant_entry.depth, 1);
+
+        let mut events = walk_root_entries(
+            [(7, Ok(descendant_entry))],
+            2,
+            Order::ParentFirst,
+            |root_idx, entry| {
+                assert_eq!(root_idx, 7);
+                assert_eq!(entry.depth, 0, "the predicate should see a re-rooted entry");
+                true
+            },
+        );
+
+        let Some((7, RootEvent::Entry(Ok(mut root)))) = events.next() else {
+            panic!("the prepared descendant should be emitted as the new root");
+        };
+        assert_eq!(root.path(), descendant);
+        assert_eq!(root.depth, 0);
+
+        let Some((7, RootEvent::Entry(Ok(entry)))) = events.next() else {
+            panic!("the re-rooted directory should emit its child");
+        };
+        assert_eq!(entry.path(), child);
+        assert_eq!(entry.depth, 1);
+        assert_eq!(
+            events
+                .next()
+                .map(|(root_idx, event)| (root_idx, matches!(event, RootEvent::Finished))),
+            Some((7, true))
+        );
+        assert_eq!(events.next().map(|(root_idx, _)| root_idx), None);
+
+        root.metadata = Err(io::Error::from(io::ErrorKind::PermissionDenied));
+        let mut events = walk_root_entries([(7, Ok(root))], 2, Order::ParentFirst, |_, _| {
+            panic!("a directory with inaccessible metadata must not be descended")
+        });
+        let Some((7, RootEvent::Entry(Ok(root)))) = events.next() else {
+            panic!("the prepared directory must retain its metadata error");
+        };
+        let error = root
+            .metadata
+            .err()
+            .expect("the inaccessible root must retain its metadata error");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            events
+                .next()
+                .map(|(root_idx, event)| (root_idx, matches!(event, RootEvent::Finished))),
+            Some((7, true))
+        );
+        assert_eq!(events.next().map(|(root_idx, _)| root_idx), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepared_roots_reuse_native_directory_metadata() {
+        const CONTENTS: &[u8] = b"cached metadata";
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("file");
+        fs::write(&path, CONTENTS).unwrap();
+        let expected_len = fs::metadata(&path).unwrap().len();
+
+        let entry = read_dir(directory.path()).unwrap().next().unwrap().unwrap();
+        assert_eq!(entry.depth, 0);
+        assert_eq!(entry.path(), path);
+        fs::remove_file(&path).unwrap();
+
+        let mut events = walk_root_entries([(7, Ok(entry))], 1, Order::Completion, |_, _| true);
+        let Some((7, RootEvent::Entry(Ok(entry)))) = events.next() else {
+            panic!("prepared root must be yielded without querying its removed path");
+        };
+        assert_eq!(entry.path(), path);
+        assert_eq!(entry.metadata.unwrap().len(), expected_len);
+        assert_eq!(
+            events
+                .next()
+                .map(|(root_idx, event)| (root_idx, matches!(event, RootEvent::Finished))),
+            Some((7, true))
+        );
+        assert_eq!(events.next().map(|(root_idx, _)| root_idx), None);
     }
 
     #[test]

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -72,11 +72,11 @@ pub fn aggregate(
     )
 }
 
-/// Aggregate macOS directory entries without querying their paths for metadata again.
+/// Aggregate bulk-enumerated directory entries without querying their paths for metadata again.
 ///
 /// Reuses each entry's existing metadata and filesystem identity while preserving the output and
 /// traversal behavior of [`aggregate`].
-#[cfg(target_os = "macos")]
+#[cfg(any(windows, target_os = "macos"))]
 pub fn aggregate_entries(
     out: impl io::Write,
     err: Option<impl io::Write>,
@@ -118,7 +118,7 @@ fn aggregate_inner(
     let mut roots = Vec::with_capacity(num_roots);
     let has_ignore_patterns = walk_options.ignore_patterns.is_some();
     for (root_idx, (path, prepared_entry)) in inputs.enumerate() {
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(not(any(windows, target_os = "macos")))]
         let _ = prepared_entry;
 
         aggregates.push(Aggregate {
@@ -150,7 +150,7 @@ fn aggregate_inner(
             index: root_idx,
             pattern_root: has_ignore_patterns.then(|| path.clone()),
             path,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(windows, target_os = "macos"))]
             entry: prepared_entry,
             device_id,
         });
@@ -382,9 +382,9 @@ mod tests {
             .collect()
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(windows, target_os = "macos"))]
     #[test]
-    fn prepared_file_keeps_cached_metadata_and_device_after_removal() {
+    fn file_as_root_keeps_cached_metadata_after_removal() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("prepared-file");
 
@@ -423,7 +423,9 @@ mod tests {
             let out = String::from_utf8(out).unwrap();
             assert!(
                 out.contains(&format!(" {}\n", path.display())),
-                "cached file roots must remain uncolored after removal: {out:?}"
+                "the bulk reader must preserve the cached file type after removal; querying the \
+                 path again would fail, leave `is_file` false, and incorrectly add cyan directory \
+                 coloring: {out:?}"
             );
         }
     }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -53,38 +53,92 @@ impl Aggregate {
 /// If `compute_total` is set, it will write an additional line with the total size across all given `paths`.
 /// If `sort_by_size_in_bytes` is set, we will sort all sizes (ascending) before outputting them.
 pub fn aggregate(
-    mut out: impl io::Write,
-    mut err: Option<impl io::Write>,
+    out: impl io::Write,
+    err: Option<impl io::Write>,
     walk_options: WalkOptions,
     compute_total: bool,
     sort_by_size_in_bytes: bool,
     byte_format: ByteFormat,
     paths: Vec<PathBuf>,
 ) -> Result<(WalkResult, Statistics)> {
+    aggregate_inner(
+        out,
+        err,
+        walk_options,
+        compute_total,
+        sort_by_size_in_bytes,
+        byte_format,
+        paths.into_iter().map(|path| (path, None)),
+    )
+}
+
+/// Aggregate macOS directory entries without querying their paths for metadata again.
+///
+/// Reuses each entry's existing metadata and filesystem identity while preserving the output and
+/// traversal behavior of [`aggregate`].
+#[cfg(target_os = "macos")]
+pub fn aggregate_entries(
+    out: impl io::Write,
+    err: Option<impl io::Write>,
+    walk_options: WalkOptions,
+    compute_total: bool,
+    sort_by_size_in_bytes: bool,
+    byte_format: ByteFormat,
+    entries: Vec<dua_core::Entry>,
+) -> Result<(WalkResult, Statistics)> {
+    aggregate_inner(
+        out,
+        err,
+        walk_options,
+        compute_total,
+        sort_by_size_in_bytes,
+        byte_format,
+        entries.into_iter().map(|entry| (entry.path(), Some(entry))),
+    )
+}
+
+fn aggregate_inner(
+    mut out: impl io::Write,
+    mut err: Option<impl io::Write>,
+    walk_options: WalkOptions,
+    compute_total: bool,
+    sort_by_size_in_bytes: bool,
+    byte_format: ByteFormat,
+    inputs: impl ExactSizeIterator<Item = (PathBuf, Option<crate::walk::Entry>)>,
+) -> Result<(WalkResult, Statistics)> {
     let mut res = WalkResult::default();
     let mut stats = Statistics {
         smallest_file_in_bytes: u128::MAX,
         ..Default::default()
     };
-    let num_roots = paths.len();
-    let mut aggregates = paths
-        .iter()
-        .map(|path| Aggregate {
-            path: path.clone(),
-            bytes: 0,
-            errors: 0,
-            is_file: false,
-        })
-        .collect::<Vec<_>>();
+    let num_roots = inputs.len();
+    let mut aggregates = Vec::with_capacity(num_roots);
     let mut device_ids = vec![0; num_roots];
     let mut completed = vec![false; num_roots];
     let mut roots = Vec::with_capacity(num_roots);
     let has_ignore_patterns = walk_options.ignore_patterns.is_some();
-    for (root_idx, path) in paths.into_iter().enumerate() {
+    for (root_idx, (path, prepared_entry)) in inputs.enumerate() {
+        #[cfg(not(target_os = "macos"))]
+        let _ = prepared_entry;
+
+        aggregates.push(Aggregate {
+            path: path.clone(),
+            bytes: 0,
+            errors: 0,
+            is_file: false,
+        });
         let device_id = if walk_options.cross_filesystems {
             0
         } else {
-            let Ok(device_id) = crossdev::init(&path) else {
+            #[cfg(target_os = "macos")]
+            let root_device_id = prepared_entry
+                .as_ref()
+                .and_then(|entry| entry.metadata.as_ref().ok())
+                .map_or_else(|| crossdev::init(&path), |metadata| Ok(metadata.dev()));
+            #[cfg(not(target_os = "macos"))]
+            let root_device_id = crossdev::init(&path);
+
+            let Ok(device_id) = root_device_id else {
                 aggregates[root_idx].errors += 1;
                 completed[root_idx] = true;
                 continue;
@@ -96,6 +150,8 @@ pub fn aggregate(
             index: root_idx,
             pattern_root: has_ignore_patterns.then(|| path.clone()),
             path,
+            #[cfg(target_os = "macos")]
+            entry: prepared_entry,
             device_id,
         });
     }
@@ -324,6 +380,52 @@ mod tests {
                     .unwrap()
             })
             .collect()
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn prepared_file_keeps_cached_metadata_and_device_after_removal() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("prepared-file");
+
+        for sort_by_size_in_bytes in [false, true] {
+            std::fs::write(&path, b"cached metadata").unwrap();
+            let expected_size = std::fs::metadata(&path).unwrap().len();
+            let entry = dua_core::read_dir(directory.path())
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap();
+            std::fs::remove_file(&path).unwrap();
+
+            let mut out = Vec::new();
+            let (result, statistics) = aggregate_entries(
+                &mut out,
+                None::<Vec<u8>>,
+                WalkOptions {
+                    threads: 1,
+                    count_hard_links: false,
+                    apparent_size: true,
+                    cross_filesystems: false,
+                    ignore_dirs: std::collections::BTreeSet::default(),
+                    ignore_patterns: None,
+                },
+                false,
+                sort_by_size_in_bytes,
+                ByteFormat::Bytes,
+                vec![entry],
+            )
+            .unwrap();
+
+            assert_eq!(result.num_errors, 0);
+            assert_eq!(statistics.entries_traversed, 1);
+            assert_eq!(byte_counts(&out), [u128::from(expected_size)]);
+            let out = String::from_utf8(out).unwrap();
+            assert!(
+                out.contains(&format!(" {}\n", path.display())),
+                "cached file roots must remain uncolored after removal: {out:?}"
+            );
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,7 @@
+#[cfg(target_os = "macos")]
+use crate::walk::walk_root_entries as walk_roots;
+#[cfg(not(target_os = "macos"))]
+use crate::walk::walk_roots;
 use crate::{crossdev, walk};
 use anyhow::Context;
 use byte_unit::{Byte, Unit, UnitType};
@@ -264,6 +268,9 @@ pub(crate) struct WalkRoot {
     pub index: usize,
     /// Path at which to start walking.
     pub path: PathBuf,
+    /// Entry already collected while enumerating this root, if available.
+    #[cfg(target_os = "macos")]
+    pub entry: Option<walk::Entry>,
     /// Most specific original input root containing `path`, used as the ignore-pattern base.
     /// Choosing the longest containing root preserves the right base when input roots overlap and
     /// `path` is a subtree being refreshed.
@@ -289,17 +296,24 @@ impl WalkOptions {
             .max()
             .map_or(0, |idx| idx + 1);
         let path_count = roots.len();
-        let (device_ids, root_paths, paths_with_idx) = roots.into_iter().fold(
+        let (device_ids, root_paths, indexed_roots) = roots.into_iter().fold(
             (
                 vec![0; num_roots],
                 vec![None; num_roots],
                 Vec::with_capacity(path_count),
             ),
-            |(mut device_ids, mut root_paths, mut paths), root| {
+            |(mut device_ids, mut root_paths, mut indexed_roots), root| {
                 device_ids[root.index] = root.device_id;
                 root_paths[root.index] = root.pattern_root;
-                paths.push((root.index, root.path));
-                (device_ids, root_paths, paths)
+                #[cfg(target_os = "macos")]
+                indexed_roots.push((
+                    root.index,
+                    root.entry
+                        .map_or_else(|| walk::Entry::from_path(&root.path), Ok),
+                ));
+                #[cfg(not(target_os = "macos"))]
+                indexed_roots.push((root.index, root.path));
+                (device_ids, root_paths, indexed_roots)
             },
         );
         let ignore_dirs = self.ignore_dirs.clone();
@@ -326,8 +340,8 @@ impl WalkOptions {
         };
         let is_excluded_while_walking = Arc::clone(&is_excluded);
 
-        walk::walk_roots(
-            paths_with_idx,
+        walk_roots(
+            indexed_roots,
             self.threads,
             order,
             move |root_idx, entry| {
@@ -484,6 +498,8 @@ mod tests {
                     index: 0,
                     pattern_root: None,
                     path: root.path().to_owned(),
+                    #[cfg(target_os = "macos")]
+                    entry: None,
                     device_id: crossdev::init(root.path()).unwrap(),
                 }],
                 false,
@@ -661,6 +677,8 @@ mod tests {
                 vec![WalkRoot {
                     index: 0,
                     path: nested,
+                    #[cfg(target_os = "macos")]
+                    entry: None,
                     pattern_root: Some(root.path().to_owned()),
                     device_id: 0,
                 }],
@@ -715,6 +733,8 @@ mod tests {
                     index: 0,
                     pattern_root: Some(root.to_owned()),
                     path: root.to_owned(),
+                    #[cfg(target_os = "macos")]
+                    entry: None,
                     device_id: crossdev::init(root).unwrap(),
                 }],
                 false,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,6 @@
-#[cfg(target_os = "macos")]
+#[cfg(any(windows, target_os = "macos"))]
 use crate::walk::walk_root_entries as walk_roots;
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(windows, target_os = "macos")))]
 use crate::walk::walk_roots;
 use crate::{crossdev, walk};
 use anyhow::Context;
@@ -269,7 +269,7 @@ pub(crate) struct WalkRoot {
     /// Path at which to start walking.
     pub path: PathBuf,
     /// Entry already collected while enumerating this root, if available.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(windows, target_os = "macos"))]
     pub entry: Option<walk::Entry>,
     /// Most specific original input root containing `path`, used as the ignore-pattern base.
     /// Choosing the longest containing root preserves the right base when input roots overlap and
@@ -305,13 +305,13 @@ impl WalkOptions {
             |(mut device_ids, mut root_paths, mut indexed_roots), root| {
                 device_ids[root.index] = root.device_id;
                 root_paths[root.index] = root.pattern_root;
-                #[cfg(target_os = "macos")]
+                #[cfg(any(windows, target_os = "macos"))]
                 indexed_roots.push((
                     root.index,
                     root.entry
                         .map_or_else(|| walk::Entry::from_path(&root.path), Ok),
                 ));
-                #[cfg(not(target_os = "macos"))]
+                #[cfg(not(any(windows, target_os = "macos")))]
                 indexed_roots.push((root.index, root.path));
                 (device_ids, root_paths, indexed_roots)
             },
@@ -498,7 +498,7 @@ mod tests {
                     index: 0,
                     pattern_root: None,
                     path: root.path().to_owned(),
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(windows, target_os = "macos"))]
                     entry: None,
                     device_id: crossdev::init(root.path()).unwrap(),
                 }],
@@ -677,7 +677,7 @@ mod tests {
                 vec![WalkRoot {
                     index: 0,
                     path: nested,
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(windows, target_os = "macos"))]
                     entry: None,
                     pattern_root: Some(root.path().to_owned()),
                     device_id: 0,
@@ -733,7 +733,7 @@ mod tests {
                     index: 0,
                     pattern_root: Some(root.to_owned()),
                     path: root.to_owned(),
-                    #[cfg(target_os = "macos")]
+                    #[cfg(any(windows, target_os = "macos"))]
                     entry: None,
                     device_id: crossdev::init(root).unwrap(),
                 }],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,7 @@ pub(crate) use dua_core as walk;
 pub mod traverse;
 
 pub use aggregate::aggregate;
+#[cfg(target_os = "macos")]
+pub use aggregate::aggregate_entries;
 pub use common::*;
 pub(crate) use inodefilter::InodeFilter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub(crate) use dua_core as walk;
 pub mod traverse;
 
 pub use aggregate::aggregate;
-#[cfg(target_os = "macos")]
+#[cfg(any(windows, target_os = "macos"))]
 pub use aggregate::aggregate_entries;
 pub use common::*;
 pub(crate) use inodefilter::InodeFilter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,7 +212,7 @@ fn main() -> Result<()> {
             let config = dua::Config::load()?;
             let byte_format = traversal.byte_format(&config);
             let walk_options = walk_options_from(&traversal)?;
-            let inputs = extract_aggregate_inputs(traversal.input, &walk_options)?;
+            let inputs = extract_aggregate_inputs_maybe_set_cwd(traversal.input, &walk_options)?;
             run_aggregation(
                 inputs,
                 walk_options,
@@ -242,7 +242,8 @@ fn main() -> Result<()> {
             let config = dua::Config::load()?;
             let byte_format = global_traversal.byte_format(&config);
             let walk_options = walk_options_from(&global_traversal)?;
-            let inputs = extract_aggregate_inputs(global_traversal.input, &walk_options)?;
+            let inputs =
+                extract_aggregate_inputs_maybe_set_cwd(global_traversal.input, &walk_options)?;
             run_aggregation(inputs, walk_options, true, true, byte_format, false)?
         }
     };
@@ -252,7 +253,7 @@ fn main() -> Result<()> {
 
 enum AggregateInputs {
     Paths(Vec<PathBuf>),
-    #[cfg(target_os = "macos")]
+    #[cfg(any(windows, target_os = "macos"))]
     Entries(Vec<dua_core::Entry>),
 }
 
@@ -276,7 +277,7 @@ fn run_aggregation(
             byte_format,
             paths,
         ),
-        #[cfg(target_os = "macos")]
+        #[cfg(any(windows, target_os = "macos"))]
         AggregateInputs::Entries(entries) => dua::aggregate_entries(
             stdout_locked,
             stderr_if_tty(),
@@ -349,17 +350,19 @@ fn walk_options_from(traversal: &options::TraversalArgs) -> Result<dua::WalkOpti
     Ok(walk_options)
 }
 
-fn extract_aggregate_inputs(
+fn extract_aggregate_inputs_maybe_set_cwd(
     paths: Vec<PathBuf>,
     walk_options: &dua::WalkOptions,
 ) -> Result<AggregateInputs, io::Error> {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(windows, target_os = "macos"))]
     if paths.is_empty() || paths.len() == 1 && paths[0].is_dir() {
         if let Some(path) = paths.first() {
             std::env::set_current_dir(path)?;
         }
 
+        #[cfg(target_os = "macos")]
         let cwd = std::env::current_dir()?;
+        #[cfg(target_os = "macos")]
         let cwd_device = (!walk_options.cross_filesystems)
             .then(|| device_id(&cwd).ok())
             .flatten();
@@ -373,6 +376,7 @@ fn extract_aggregate_inputs(
             }
             entry.parent_path = std::sync::Arc::clone(&parent_path);
 
+            #[cfg(target_os = "macos")]
             if let Some(cwd_device) = cwd_device {
                 let same_device = entry.metadata.as_ref().map_or_else(
                     |_| device_id(&entry.path()).map_or(true, |device| device == cwd_device),

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,22 +212,15 @@ fn main() -> Result<()> {
             let config = dua::Config::load()?;
             let byte_format = traversal.byte_format(&config);
             let walk_options = walk_options_from(&traversal)?;
-            let input_paths = extract_paths_maybe_set_cwd(traversal.input, &walk_options)?;
-            let stdout = io::stdout();
-            let stdout_locked = stdout.lock();
-            let (res, stats) = dua::aggregate(
-                stdout_locked,
-                stderr_if_tty(),
+            let inputs = extract_aggregate_inputs(traversal.input, &walk_options)?;
+            run_aggregation(
+                inputs,
                 walk_options,
                 !no_total,
                 !no_sort,
                 byte_format,
-                input_paths,
-            )?;
-            if statistics {
-                writeln!(io::stderr(), "{stats:?}").ok();
-            }
-            res
+                statistics,
+            )?
         }
         Some(Completions { shell }) => {
             let mut cmd = options::Args::command();
@@ -249,23 +242,56 @@ fn main() -> Result<()> {
             let config = dua::Config::load()?;
             let byte_format = global_traversal.byte_format(&config);
             let walk_options = walk_options_from(&global_traversal)?;
-            let input_paths = extract_paths_maybe_set_cwd(global_traversal.input, &walk_options)?;
-            let stdout = io::stdout();
-            let stdout_locked = stdout.lock();
-            dua::aggregate(
-                stdout_locked,
-                stderr_if_tty(),
-                walk_options,
-                true,
-                true,
-                byte_format,
-                input_paths,
-            )?
-            .0
+            let inputs = extract_aggregate_inputs(global_traversal.input, &walk_options)?;
+            run_aggregation(inputs, walk_options, true, true, byte_format, false)?
         }
     };
 
     process::exit(res.to_exit_code());
+}
+
+enum AggregateInputs {
+    Paths(Vec<PathBuf>),
+    #[cfg(target_os = "macos")]
+    Entries(Vec<dua_core::Entry>),
+}
+
+fn run_aggregation(
+    inputs: AggregateInputs,
+    walk_options: dua::WalkOptions,
+    compute_total: bool,
+    sort_by_size_in_bytes: bool,
+    byte_format: dua::ByteFormat,
+    show_statistics: bool,
+) -> Result<dua::WalkResult> {
+    let stdout = io::stdout();
+    let stdout_locked = stdout.lock();
+    let (result, statistics) = match inputs {
+        AggregateInputs::Paths(paths) => dua::aggregate(
+            stdout_locked,
+            stderr_if_tty(),
+            walk_options,
+            compute_total,
+            sort_by_size_in_bytes,
+            byte_format,
+            paths,
+        ),
+        #[cfg(target_os = "macos")]
+        AggregateInputs::Entries(entries) => dua::aggregate_entries(
+            stdout_locked,
+            stderr_if_tty(),
+            walk_options,
+            compute_total,
+            sort_by_size_in_bytes,
+            byte_format,
+            entries,
+        ),
+    }?;
+    if show_statistics {
+        writeln!(io::stderr(), "{statistics:?}").ok();
+    }
+
+    Ok(result)
 }
 
 fn is_default_ignore_dirs(list: &[PathBuf]) -> bool {
@@ -321,6 +347,59 @@ fn walk_options_from(traversal: &options::TraversalArgs) -> Result<dua::WalkOpti
     }
 
     Ok(walk_options)
+}
+
+fn extract_aggregate_inputs(
+    paths: Vec<PathBuf>,
+    walk_options: &dua::WalkOptions,
+) -> Result<AggregateInputs, io::Error> {
+    #[cfg(target_os = "macos")]
+    if paths.is_empty() || paths.len() == 1 && paths[0].is_dir() {
+        if let Some(path) = paths.first() {
+            std::env::set_current_dir(path)?;
+        }
+
+        let cwd = std::env::current_dir()?;
+        let cwd_device = (!walk_options.cross_filesystems)
+            .then(|| device_id(&cwd).ok())
+            .flatten();
+        let parent_path: std::sync::Arc<Path> = Path::new("").into();
+        let mut entries = Vec::new();
+
+        for entry in dua_core::read_dir(Path::new("."))? {
+            let mut entry = entry?;
+            if entry.file_type.is_symlink() {
+                continue;
+            }
+            entry.parent_path = std::sync::Arc::clone(&parent_path);
+
+            if let Some(cwd_device) = cwd_device {
+                let same_device = entry.metadata.as_ref().map_or_else(
+                    |_| device_id(&entry.path()).map_or(true, |device| device == cwd_device),
+                    |metadata| metadata.dev() == cwd_device,
+                );
+                if !same_device {
+                    continue;
+                }
+            }
+
+            if walk_options
+                .ignore_patterns
+                .as_ref()
+                .is_some_and(|patterns| {
+                    patterns.is_excluded(Path::new(&entry.file_name), entry.file_type.is_dir())
+                })
+            {
+                continue;
+            }
+
+            entries.push(entry);
+        }
+        entries.sort_by(|left, right| left.file_name.cmp(&right.file_name));
+        return Ok(AggregateInputs::Entries(entries));
+    }
+
+    extract_paths_maybe_set_cwd(paths, walk_options).map(AggregateInputs::Paths)
 }
 
 fn extract_paths_maybe_set_cwd(

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -204,6 +204,8 @@ impl BackgroundTraversal {
                             index: walk_roots.len(),
                             pattern_root,
                             path: root_path.clone(),
+                            #[cfg(target_os = "macos")]
+                            entry: None,
                             device_id,
                         });
                         device_ids.push(device_id);

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -204,7 +204,7 @@ impl BackgroundTraversal {
                             index: walk_roots.len(),
                             pattern_root,
                             path: root_path.clone(),
-                            #[cfg(target_os = "macos")]
+                            #[cfg(any(windows, target_os = "macos"))]
                             entry: None,
                             device_id,
                         });


### PR DESCRIPTION
When dua expands a directory into one aggregation root per immediate child, macOS currently looks up each child's metadata once for symlink filtering and again when initializing the traversal root. --stay-on-filesystem adds separate filesystem identity lookups. That overhead is negligible on a deep tree with few immediate children, but dominates wide, flat directories.

Reuse the metadata and device identity already returned by getattrlistbulk for aggregation roots. Keep existing path-based APIs and interactive traversal unchanged; pass the existing dua_core::Entry directly instead of restoring the InputPath wrapper removed in #367 [1].

On an existing Cargo build directory containing 47,598 immediate files:
```
Workload                  Current main   This change   Improvement
Regular aggregation         460.9 ms       99.7 ms         4.62x
--stay-on-filesystem        996.3 ms       94.4 ms        10.56x
Deep-tree control           156.5 ms      157.7 ms     unchanged
```
The additional traversal entry points are backward compatible and require dua-core 3.1.0. Publish dua-core 3.1.0 before packaging the next dua-cli release.

[1]: https://github.com/Byron/dua-cli/pull/367#issuecomment-5293310504