### PR TITLE
Skip path resolution without ignored directories

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -288,7 +288,7 @@ pub(crate) struct WalkRoot {
 impl WalkOptions {
     /// Return whether `path`, resolved relative to `cwd`, names an ignored directory.
     #[must_use]
-    pub fn ignores_directory(&self, path: &Path, cwd: &Path) -> bool {
+    pub fn is_ignored_directory(&self, path: &Path, cwd: &Path) -> bool {
         ignore_directory(path, &self.ignore_dirs, cwd)
     }
 
@@ -443,8 +443,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ignore_directories() {
+    fn walk_options_identify_ignored_directories() {
         let cwd = std::env::current_dir().unwrap();
+        let mut options = WalkOptions {
+            threads: 1,
+            count_hard_links: false,
+            apparent_size: false,
+            cross_filesystems: true,
+            ignore_dirs: BTreeSet::new(),
+            ignore_patterns: None,
+            metadata_options: crate::TraversalOptions::default(),
+        };
         #[cfg(unix)]
         let mut parameters = vec![
             ("/usr", vec!["/usr"], true),
@@ -474,19 +483,21 @@ mod tests {
         ];
 
         parameters.extend([
+            ("src", vec![], false),
             ("src", vec!["src"], true),
             ("src/interactive", vec!["src"], false),
             ("src/interactive/..", vec!["src"], true),
         ]);
 
         for (path, ignore_dirs, expected_result) in parameters {
-            let ignore_dirs = canonicalize_ignore_dirs(
+            options.ignore_dirs = canonicalize_ignore_dirs(
                 &ignore_dirs.into_iter().map(Into::into).collect::<Vec<_>>(),
             );
             assert_eq!(
-                ignore_directory(path.as_ref(), &ignore_dirs, &cwd),
+                options.is_ignored_directory(path.as_ref(), &cwd),
                 expected_result,
-                "result='{expected_result}' for path='{path}' and ignore_dir='{ignore_dirs:?}' "
+                "result='{expected_result}' for path='{path}' and ignore_dir='{:?}' ",
+                options.ignore_dirs
             );
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -286,6 +286,12 @@ pub(crate) struct WalkRoot {
 }
 
 impl WalkOptions {
+    /// Return whether `path`, resolved relative to `cwd`, names an ignored directory.
+    #[must_use]
+    pub fn ignores_directory(&self, path: &Path, cwd: &Path) -> bool {
+        ignore_directory(path, &self.ignore_dirs, cwd)
+    }
+
     pub(crate) fn iter_from_paths(
         &self,
         roots: Vec<WalkRoot>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,7 +405,7 @@ fn extract_aggregate_inputs_maybe_set_cwd(
                 continue;
             }
 
-            if walk_options.ignores_directory(Path::new(&entry.file_name), &cwd) {
+            if walk_options.is_ignored_directory(Path::new(&entry.file_name), &cwd) {
                 continue;
             }
 
@@ -456,7 +456,7 @@ fn extract_paths_maybe_set_cwd(
                 .as_ref()
                 .is_none_or(|patterns| !patterns.excludes_input_path(path, &cwd))
         })
-        .filter(|path| !paths_were_expanded || !walk_options.ignores_directory(path, &cwd))
+        .filter(|path| !paths_were_expanded || !walk_options.is_ignored_directory(path, &cwd))
         .collect())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,9 +405,7 @@ fn extract_aggregate_inputs_maybe_set_cwd(
                 continue;
             }
 
-            if gix::path::realpath_opts(&entry.path(), &cwd, 32)
-                .is_ok_and(|path| walk_options.ignore_dirs.contains(&path))
-            {
+            if walk_options.ignores_directory(Path::new(&entry.file_name), &cwd) {
                 continue;
             }
 
@@ -458,14 +456,7 @@ fn extract_paths_maybe_set_cwd(
                 .as_ref()
                 .is_none_or(|patterns| !patterns.excludes_input_path(path, &cwd))
         })
-        .filter(|path| {
-            if !paths_were_expanded || walk_options.ignore_dirs.is_empty() {
-                return true;
-            }
-            let is_ignored = gix::path::realpath_opts(path, &cwd, 32)
-                .is_ok_and(|real| walk_options.ignore_dirs.contains(&real));
-            !is_ignored
-        })
+        .filter(|path| !paths_were_expanded || !walk_options.ignores_directory(path, &cwd))
         .collect())
 }
 


### PR DESCRIPTION
Prepared macOS and Windows aggregation roots resolve every child path even when the ignored-directory list is empty. Path resolution checks for symbolic links and therefore adds one filesystem lookup per root.

Share the existing traversal predicate with both aggregation input paths. Its empty-list short circuit skips path resolution, and prepared roots use borrowed filenames without allocating paths.

This reduces duplication and fixes a tiny missed optimization from f9b6200c8.