### PR TITLE
Avoid materiailizing vector

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -375,10 +375,8 @@ fn extract_aggregate_inputs_maybe_set_cwd(
         let parent_path: std::sync::Arc<Path> = Path::new("").into();
         let mut selected_entries = Vec::new();
 
-        let entries = dua_core::read_dir(Path::new("."), walk_options.metadata_options)?
-            .collect::<Result<Vec<_>, _>>()?;
-
-        for mut entry in entries {
+        for entry in dua_core::read_dir(Path::new("."), walk_options.metadata_options)? {
+            let mut entry = entry?;
             if entry.file_type.is_symlink() {
                 continue;
             }


### PR DESCRIPTION
This saves an allocation at the expense of delaying reporting of traversal errors.

This previously changed from streaming to eager in 0acd5fa42 during review of #371.

PR note: if eager error reporting is important I'd be happy to change this into a comment addition instead.