### PR TITLE
Apply --ignore-dirs to paths dua expanded into roots itself

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -411,6 +411,10 @@ fn extract_paths_maybe_set_cwd(
     walk_options: &dua::WalkOptions,
 ) -> Result<Vec<PathBuf>, io::Error> {
     let cross_filesystems = walk_options.cross_filesystems;
+    // Paths were explicitly passed by the user on the command-line; per `--ignore-dirs`'s
+    // documented behavior, these are never subject to `-i`/`--ignore-dirs` filtering, only
+    // paths that we ourselves expand into roots below are.
+    let paths_were_expanded = paths.is_empty() || (paths.len() == 1 && paths[0].is_dir());
     if paths.len() == 1 && paths[0].is_dir() {
         std::env::set_current_dir(&paths[0])?;
         paths.clear();
@@ -439,6 +443,15 @@ fn extract_paths_maybe_set_cwd(
                 .ignore_patterns
                 .as_ref()
                 .is_none_or(|patterns| !patterns.excludes_input_path(path, &cwd))
+        })
+        .filter(|path| {
+            // Only paths we expanded into roots ourselves are eligible for --ignore-dirs here,
+            // explicitly passed top-level paths are never ignored.
+            if !paths_were_expanded || walk_options.ignore_dirs.is_empty() {
+                return true;
+            }
+            !gix::path::realpath_opts(path, &cwd, 32)
+                .is_ok_and(|real| walk_options.ignore_dirs.contains(&real))
         })
         .collect())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -445,13 +445,12 @@ fn extract_paths_maybe_set_cwd(
                 .is_none_or(|patterns| !patterns.excludes_input_path(path, &cwd))
         })
         .filter(|path| {
-            // Only paths we expanded into roots ourselves are eligible for --ignore-dirs here,
-            // explicitly passed top-level paths are never ignored.
             if !paths_were_expanded || walk_options.ignore_dirs.is_empty() {
                 return true;
             }
-            !gix::path::realpath_opts(path, &cwd, 32)
-                .is_ok_and(|real| walk_options.ignore_dirs.contains(&real))
+            let is_ignored = gix::path::realpath_opts(path, &cwd, 32)
+                .is_ok_and(|real| walk_options.ignore_dirs.contains(&real));
+            !is_ignored
         })
         .collect())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,7 +360,6 @@ fn extract_aggregate_inputs_maybe_set_cwd(
             std::env::set_current_dir(path)?;
         }
 
-        #[cfg(target_os = "macos")]
         let cwd = std::env::current_dir()?;
         #[cfg(target_os = "macos")]
         let cwd_device = (!walk_options.cross_filesystems)
@@ -393,6 +392,12 @@ fn extract_aggregate_inputs_maybe_set_cwd(
                 .is_some_and(|patterns| {
                     patterns.is_excluded(Path::new(&entry.file_name), entry.file_type.is_dir())
                 })
+            {
+                continue;
+            }
+
+            if gix::path::realpath_opts(&entry.path(), &cwd, 32)
+                .is_ok_and(|path| walk_options.ignore_dirs.contains(&path))
             {
                 continue;
             }

--- a/tests/snapshots/success-ignore-dirs-below-given-path
+++ b/tests/snapshots/success-ignore-dirs-below-given-path
@@ -1,0 +1,5 @@
+[32m <SIZE> B[39m b.empty
+[32m <SIZE> KB[39m .hidden.666
+[32m <SIZE> KB[39m a
+[32m <SIZE> KB[39m z123.b
+[32m <SIZE> KB[39m total

--- a/tests/snapshots/success-ignore-dirs-given-explicitly
+++ b/tests/snapshots/success-ignore-dirs-given-explicitly
@@ -1,0 +1,3 @@
+[32m <SIZE> KB[39m ./a
+[32m <SIZE> MB[39m [36m./dir[39m
+[32m <SIZE> MB[39m total

--- a/tests/stateless-journey.sh
+++ b/tests/stateless-journey.sh
@@ -51,6 +51,18 @@ WITH_FAILURE=1
           )
         )
       )
+      (with "--ignore-dirs naming a directory below the given one"
+        (when "specifying the 'aggregate' subcommand"
+          it "leaves that directory out, even though it was reached by expanding the given path" && {
+            WITH_SNAPSHOT="$snapshot/success-ignore-dirs-below-given-path" \
+            expect_run ${SUCCESSFULLY} "$exe" aggregate -i "$PWD/dir" .
+          }
+          it "still measures a directory named by --ignore-dirs when it is given explicitly" && {
+            WITH_SNAPSHOT="$snapshot/success-ignore-dirs-given-explicitly" \
+            expect_run ${SUCCESSFULLY} "$exe" aggregate -i "$PWD/dir" ./dir ./a
+          }
+        )
+      )
       (with "multiple given paths"
         (when "specifying the 'aggregate' subcommand"
           (with "no option to adjust the total"


### PR DESCRIPTION
## What's broken

`--ignore-dirs` has no effect when you pass a single directory, which is the common invocation. The help text says these paths "will only be ignored if they are eventually reached as part of the traversal", and the ignored directory is reached, but it is still measured.

## Repro

```
$ dua aggregate -i /tmp/duatest/root1/ignoreme /tmp/duatest/root1
   12.00 KiB keep
   56.00 KiB ignoreme
   68.00 KiB total
```

Passing two roots instead works, which is what pointed at the cause.

## The fix

Given zero or one directory, `extract_paths_maybe_set_cwd` chdirs into it and expands its children into independent traversal roots. Roots are deliberately exempt from the `-i` check in `common.rs`, since an explicitly passed path should never be ignored. Children promoted to roots by that expansion inherit the exemption they were never meant to have.

The filter now applies to expanded paths only, alongside the existing `ignore_patterns` filter in the same place, and short-circuits when `ignore_dirs` is empty so the common case costs nothing. Explicitly passed paths keep the documented behaviour: `dua aggregate -i /x /x` still measures `/x`.

This also affects `dua i`, which goes through the same function.

## Verification

Two cases in `tests/stateless-journey.sh` with snapshots: a directory below the given path is dropped, and the same directory named explicitly is still measured. Both snapshots fail without the change, the first one showing `dir` back in the output. `cargo test --all` and the journey suite pass.

I put these in the journey suite rather than as unit tests on purpose. The function changes the process' current directory, and a unit test doing that raced `journeys_readonly::once_waits_for_replayed_refresh_to_finish` under the parallel runner, failing about one run in five.
