### PR TITLE
Shrink native macOS traversal metadata

### DIFF
--- a/crates/dua-lib/src/macos/mod.rs
+++ b/crates/dua-lib/src/macos/mod.rs
@@ -111,10 +111,10 @@ impl FileType {
 pub struct Metadata {
     len: u64,
     allocated_size: u64,
-    /// Data-fork allocation and clone identity, present only when extended metadata was requested
-    /// and supported by the filesystem. Unlike `ino`, which identifies hard links to one file,
-    /// the clone identity can be shared by copy-on-write clones with distinct inodes.
-    data_fork: Option<DataFork>,
+    /// Data-fork allocation, or total allocation when extended metadata is unavailable.
+    data_allocated_size: u64,
+    /// Unlike `ino`, clone identity can be shared by copy-on-write clones with distinct inodes.
+    clone_id: Option<NonZeroU64>,
     modified: Option<SystemTime>,
     dev: u64,
     ino: u64,
@@ -126,11 +126,13 @@ impl Metadata {
     fn from_std(metadata: &fs::Metadata, data_fork: Option<DataFork>) -> Self {
         let allocated_size = metadata.blocks().saturating_mul(STAT_BLOCK_BYTES);
         let file_type = FileType::from_std(metadata.file_type());
+        let data_fork =
+            data_fork.filter(|fork| file_type.is_file() && fork.allocated_size <= allocated_size);
         Self {
             len: metadata.len(),
             allocated_size,
-            data_fork: data_fork
-                .filter(|fork| file_type.is_file() && fork.allocated_size <= allocated_size),
+            data_allocated_size: data_fork.map_or(allocated_size, |fork| fork.allocated_size),
+            clone_id: data_fork.and_then(|fork| fork.clone_id),
             modified: metadata.modified().ok(),
             dev: metadata.dev(),
             ino: metadata.ino(),
@@ -155,8 +157,7 @@ impl Metadata {
     /// Return data-fork allocation, or total allocation when separate fork metadata is unavailable.
     #[must_use]
     pub fn data_allocated_size(&self) -> u64 {
-        self.data_fork
-            .map_or(self.allocated_size, |fork| fork.allocated_size)
+        self.data_allocated_size
     }
 
     /// Return the allocated size as 512-byte filesystem accounting blocks.
@@ -203,7 +204,7 @@ impl Metadata {
     /// Clone identifiers are meaningful only within the same filesystem device.
     #[must_use]
     pub fn clone_id(&self) -> Option<NonZeroU64> {
-        self.data_fork.and_then(|fork| fork.clone_id)
+        self.clone_id
     }
 }
 
@@ -477,13 +478,15 @@ impl ParsedRecord {
                     .ok_or_else(|| invalid_data("missing file hard-link count"))?,
             )
         };
+        let data_fork = self
+            .data_fork()
+            .filter(|fork| file_type.is_file() && fork.allocated_size <= allocated_size);
 
         Ok(Metadata {
             len,
             allocated_size,
-            data_fork: self
-                .data_fork()
-                .filter(|fork| file_type.is_file() && fork.allocated_size <= allocated_size),
+            data_allocated_size: data_fork.map_or(allocated_size, |fork| fork.allocated_size),
+            clone_id: data_fork.and_then(|fork| fork.clone_id),
             modified: Some(
                 self.modified
                     .ok_or_else(|| invalid_data("missing modification timestamp"))?,

--- a/crates/dua-lib/src/macos/mod.rs
+++ b/crates/dua-lib/src/macos/mod.rs
@@ -109,7 +109,9 @@ impl FileType {
 /// macOS metadata obtained during native directory enumeration.
 #[derive(Clone, Copy)]
 pub struct Metadata {
+    /// Logical file or directory length.
     len: u64,
+    /// Total allocation, including resource forks and other extended metadata.
     allocated_size: u64,
     /// Data-fork allocation, or total allocation when extended metadata is unavailable.
     data_allocated_size: u64,

--- a/crates/dua-lib/src/macos/tests.rs
+++ b/crates/dua-lib/src/macos/tests.rs
@@ -9,6 +9,20 @@ fn options(apfs_clone_metadata: bool) -> Options {
 }
 
 #[test]
+fn metadata_and_entries_keep_clone_tracking_compact() {
+    assert_eq!(
+        size_of::<Metadata>(),
+        80,
+        "effective data allocation and clone identity must not require another discriminant"
+    );
+    assert_eq!(
+        size_of::<Entry>(),
+        136,
+        "native directory entries must retain compact inline metadata"
+    );
+}
+
+#[test]
 fn directory_reader_rejects_regular_files_before_iteration() {
     let directory = tempfile::tempdir().unwrap();
     let file = directory.path().join("file");
@@ -59,6 +73,19 @@ fn bulk_metadata_matches_std_for_regular_files_resource_forks_and_symlinks() {
         "resource fork must allocate storage: data={data_blocks}, total={resource_blocks}"
     );
     std::os::unix::fs::symlink("file", directory.path().join("link")).unwrap();
+
+    let ordinary_metadata = ReadDir::open(Arc::from(directory.path()), 1, options(false))
+        .unwrap()
+        .find(|entry| entry.as_ref().is_ok_and(|entry| entry.file_name == "file"))
+        .expect("the resource-fork fixture must be enumerated")
+        .unwrap()
+        .metadata
+        .unwrap();
+    assert_eq!(
+        ordinary_metadata.data_allocated_size(),
+        ordinary_metadata.allocated_size(),
+        "without extended metadata, data allocation must fall back to total allocation"
+    );
 
     let entries = ReadDir::open(Arc::from(directory.path()), 1, options(true))
         .unwrap()


### PR DESCRIPTION
Optional APFS fork metadata adds a separate discriminant to every native directory entry, including traversals with clone deduplication disabled. Store the effective data allocation and optional clone identifier directly instead.

This reduces native metadata from 88 to 80 bytes and directory entries from 144 to 136 bytes without changing the public accessors. Assert both layouts and preserve resource-fork fallback behavior.

PR note: I'm not sure this is worth it; will let you decide.