### PR TITLE
Match macOS `du` allocation accounting

### DIFF
--- a/crates/dua-lib/src/macos/attributes.rs
+++ b/crates/dua-lib/src/macos/attributes.rs
@@ -357,6 +357,10 @@ pub(super) fn parse_record(
     Ok(record)
 }
 
+/// Return whether a requested attribute occupies space in the record.
+///
+/// Packed-invalid records contain default values even when the returned-attribute mask marks the
+/// attribute unavailable; ordinary records omit unavailable attributes entirely.
 fn attribute_is_packed(
     returned: libc::attrgroup_t,
     attribute: libc::attrgroup_t,

--- a/crates/dua-lib/src/macos/attributes.rs
+++ b/crates/dua-lib/src/macos/attributes.rs
@@ -12,7 +12,11 @@ use std::{
 pub(super) const VNON: u32 = 0;
 pub(super) const VREG: u32 = 1;
 pub(super) const VDIR: u32 = 2;
+pub(super) const VBLK: u32 = 3;
+pub(super) const VCHR: u32 = 4;
 pub(super) const VLNK: u32 = 5;
+pub(super) const VSOCK: u32 = 6;
+pub(super) const VFIFO: u32 = 7;
 // These `<sys/stat.h>` filesystem flags and accounting units are absent from `libc`.
 pub(super) const SF_FIRMLINK: u32 = 0x0080_0000;
 pub(super) const STAT_BLOCK_BYTES: u64 = 512;
@@ -22,14 +26,19 @@ const EF_MAY_SHARE_BLOCKS: u64 = 0x0000_0001;
 const ATTR_CMN_ERROR: libc::attrgroup_t = 0x2000_0000;
 const NANOS_PER_SECOND: u32 = 1_000_000_000;
 
-const COMMON_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_CMN_RETURNED_ATTRS
+const FTS_COMMON_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_CMN_RETURNED_ATTRS
     | libc::ATTR_CMN_NAME
     | libc::ATTR_CMN_DEVID
     | libc::ATTR_CMN_OBJTYPE
+    | libc::ATTR_CMN_CRTIME
     | libc::ATTR_CMN_MODTIME
+    | libc::ATTR_CMN_CHGTIME
+    | libc::ATTR_CMN_ACCTIME
+    | libc::ATTR_CMN_OWNERID
+    | libc::ATTR_CMN_GRPID
+    | libc::ATTR_CMN_ACCESSMASK
     | libc::ATTR_CMN_FLAGS
-    | libc::ATTR_CMN_FILEID
-    | ATTR_CMN_ERROR;
+    | libc::ATTR_CMN_FILEID;
 // XNU's `vfs_attrlist.c` `LIST_DIR_ATTRS` authorizes this subset with LIST_DIRECTORY alone.
 // Metadata attributes additionally require SEARCH, which a readable directory need not grant.
 const LIST_ONLY_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_CMN_RETURNED_ATTRS
@@ -37,12 +46,11 @@ const LIST_ONLY_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_CMN_RETURNED_ATTRS
     | libc::ATTR_CMN_OBJTYPE
     | libc::ATTR_CMN_FILEID
     | ATTR_CMN_ERROR;
-const DIRECTORY_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_DIR_LINKCOUNT
-    | libc::ATTR_DIR_MOUNTSTATUS
-    | libc::ATTR_DIR_ALLOCSIZE
-    | libc::ATTR_DIR_DATALENGTH;
-const FILE_ATTRIBUTES: libc::attrgroup_t =
-    libc::ATTR_FILE_LINKCOUNT | libc::ATTR_FILE_ALLOCSIZE | libc::ATTR_FILE_DATALENGTH;
+const FTS_FILE_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_FILE_LINKCOUNT
+    | libc::ATTR_FILE_ALLOCSIZE
+    | libc::ATTR_FILE_IOBLOCKSIZE
+    | libc::ATTR_FILE_DEVTYPE
+    | libc::ATTR_FILE_DATALENGTH;
 const APFS_FILE_ATTRIBUTES: libc::attrgroup_t = libc::ATTR_FILE_DATAALLOCSIZE;
 const APFS_EXTENDED_ATTRIBUTES: libc::attrgroup_t =
     libc::ATTR_CMNEXT_CLONEID | libc::ATTR_CMNEXT_EXT_FLAGS;
@@ -96,11 +104,11 @@ pub(super) fn requested_attributes(list_only: bool, include_apfs: bool) -> libc:
         commonattr: if list_only {
             LIST_ONLY_ATTRIBUTES
         } else {
-            COMMON_ATTRIBUTES
+            FTS_COMMON_ATTRIBUTES
         },
         volattr: 0,
-        dirattr: if list_only { 0 } else { DIRECTORY_ATTRIBUTES },
-        fileattr: if list_only { 0 } else { FILE_ATTRIBUTES },
+        dirattr: 0,
+        fileattr: if list_only { 0 } else { FTS_FILE_ATTRIBUTES },
         forkattr: 0,
     };
     if include_apfs && !list_only {
@@ -124,6 +132,8 @@ pub(super) fn root_clone_attributes() -> libc::attrlist {
 
 #[derive(Default)]
 pub(super) struct ParsedRecord {
+    returned_common: libc::attrgroup_t,
+    returned_file: libc::attrgroup_t,
     pub(super) file_name: Option<OsString>,
     pub(super) device: Option<u64>,
     pub(super) object_type: Option<u32>,
@@ -131,10 +141,6 @@ pub(super) struct ParsedRecord {
     pub(super) flags: u32,
     pub(super) inode: Option<u64>,
     pub(super) error: u32,
-    pub(super) directory_links: Option<u64>,
-    pub(super) mount_status: u32,
-    pub(super) directory_allocated: Option<u64>,
-    pub(super) directory_length: Option<u64>,
     pub(super) file_links: Option<u64>,
     pub(super) file_length: Option<u64>,
     pub(super) file_allocated: Option<u64>,
@@ -163,7 +169,11 @@ pub(super) fn read_record_length(bytes: &[u8]) -> io::Result<usize> {
         .map_err(|_| invalid_data("macOS attribute record length exceeds the address space"))
 }
 
-pub(super) fn parse_record(bytes: &[u8]) -> io::Result<ParsedRecord> {
+pub(super) fn parse_record(
+    bytes: &[u8],
+    pack_invalid: bool,
+    include_apfs: bool,
+) -> io::Result<ParsedRecord> {
     if bytes.len() < size_of::<RecordHeader>() {
         return Err(invalid_data("macOS attribute record is truncated"));
     }
@@ -181,43 +191,59 @@ pub(super) fn parse_record(bytes: &[u8]) -> io::Result<ParsedRecord> {
         return Err(invalid_data("macOS attributes omit their returned bitmap"));
     }
 
-    let mut record = ParsedRecord::default();
+    let mut record = ParsedRecord {
+        returned_common: returned.commonattr,
+        returned_file: returned.fileattr,
+        ..Default::default()
+    };
 
     if returned.commonattr & ATTR_CMN_ERROR != 0 {
         record.error = cursor.take_u32()?;
     }
-    if returned.commonattr & libc::ATTR_CMN_NAME != 0 {
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_NAME, pack_invalid) {
         // `getattrlist(2)` defines attr_dataoffset relative to this attrreference.
         let reference_offset = bytes.len() - cursor.bytes.len();
         let reference = libc::attrreference_t {
             attr_dataoffset: cursor.take_i32()?,
             attr_length: cursor.take_u32()?,
         };
-        let offset = isize::try_from(reference.attr_dataoffset)
-            .map_err(|_| invalid_data("macOS filename has an invalid offset"))?;
-        let start = reference_offset
-            .checked_add_signed(offset)
-            .ok_or_else(|| invalid_data("macOS filename has an invalid offset"))?;
-        let length = usize::try_from(reference.attr_length)
-            .map_err(|_| invalid_data("macOS filename exceeds the address space"))?;
-        let end = start
-            .checked_add(length)
-            .filter(|end| *end <= bytes.len())
-            .ok_or_else(|| invalid_data("macOS filename exceeds its record"))?;
-        let mut name = &bytes[start..end];
-        if name.last() == Some(&0) {
-            name = &name[..name.len() - 1];
+        if returned.commonattr & libc::ATTR_CMN_NAME != 0 {
+            let offset = isize::try_from(reference.attr_dataoffset)
+                .map_err(|_| invalid_data("macOS filename has an invalid offset"))?;
+            let start = reference_offset
+                .checked_add_signed(offset)
+                .ok_or_else(|| invalid_data("macOS filename has an invalid offset"))?;
+            let length = usize::try_from(reference.attr_length)
+                .map_err(|_| invalid_data("macOS filename exceeds the address space"))?;
+            let end = start
+                .checked_add(length)
+                .filter(|end| *end <= bytes.len())
+                .ok_or_else(|| invalid_data("macOS filename exceeds its record"))?;
+            let mut name = &bytes[start..end];
+            if name.last() == Some(&0) {
+                name = &name[..name.len() - 1];
+            }
+            record.file_name = Some(OsString::from_vec(name.to_vec()));
         }
-        record.file_name = Some(OsString::from_vec(name.to_vec()));
     }
-    if returned.commonattr & libc::ATTR_CMN_DEVID != 0 {
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_DEVID, pack_invalid) {
         // Darwin's signed `dev_t` is sign-extended by `std::fs::Metadata::dev()`.
-        record.device = Some(i64::from(cursor.take_i32()?).cast_unsigned());
+        let device = i64::from(cursor.take_i32()?).cast_unsigned();
+        if returned.commonattr & libc::ATTR_CMN_DEVID != 0 {
+            record.device = Some(device);
+        }
     }
-    if returned.commonattr & libc::ATTR_CMN_OBJTYPE != 0 {
-        record.object_type = Some(cursor.take_u32()?);
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_OBJTYPE, pack_invalid) {
+        let object_type = cursor.take_u32()?;
+        if returned.commonattr & libc::ATTR_CMN_OBJTYPE != 0 {
+            record.object_type = Some(object_type);
+        }
     }
-    if returned.commonattr & libc::ATTR_CMN_MODTIME != 0 {
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_CRTIME, pack_invalid) {
+        cursor.take_i64()?;
+        cursor.take_i64()?;
+    }
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_MODTIME, pack_invalid) {
         let seconds = cursor.take_i64()?;
         let nanoseconds = cursor.take_i64()?;
         // Apple represents fractional pre-epoch timestamps with negative nanoseconds.
@@ -235,54 +261,139 @@ pub(super) fn parse_record(bytes: &[u8]) -> io::Result<ParsedRecord> {
             .ok()
             .filter(|nanos| *nanos < NANOS_PER_SECOND)
             .ok_or_else(|| invalid_data("macOS modification time has invalid nanoseconds"))?;
-        record.modified = if seconds >= 0 {
-            UNIX_EPOCH.checked_add(Duration::new(seconds.cast_unsigned(), nanos))
-        } else {
-            UNIX_EPOCH
-                .checked_sub(Duration::new(seconds.unsigned_abs(), 0))
-                .and_then(|time| time.checked_add(Duration::new(0, nanos)))
-        };
+        if returned.commonattr & libc::ATTR_CMN_MODTIME != 0 {
+            record.modified = if seconds >= 0 {
+                UNIX_EPOCH.checked_add(Duration::new(seconds.cast_unsigned(), nanos))
+            } else {
+                UNIX_EPOCH
+                    .checked_sub(Duration::new(seconds.unsigned_abs(), 0))
+                    .and_then(|time| time.checked_add(Duration::new(0, nanos)))
+            };
+        }
     }
-    if returned.commonattr & libc::ATTR_CMN_FLAGS != 0 {
-        record.flags = cursor.take_u32()?;
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_CHGTIME, pack_invalid) {
+        cursor.take_i64()?;
+        cursor.take_i64()?;
     }
-    if returned.commonattr & libc::ATTR_CMN_FILEID != 0 {
-        record.inode = Some(cursor.take_u64()?);
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_ACCTIME, pack_invalid) {
+        cursor.take_i64()?;
+        cursor.take_i64()?;
+    }
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_OWNERID, pack_invalid) {
+        cursor.take_u32()?;
+    }
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_GRPID, pack_invalid) {
+        cursor.take_u32()?;
+    }
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_ACCESSMASK, pack_invalid) {
+        cursor.take_u32()?;
+    }
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_FLAGS, pack_invalid) {
+        let flags = cursor.take_u32()?;
+        if returned.commonattr & libc::ATTR_CMN_FLAGS != 0 {
+            record.flags = flags;
+        }
+    }
+    if attribute_is_packed(returned.commonattr, libc::ATTR_CMN_FILEID, pack_invalid) {
+        let inode = cursor.take_u64()?;
+        if returned.commonattr & libc::ATTR_CMN_FILEID != 0 {
+            record.inode = Some(inode);
+        }
     }
 
-    if returned.dirattr & libc::ATTR_DIR_LINKCOUNT != 0 {
-        record.directory_links = Some(u64::from(cursor.take_u32()?));
+    let pack_file = pack_invalid && record.object_type != Some(VDIR);
+    if attribute_is_packed(returned.fileattr, libc::ATTR_FILE_LINKCOUNT, pack_file) {
+        let links = u64::from(cursor.take_u32()?);
+        if returned.fileattr & libc::ATTR_FILE_LINKCOUNT != 0 {
+            record.file_links = Some(links);
+        }
     }
-    if returned.dirattr & libc::ATTR_DIR_MOUNTSTATUS != 0 {
-        record.mount_status = cursor.take_u32()?;
+    if attribute_is_packed(returned.fileattr, libc::ATTR_FILE_ALLOCSIZE, pack_file) {
+        let allocated = cursor.take_u64()?;
+        if returned.fileattr & libc::ATTR_FILE_ALLOCSIZE != 0 {
+            record.file_allocated = Some(fts_allocated_bytes(allocated));
+        }
     }
-    if returned.dirattr & libc::ATTR_DIR_ALLOCSIZE != 0 {
-        record.directory_allocated = Some(cursor.take_u64()?);
+    if attribute_is_packed(returned.fileattr, libc::ATTR_FILE_IOBLOCKSIZE, pack_file) {
+        cursor.take_u32()?;
     }
-    if returned.dirattr & libc::ATTR_DIR_DATALENGTH != 0 {
-        record.directory_length = Some(cursor.take_u64()?);
+    if attribute_is_packed(returned.fileattr, libc::ATTR_FILE_DEVTYPE, pack_file) {
+        cursor.take_u32()?;
+    }
+    if attribute_is_packed(returned.fileattr, libc::ATTR_FILE_DATALENGTH, pack_file) {
+        let length = cursor.take_u64()?;
+        if returned.fileattr & libc::ATTR_FILE_DATALENGTH != 0 {
+            record.file_length = Some(length);
+        }
+    }
+    let pack_apfs = pack_file && include_apfs;
+    if attribute_is_packed(returned.fileattr, libc::ATTR_FILE_DATAALLOCSIZE, pack_apfs) {
+        let allocated = cursor.take_u64()?;
+        if returned.fileattr & libc::ATTR_FILE_DATAALLOCSIZE != 0 {
+            record.file_data_allocated = Some(fts_allocated_bytes(allocated));
+        }
     }
 
-    if returned.fileattr & libc::ATTR_FILE_LINKCOUNT != 0 {
-        record.file_links = Some(u64::from(cursor.take_u32()?));
+    if attribute_is_packed(
+        returned.forkattr,
+        libc::ATTR_CMNEXT_CLONEID,
+        pack_invalid && include_apfs,
+    ) {
+        let clone_id = cursor.take_u64()?;
+        if returned.forkattr & libc::ATTR_CMNEXT_CLONEID != 0 {
+            record.clone_id = NonZeroU64::new(clone_id);
+        }
     }
-    if returned.fileattr & libc::ATTR_FILE_ALLOCSIZE != 0 {
-        record.file_allocated = Some(cursor.take_u64()?);
-    }
-    if returned.fileattr & libc::ATTR_FILE_DATALENGTH != 0 {
-        record.file_length = Some(cursor.take_u64()?);
-    }
-    if returned.fileattr & libc::ATTR_FILE_DATAALLOCSIZE != 0 {
-        record.file_data_allocated = Some(cursor.take_u64()?);
-    }
-
-    if returned.forkattr & libc::ATTR_CMNEXT_CLONEID != 0 {
-        record.clone_id = NonZeroU64::new(cursor.take_u64()?);
-    }
-    if returned.forkattr & libc::ATTR_CMNEXT_EXT_FLAGS != 0 {
-        record.extended_flags = Some(cursor.take_u64()?);
+    if attribute_is_packed(
+        returned.forkattr,
+        libc::ATTR_CMNEXT_EXT_FLAGS,
+        pack_invalid && include_apfs,
+    ) {
+        let extended_flags = cursor.take_u64()?;
+        if returned.forkattr & libc::ATTR_CMNEXT_EXT_FLAGS != 0 {
+            record.extended_flags = Some(extended_flags);
+        }
     }
     Ok(record)
+}
+
+fn attribute_is_packed(
+    returned: libc::attrgroup_t,
+    attribute: libc::attrgroup_t,
+    pack_invalid: bool,
+) -> bool {
+    pack_invalid || returned & attribute != 0
+}
+
+fn fts_allocated_bytes(bytes: u64) -> u64 {
+    bytes
+        .div_ceil(STAT_BLOCK_BYTES)
+        .saturating_mul(STAT_BLOCK_BYTES)
+}
+
+impl ParsedRecord {
+    /// Return whether Apple FTS would synthesize a complete `stat` from this bulk record.
+    ///
+    /// FTS always stats directories, tolerates an unavailable creation time, and only requires a
+    /// device type for block and character devices. Matching that validity gate keeps consumers of
+    /// this walker on the same allocation-size path as macOS `du`.
+    pub(super) fn satisfies_fts_stat_contract(&self) -> bool {
+        let Some(object_type) = self.object_type else {
+            return false;
+        };
+        if !matches!(object_type, VREG | VBLK | VCHR | VLNK | VSOCK | VFIFO) {
+            return false;
+        }
+
+        let required_common = FTS_COMMON_ATTRIBUTES & !libc::ATTR_CMN_CRTIME;
+        let mut required_file = FTS_FILE_ATTRIBUTES;
+        if object_type != VBLK && object_type != VCHR {
+            required_file &= !libc::ATTR_FILE_DEVTYPE;
+        }
+
+        self.returned_common & required_common == required_common
+            && self.returned_file & required_file == required_file
+    }
 }
 
 struct Cursor<'a> {
@@ -322,4 +433,94 @@ impl<'a> Cursor<'a> {
 
 pub(super) fn invalid_data(message: &'static str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn complete_record(object_type: u32) -> ParsedRecord {
+        ParsedRecord {
+            returned_common: FTS_COMMON_ATTRIBUTES,
+            returned_file: FTS_FILE_ATTRIBUTES,
+            object_type: Some(object_type),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn full_request_matches_fts_without_directory_attributes() {
+        let attributes = requested_attributes(false, false);
+
+        assert_eq!(attributes.commonattr, FTS_COMMON_ATTRIBUTES);
+        assert_eq!(attributes.dirattr, 0);
+        assert_eq!(attributes.fileattr, FTS_FILE_ATTRIBUTES);
+        assert_eq!(attributes.forkattr, 0);
+
+        let apfs_attributes = requested_attributes(false, true);
+        assert_eq!(apfs_attributes.commonattr, FTS_COMMON_ATTRIBUTES);
+        assert_eq!(apfs_attributes.dirattr, 0);
+        assert_eq!(
+            apfs_attributes.fileattr,
+            FTS_FILE_ATTRIBUTES | APFS_FILE_ATTRIBUTES
+        );
+        assert_eq!(apfs_attributes.forkattr, APFS_EXTENDED_ATTRIBUTES);
+    }
+
+    #[test]
+    fn fts_contract_accepts_only_known_non_directory_vnode_types() {
+        for object_type in [VREG, VBLK, VCHR, VLNK, VSOCK, VFIFO] {
+            assert!(
+                complete_record(object_type).satisfies_fts_stat_contract(),
+                "known vnode type {object_type} must use complete bulk metadata"
+            );
+        }
+        for object_type in [VNON, VDIR, 8, u32::MAX] {
+            assert!(
+                !complete_record(object_type).satisfies_fts_stat_contract(),
+                "unknown or directory vnode type {object_type} must fall back to stat"
+            );
+        }
+
+        assert!(
+            !ParsedRecord {
+                returned_common: FTS_COMMON_ATTRIBUTES,
+                returned_file: FTS_FILE_ATTRIBUTES,
+                ..Default::default()
+            }
+            .satisfies_fts_stat_contract(),
+            "a missing vnode type must fall back to stat"
+        );
+    }
+
+    #[test]
+    fn fts_contract_rejects_missing_required_attributes() {
+        let mut missing_common = complete_record(VREG);
+        missing_common.returned_common &= !libc::ATTR_CMN_DEVID;
+        assert!(!missing_common.satisfies_fts_stat_contract());
+
+        let mut missing_file = complete_record(VREG);
+        missing_file.returned_file &= !libc::ATTR_FILE_ALLOCSIZE;
+        assert!(!missing_file.satisfies_fts_stat_contract());
+
+        let mut missing_creation_time = complete_record(VREG);
+        missing_creation_time.returned_common &= !libc::ATTR_CMN_CRTIME;
+        assert!(missing_creation_time.satisfies_fts_stat_contract());
+
+        let mut regular_without_device_type = complete_record(VREG);
+        regular_without_device_type.returned_file &= !libc::ATTR_FILE_DEVTYPE;
+        assert!(regular_without_device_type.satisfies_fts_stat_contract());
+
+        let mut block_without_device_type = complete_record(VBLK);
+        block_without_device_type.returned_file &= !libc::ATTR_FILE_DEVTYPE;
+        assert!(!block_without_device_type.satisfies_fts_stat_contract());
+    }
+
+    #[test]
+    fn fts_allocation_rounds_up_to_512_byte_stat_blocks() {
+        assert_eq!(fts_allocated_bytes(0), 0);
+        assert_eq!(fts_allocated_bytes(1), 512);
+        assert_eq!(fts_allocated_bytes(512), 512);
+        assert_eq!(fts_allocated_bytes(513), 1024);
+    }
 }

--- a/crates/dua-lib/src/macos/mod.rs
+++ b/crates/dua-lib/src/macos/mod.rs
@@ -469,7 +469,10 @@ fn clone_attributes_at(path: &Path, metadata: &fs::Metadata) -> Option<DataFork>
 
 impl ParsedRecord {
     fn metadata(&self, file_type: FileType) -> io::Result<Metadata> {
-        debug_assert!(!file_type.is_dir());
+        debug_assert!(
+            !file_type.is_dir(),
+            "directories must fail the Apple FTS stat contract and use path metadata"
+        );
         let len = self
             .file_length
             .ok_or_else(|| invalid_data("missing file length"))?;

--- a/crates/dua-lib/src/macos/mod.rs
+++ b/crates/dua-lib/src/macos/mod.rs
@@ -188,8 +188,8 @@ impl Metadata {
 
     /// Return the number of hard links to this entry.
     ///
-    /// Bulk-enumerated directories use `ATTR_DIR_LINKCOUNT`, which `getattrlist(2)` says
-    /// excludes historical `.` and `..` links and can therefore differ from `stat(2)`.
+    /// Directories use path metadata because the Apple FTS contract does not synthesize their
+    /// `stat` fields from bulk attributes.
     #[must_use]
     pub fn nlink(&self) -> u64 {
         self.nlink
@@ -253,8 +253,19 @@ impl ReadDir {
     /// because `self.fallback` was initialized. Returns `false` when the directory is exhausted.
     fn refill(&mut self) -> io::Result<bool> {
         loop {
-            let mut attributes =
-                requested_attributes(self.listing_error.is_some(), self.extended_attributes);
+            let list_only = self.listing_error.is_some();
+            let include_apfs = self.extended_attributes && !list_only;
+            let mut attributes = requested_attributes(list_only, include_apfs);
+            let mut options = if list_only {
+                0
+            } else {
+                u64::from(libc::FSOPT_PACK_INVAL_ATTRS)
+            };
+            if include_apfs {
+                options |= u64::from(libc::FSOPT_ATTR_CMN_EXTENDED);
+            }
+            // Apple FTS, and therefore macOS `du`, uses packed invalid attributes when collecting
+            // full metadata. APFS clone metadata is an optional extension of that same layout.
             // SAFETY: the directory descriptor is owned and remains open, `attributes` is a valid
             // initialized Darwin attrlist, and the aligned buffer is writable for its exact size.
             let count = unsafe {
@@ -263,11 +274,7 @@ impl ReadDir {
                     (&raw mut attributes).cast(),
                     self.buffer.as_mut_bytes().as_mut_ptr().cast(),
                     self.buffer.as_bytes().len(),
-                    if self.extended_attributes {
-                        u64::from(libc::FSOPT_ATTR_CMN_EXTENDED)
-                    } else {
-                        0
-                    },
+                    options,
                 )
             };
             if count > 0 {
@@ -358,7 +365,11 @@ impl ReadDir {
         self.offset = end;
         self.remaining -= 1;
 
-        let mut parsed = parse_record(record)?;
+        let mut parsed = parse_record(
+            record,
+            self.listing_error.is_none(),
+            self.extended_attributes,
+        )?;
         let file_name = parsed
             .file_name
             .take()
@@ -374,17 +385,14 @@ impl ReadDir {
         let metadata = if let Some(error) = metadata_error {
             Err(io::Error::from_raw_os_error(error))
         } else {
-            if parsed.object_type.is_none() {
-                return Err(invalid_data("macOS directory record has no object type"));
-            }
             let metadata_from_path = || {
                 fs::symlink_metadata(self.parent_path.join(&file_name))
                     .map(|metadata| Metadata::from_std(&metadata, None))
             };
-            // XNU uses NOCROSSMOUNT for bulk lookup; stat the visible mount or firmlink.
-            let special_mount = parsed.flags & SF_FIRMLINK != 0
-                || parsed.mount_status & libc::DIR_MNTSTATUS_MNTPOINT != 0;
-            if special_mount {
+            // XNU uses NOCROSSMOUNT for bulk lookup. Directories fall through the FTS contract
+            // below, while firmlinks need an explicit path lookup to expose the visible target.
+            let firmlink = parsed.flags & SF_FIRMLINK != 0;
+            if firmlink || !parsed.satisfies_fts_stat_contract() {
                 metadata_from_path()
             } else {
                 parsed.metadata(file_type).or_else(|_| metadata_from_path())
@@ -452,7 +460,7 @@ fn clone_attributes_at(path: &Path, metadata: &fs::Metadata) -> Option<DataFork>
     let bytes = buffer.as_bytes();
     let length = read_record_length(bytes).ok()?;
     let record = bytes.get(..length)?;
-    let parsed = parse_record(record).ok()?;
+    let parsed = parse_record(record, false, true).ok()?;
     if parsed.device != Some(metadata.dev()) || parsed.inode != Some(metadata.ino()) {
         return None;
     }
@@ -461,25 +469,16 @@ fn clone_attributes_at(path: &Path, metadata: &fs::Metadata) -> Option<DataFork>
 
 impl ParsedRecord {
     fn metadata(&self, file_type: FileType) -> io::Result<Metadata> {
-        let (len, allocated_size, nlink) = if file_type.is_dir() {
-            (
-                self.directory_length
-                    .ok_or_else(|| invalid_data("missing directory length"))?,
-                self.directory_allocated
-                    .ok_or_else(|| invalid_data("missing directory allocation"))?,
-                self.directory_links
-                    .ok_or_else(|| invalid_data("missing directory hard-link count"))?,
-            )
-        } else {
-            (
-                self.file_length
-                    .ok_or_else(|| invalid_data("missing file length"))?,
-                self.file_allocated
-                    .ok_or_else(|| invalid_data("missing file allocation"))?,
-                self.file_links
-                    .ok_or_else(|| invalid_data("missing file hard-link count"))?,
-            )
-        };
+        debug_assert!(!file_type.is_dir());
+        let len = self
+            .file_length
+            .ok_or_else(|| invalid_data("missing file length"))?;
+        let allocated_size = self
+            .file_allocated
+            .ok_or_else(|| invalid_data("missing file allocation"))?;
+        let nlink = self
+            .file_links
+            .ok_or_else(|| invalid_data("missing file hard-link count"))?;
         let data_fork = self
             .data_fork()
             .filter(|fork| file_type.is_file() && fork.allocated_size <= allocated_size);


### PR DESCRIPTION
> [!NOTE]
> **AI development disclosure**
> 
> Both the code changes in this PR and this description were produced by Codex under my direction. I defined the scope and guided the investigation; Codex performed the data collection, cross-version comparisons, source and history tracing, implementation, test development and execution, validation, and final drafting.
> 
> I manually reviewed the relevant primary sources and found no serious issues. If this approach is incorrect or does not fit `dua`'s direction, please feel free to modify or reject it, or let me know how it should be improved!

## Background

Hi! I found this issue unexpectedly while using `dua` on macOS 26. When scanning an OrbStack directory mounted through NFS, `dua`'s default allocated-size total did not match the equivalent result from `/usr/bin/du`.

At first, this looked like a single NFS regression. Testing several `dua` releases showed that the discrepancy had actually changed direction:

- v2.41.1 and earlier overcounted the tree;
- v2.42.0 and v2.42.1 undercounted it.

Further checks ruled out hard-link deduplication, traversal concurrency, and cancellation between subtrees. The discrepancy came from the allocated-size metadata returned by three different macOS query contracts.

This PR assumes that matching the system `du` behavior may be desirable for `dua`, at least for default allocated-size accounting on macOS. It therefore follows the metadata contract used by Apple FTS - the traversal implementation behind macOS `/usr/bin/du` - rather than adding an OrbStack/NFS-specific workaround.

## Reproduction

The comparison uses equivalent default allocated-size modes:

```bash
dua aggregate -f bytes "$NFS_ROOT"
BLOCKSIZE=512 /usr/bin/du -s "$NFS_ROOT"
```

`dua` reports bytes directly. With `BLOCKSIZE=512`, macOS `du` reports 512-byte blocks:

```text
/usr/bin/du: 12,442,673 × 512 = 6,370,648,576 bytes
```

The main comparison was run sequentially against the same mounted tree:

| Implementation      | Reported bytes | Delta vs `/usr/bin/du` |
| ------------------- | -------------: | ---------------------: |
| v2.41.0             |  6,628,753,408 | +258,104,832 (+4.051%) |
| v2.41.1             |  6,628,753,408 | +258,104,832 (+4.051%) |
| v2.42.0             |  6,357,613,568 |  -13,035,008 (-0.205%) |
| v2.42.1             |  6,357,612,032 |  -13,036,544 (-0.205%) |
| Initial fixed build |  6,370,648,576 |                      0 |
| `/usr/bin/du`       |  6,370,648,576 |              Reference |

These runs traversed 140,829 entries and reported the same 13 inaccessible paths. A later v2.39.1 check reproduced the v2.41.x byte total, although that older release propagated traversal errors differently. This also shows that the v2.40 walker was not the origin of the overcount.

OrbStack is a live filesystem, so absolute totals describe individual snapshots. The relevant evidence is the stable version-to-version difference under matching entry and error counts, followed by repeated exact agreement between the fix and `du` on later snapshots.

## Root cause

Before v2.42.0, `dua` ultimately accounted allocated size using per-entry Unix metadata and `st_blocks × 512`. That is a conventional Unix definition, but it does not guarantee the same filesystem query contract as Apple FTS. On this NFS mount, the per-path metadata query returned a total 258,104,832 bytes larger than `/usr/bin/du`.

PR #367 introduced a native macOS walker using `getattrlistbulk`. Its original implementation:

- requested a reduced common/file/directory attribute set;
- called `getattrlistbulk(..., options = 0)`;
- trusted records without first proving that the returned attributes were sufficient to synthesize a complete `stat`;
- used directory allocation from bulk records, whereas Apple FTS always performs a path lookup for directories.

These differences were not exposed by the existing local-filesystem tests, but on this NFS mount they changed the discrepancy from an overcount to an undercount of 13,035,008 bytes.

PR #369 then reused the same bulk metadata for aggregation roots. This was not the primary cause, but it extended the affected path and reduced the total by another 1,536 bytes on this snapshot.

## Implementation

This PR makes `dua`'s macOS bulk walker follow the relevant Apple FTS contract:

- Request the complete common and file attribute sets needed to synthesize `stat`.
- Leave directory attributes unset, because FTS does not synthesize directory `stat` fields from bulk records.
- Use `FSOPT_PACK_INVAL_ATTRS` for full metadata enumeration.
- Decode packed-invalid fields in request order while separately retaining the returned-attribute bitmap.
- Accept bulk metadata only for FTS-recognized vnode types when the required attributes were actually returned.
- Fall back to no-follow path metadata for directories, firmlinks, unknown vnode types, and incomplete records.
- Round allocation bytes to 512-byte accounting units, matching how FTS constructs `st_blocks`.
- Preserve the existing list-only permission retry and ordinary directory-reading fallback.
- Keep the bulk fast path for complete non-directory records.

The branch is based on #371. Its optional APFS data-fork allocation, clone ID, extended flags, and `FSOPT_ATTR_CMN_EXTENDED` behavior are retained as extensions of the same packed layout. Missing APFS extension attributes disable clone metadata without invalidating an otherwise complete FTS-compatible record.

The implementation does not inspect the filesystem name and contains no NFS-specific branch.

## Validation

The following checks passed on the current branch:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --all-features -- -D warnings
cargo test --workspace --all-targets --all-features
git diff --check
```

All 126 automated tests passed. The macOS coverage includes bulk metadata, APFS clones and data forks, resource forks, symlinks, hard links, permissions, buffer refills, fallback behavior, FTS/APFS request shapes, vnode validation, returned-attribute completeness, and allocation rounding.

Real OrbStack NFS validation confirmed that:

- the default total matched `/usr/bin/du` exactly;
- the `ubuntu` and `docker` subtrees matched independently, ruling out cancellation between positive and negative errors;
- `--count-hard-links` matched `/usr/bin/du -l` exactly;
- 1, 4, and 8 threads produced identical totals, entry counts, and errors;
- `--apparent-size` remained unchanged from v2.42.1;
- the same 13 permission errors were preserved.

After rebasing onto #371, the current head was checked again on a later filesystem snapshot:

```text
Default accounting:
dua                 6,370,499,072 bytes
/usr/bin/du         6,370,499,072 bytes

Counting hard links:
dua                 7,586,685,440 bytes
/usr/bin/du -l      7,586,685,440 bytes
```

The absolute totals changed with the live filesystem, but equality with the corresponding `du` mode remained exact. The rebased head also produced the same result with one thread and the default eight threads.

No automated real-NFS fixture is included. Unit tests protect the query, parsing, validation, fallback, and rounding rules; the OrbStack runs provide end-to-end evidence for the original issue.

## Performance

A controlled benchmark performed before the rebase onto #371 compared v2.42.1 with the initial fix. Both binaries used Rust 1.95.0 and the same release/all-features configuration. After one warm-up per binary, each workload ran 12 times in alternating order:

| Workload | v2.42.1 mean ± sd | Fix mean ± sd | Median, before → after |
|---|---:|---:|---:|
| OrbStack NFS, ~140k entries and 13 errors | 0.387 ± 0.014 s | 0.403 ± 0.013 s | 0.380 → 0.400 s |
| APFS fixture with 100,101 directories | 1.790 ± 0.138 s | 1.725 ± 0.162 s | 1.820 → 1.755 s |

The NFS workload was approximately 17 ms slower on average. The APFS difference was smaller than the observed run-to-run variation. These two workloads did not show a material regression, but they do not cover every filesystem, tree shape, or cache state.

This benchmark predates the rebase onto #371. The rebased head has passed correctness and APFS clone tests, but it has not been re-benchmarked against the current `main`.

## Compatibility and limitations

- The code changes are limited to macOS; Linux and Windows paths are unchanged.
- The accounting contract applies to all macOS filesystems using the bulk path, not only NFS.
- Complete non-directory records retain the bulk fast path.
- Directories now use path metadata, matching Apple FTS; this may have different costs on directory-heavy workloads.
- No CLI, public API, or serialization changes are introduced relative to the current base.
- This PR does not address NFS server availability, retries, timeouts, or mount recovery.
- It does not change `--apparent-size` or attempt byte-for-byte parity with macOS `du -A`.
- The real-world validation covers OrbStack NFS and should not be treated as certification for every NFS server or mount configuration.

## References

- [PR #35: introduce real/apparent size accounting](https://github.com/Byron/dua-cli/pull/35) and the [v2.41.1 Unix allocated-size call site](https://github.com/Byron/dua-cli/blob/90a59e15a681d50a64c0f86483100b257297f5a7/src/traverse.rs#L393-L402)
- [PR #367: introduce the native macOS bulk walker](https://github.com/Byron/dua-cli/pull/367), including its [attribute request](https://github.com/Byron/dua-cli/blob/7d115c014eff2f85ab60e82266f4f1beb4782598/crates/dua-lib/src/macos/attributes.rs#L22-L42) and [`getattrlistbulk` call](https://github.com/Byron/dua-cli/blob/7d115c014eff2f85ab60e82266f4f1beb4782598/crates/dua-lib/src/macos.rs#L211-L219)
- [PR #369: reuse bulk metadata for aggregation roots](https://github.com/Byron/dua-cli/pull/369)
- [PR #371: add optional APFS clone accounting](https://github.com/Byron/dua-cli/pull/371)
- [Apple FTS: attribute request and bulk enumeration](https://github.com/apple-oss-distributions/Libc/blob/71bbe350ab79eef58113991d817ccc6165061a64/gen/fts.c#L778-L824)
- [Apple FTS: vnode validation, fallback behavior, and `st_blocks` construction](https://github.com/apple-oss-distributions/Libc/blob/71bbe350ab79eef58113991d817ccc6165061a64/gen/fts.c#L903-L994)
- [Apple `du`: FTS traversal and `st_blocks` aggregation](https://github.com/apple-oss-distributions/file_cmds/blob/659a8a301e2acf0343f8b8673a154a2ca4d07084/du/du.c#L330-L412)
- [Apple `getattrlist(2)` documentation](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/man/man2/getattrlist.2)
