### PR TITLE
Show marked percentage of total size

### DIFF
--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -89,6 +89,7 @@ impl MainWindow {
             let props = MarkPaneProps {
                 border_style: mark_style,
                 format: display.byte_format,
+                root_total_size: *total_bytes,
             };
             pane.render(props, mark_area, buffer);
         }

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -59,6 +59,7 @@ pub struct MarkPane {
 pub struct MarkPaneProps {
     pub border_style: Style,
     pub format: ByteFormat,
+    pub root_total_size: u128,
 }
 
 impl MarkPane {
@@ -253,13 +254,20 @@ impl MarkPane {
         let MarkPaneProps {
             border_style,
             format,
+            root_total_size,
         } = props.borrow();
 
         let marked: &_ = &self.marked;
+        let percentage = if *root_total_size == 0 {
+            0.0
+        } else {
+            self.total_size as f64 / *root_total_size as f64 * 100.0
+        };
         let title = format!(
-            "Marked {} items ({}) ",
+            "Marked {} items ({}, {percentage:.2}% of {}) ",
             COUNT.format(self.item_count as f64),
-            format.display(self.total_size)
+            format.display(self.total_size),
+            format.display(*root_total_size)
         );
         let selected = self.selected;
         let has_focus = self.has_focus;
@@ -496,6 +504,33 @@ pub fn calculate_size_and_count(marked: &EntryMarkMap) -> (u128, u64) {
 #[cfg(test)]
 mod mark_pane_tests {
     use super::*;
+    use tui::buffer::Cell;
+
+    #[test]
+    fn title_shows_percentage_of_root_size() {
+        let area = Rect::new(0, 0, 80, 4);
+        let mut buffer = Buffer::empty(area);
+        MarkPane {
+            total_size: 312_400_000,
+            item_count: 20_000,
+            ..Default::default()
+        }
+        .render(
+            MarkPaneProps {
+                border_style: Style::default(),
+                format: ByteFormat::Metric,
+                root_total_size: 1_000_000_000,
+            },
+            area,
+            &mut buffer,
+        );
+
+        let rendered: String = buffer.content.iter().map(Cell::symbol).collect();
+        assert!(
+            rendered.contains("Marked 20K items (312.40 MB, 31.24% of 1.00 GB)"),
+            "rendered title: {rendered:?}"
+        );
+    }
 
     #[test]
     fn test_calculate_size() {


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #113

## Summary

- Show marked bytes as a percentage of the top-level root total in the mark pane title.
- Format the root total with the active byte unit and show zero-byte roots as 0.00%.
- Cover the rendered title with a regression test.

## Validation

- `cargo test title_shows_percentage_of_root_size`
- `make check-pre-push`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `codex review --commit 01db88e5` (no actionable findings)

## Commit

- `01db88e5` feat: show marked percentage of total size (#113)