### PR TITLE
Support Ctrl+Z in interactive mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "ratatui",
  "serde",
  "shlex 2.0.1",
+ "signal-hook",
  "tempfile",
  "toml",
  "trash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ include = [
 default = ["tui-crossplatform", "trash-move"]
 tui-crossplatform = [
     "crossterm",
+    "dep:signal-hook",
     "tui",
     "open",
     "unicode-segmentation",
@@ -100,6 +101,9 @@ shlex = "2.0.1"
 
 [target.'cfg(not(any(windows, target_os = "macos")))'.dependencies]
 filesize = "0.2.0"
+
+[target.'cfg(unix)'.dependencies]
+signal-hook = { version = "0.3.18", optional = true }
 
 [[bin]]
 name = "dua"

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -22,6 +22,8 @@ use tui::{
 
 use super::notification;
 use super::state::{AppState, Cursor};
+#[cfg(unix)]
+use super::terminal::suspend_terminal;
 use super::tree_view::TreeView;
 
 impl AppState {
@@ -377,6 +379,10 @@ impl AppState {
 
         let mut handled = true;
         match key.code {
+            #[cfg(unix)]
+            _ if is_suspend_key(key) => {
+                suspend_terminal(terminal, config.notifications.any_enabled())?;
+            }
             Tab => {
                 self.cycle_focus(window);
             }
@@ -803,4 +809,9 @@ fn strip_colors(buffer: &mut Buffer) {
 
 pub fn refresh_key() -> KeyEvent {
     KeyEvent::new(KeyCode::Char('\r'), KeyModifiers::ALT)
+}
+
+#[cfg(unix)]
+fn is_suspend_key(key: KeyEvent) -> bool {
+    key.code == KeyCode::Char('z') && key.modifiers.contains(KeyModifiers::CONTROL)
 }

--- a/src/interactive/app/terminal.rs
+++ b/src/interactive/app/terminal.rs
@@ -1,9 +1,19 @@
 use std::path::PathBuf;
 
+#[cfg(unix)]
+use std::io;
+
 use crate::interactive::EntryCheck;
 use anyhow::Result;
 use crossbeam::channel::Receiver;
 use crossterm::event::Event;
+#[cfg(unix)]
+use crossterm::{
+    cursor::Show,
+    event::{DisableFocusChange, EnableFocusChange},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
 use dua::Config;
 #[cfg(test)]
 use dua::traverse::TraversalStats;
@@ -13,6 +23,38 @@ use tui::{Terminal, backend::Backend};
 use crate::interactive::widgets::MainWindow;
 
 use super::{DisplayOptions, sorted_entries, state::AppState};
+
+/// Restores the user's terminal, suspends the process, and reinitializes the TUI after resume.
+///
+/// The previous frame is invalidated after resume so the caller's next draw repaints the complete
+/// UI. This function does not draw by itself; the event loop draws normally after handling the
+/// suspend key event.
+#[cfg(unix)]
+pub fn suspend_terminal<B>(terminal: &mut Terminal<B>, focus_change: bool) -> Result<()>
+where
+    B: Backend,
+{
+    let mut stderr = io::stderr();
+    if focus_change {
+        execute!(stderr, DisableFocusChange)?;
+    }
+    execute!(stderr, Show)?;
+    disable_raw_mode()?;
+    execute!(stderr, LeaveAlternateScreen)?;
+
+    // This suspends the program, and anything that follows undoes the lines above.
+    signal_hook::low_level::raise(signal_hook::consts::signal::SIGTSTP)?;
+
+    enable_raw_mode()?;
+    execute!(stderr, EnterAlternateScreen)?;
+    if focus_change {
+        execute!(stderr, EnableFocusChange)?;
+    }
+    // `Terminal::clear()` queries the cursor position, racing the input thread for its response.
+    // This triggers a redraw as well without that issue.
+    terminal.swap_buffers();
+    Ok(())
+}
 
 /// State and methods representing the interactive disk usage analyser for the terminal
 pub struct TerminalApp {


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #65

## Summary

- Handle Ctrl+Z globally in the Unix interactive UI.
- Release focus reporting, cursor, raw mode, and the alternate screen before raising `SIGTSTP`.
- Reclaim the Ratatui terminal after `fg`, invalidating its retained frame with `swap_buffers()` so the next draw repaints immediately without querying terminal input.
- Reuse `signal-hook`, already present through crossterm, as an optional direct dependency.

## Commits

- `83377625` — `fix: support Ctrl+Z in interactive mode (#65)`
- `d463b091` — `fix: redraw immediately after resume (#65)`

## Validation

- `make check`
- `cargo test --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` and `git diff --check`
- `cargo check --target aarch64-pc-windows-msvc --all --bins --tests --examples`
- Deterministic Expect PTY: the original code queried cursor position after `fg`; the fix redrew immediately without querying input, traversal continued, and the shell was restored after quit
- `codex review --commit d463b091d977810f17d7d461b8a63f7b4f9fb6a8` — no actionable findings
