### PR TITLE
feat: traverse beyond the interactive root

### DIFF
--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -15,6 +15,7 @@ use dua::{
     Config, WalkResult,
     traverse::{BackgroundTraversal, EntryData, Traversal, TreeIndex},
 };
+use petgraph::Direction;
 use std::path::PathBuf;
 use tui::{
     Terminal, backend::Backend, buffer::Buffer, layout::Rect, style::Color, widgets::Widget,
@@ -23,6 +24,14 @@ use tui::{
 use super::notification;
 use super::state::{AppState, Cursor};
 use super::tree_view::TreeView;
+
+/// Information needed to extend the traversal one directory upward:
+///
+/// 0. The parent directory to scan.
+/// 1. Existing subtree roots to preserve as `(filesystem path, tree node)` pairs.
+/// 2. Whether the current root represents a complete directory and must become a child of a new
+///    root. If false, it is a synthetic container that can be repurposed as the parent.
+type ParentScan = (PathBuf, Vec<(PathBuf, TreeIndex)>, bool);
 
 impl AppState {
     pub fn navigation_mut(&mut self) -> &mut Navigation {
@@ -87,6 +96,174 @@ impl AppState {
             active_traversal: bg_traversal,
             previous_selection: None,
         });
+        Ok(())
+    }
+
+    pub(super) fn can_scan_parent(&self, tree: &TreeView<'_>) -> bool {
+        self.parent_scan_target(tree).is_some()
+    }
+
+    fn parent_scan_target(&self, tree: &TreeView<'_>) -> Option<ParentScan> {
+        if self.scan.is_some()
+            || self.glob_navigation.is_some()
+            || self.navigation.view_root != tree.traversal.root_index
+        {
+            return None;
+        }
+
+        if let Some(current_root) = &self.root_path {
+            let parent = current_root.parent()?;
+            return (parent != current_root.as_path()).then(|| {
+                (
+                    parent.to_owned(),
+                    vec![(current_root.clone(), tree.traversal.root_index)],
+                    true,
+                )
+            });
+        }
+
+        let cwd = std::env::current_dir().ok()?;
+        let mut common_parent = None;
+        let mut roots = Vec::new();
+        for index in tree
+            .tree()
+            .neighbors_directed(tree.traversal.root_index, Direction::Outgoing)
+        {
+            let path = tree.path_of(index);
+            let path = if path.is_absolute() {
+                path
+            } else {
+                cwd.join(path)
+            };
+            let name = path.file_name()?.to_owned();
+            let parent = path.parent()?.canonicalize().ok()?;
+            if common_parent
+                .as_ref()
+                .is_some_and(|common| common != &parent)
+            {
+                return None;
+            }
+            roots.push((parent.join(name), index));
+            common_parent = Some(parent);
+        }
+        common_parent.map(|parent| (parent, roots, false))
+    }
+
+    fn scan_parent(&mut self, tree: &mut TreeView<'_>) -> Result<()> {
+        if self.scan.is_some() {
+            self.message = Some("Traversal already running".into());
+            return Ok(());
+        }
+        let Some((parent, preexisting, wrap_root)) = self.parent_scan_target(tree) else {
+            self.message = Some("Top level reached".into());
+            return Ok(());
+        };
+
+        let old_root = tree.traversal.root_index;
+        let new_root = if wrap_root {
+            tree.tree_mut().add_node(EntryData {
+                name: parent.clone(),
+                is_dir: true,
+                ..EntryData::default()
+            })
+        } else {
+            old_root
+        };
+        let pattern_roots = self
+            .walk_options
+            .ignore_patterns
+            .as_ref()
+            .map(|_| std::slice::from_ref(&parent));
+        let active_traversal = match BackgroundTraversal::start_incremental(
+            new_root,
+            &self.walk_options,
+            vec![parent.clone()],
+            pattern_roots,
+            true,
+            false,
+            preexisting
+                .iter()
+                .map(|(path, index)| (path.clone(), *index, wrap_root))
+                .collect(),
+        ) {
+            Ok(traversal) => traversal,
+            Err(err) => {
+                if wrap_root {
+                    tree.tree_mut().remove_node(new_root);
+                }
+                return Err(err);
+            }
+        };
+
+        let previous_selection = self.navigation.selected;
+        if wrap_root {
+            let current_root = self.root_path.as_ref().expect("complete root is set");
+            let entry = tree
+                .tree_mut()
+                .node_weight_mut(old_root)
+                .expect("root exists");
+            entry.name = current_root
+                .file_name()
+                .expect("filesystem roots have no parent")
+                .into();
+            entry.is_dir = true;
+            let children = tree
+                .tree()
+                .neighbors_directed(old_root, Direction::Outgoing)
+                .collect::<Vec<_>>();
+            for child in children {
+                let name = tree.tree()[child]
+                    .name
+                    .file_name()
+                    .expect("children have a file name")
+                    .to_owned();
+                tree.tree_mut()[child].name = name.into();
+            }
+            tree.tree_mut().add_edge(new_root, old_root, ());
+        } else {
+            let root = tree
+                .tree_mut()
+                .node_weight_mut(old_root)
+                .expect("root exists");
+            root.name.clone_from(&parent);
+            root.is_dir = true;
+            for (path, index) in &preexisting {
+                tree.tree_mut()[*index].name = path
+                    .file_name()
+                    .expect("paths with a parent have a file name")
+                    .into();
+            }
+        }
+
+        tree.recompute_sizes_recursively(new_root);
+        tree.traversal.root_index = new_root;
+        self.navigation.tree_root = new_root;
+        self.navigation.view_root = new_root;
+        self.entries = tree.sorted_entries(new_root, self.sorting, self.entry_check());
+        let selected = if wrap_root {
+            Some(old_root)
+        } else {
+            previous_selection
+                .filter(|selected| preexisting.iter().any(|(_, index)| index == selected))
+                .or_else(|| self.entries.first().map(|entry| entry.index))
+        };
+        self.navigation.select(selected);
+        self.update_entry_annotations(tree);
+
+        let previous_selection = selected.and_then(|selected| {
+            self.entries
+                .iter()
+                .position(|entry| entry.index == selected)
+                .map(|position| (tree.tree()[selected].name.clone(), position))
+        });
+        self.root_path = Some(parent.clone());
+        self.root_paths = vec![parent];
+        self.received_events = false;
+        self.scan = Some(FilesystemScan {
+            active_traversal,
+            previous_selection,
+        });
+        self.reset_message();
         Ok(())
     }
 
@@ -467,6 +644,7 @@ impl AppState {
                         window,
                         &tree_view,
                     ),
+                    Char('U') => self.scan_parent(&mut tree_view)?,
                     Char('u' | 'h') | Backspace | Left => {
                         self.exit_node_with_traversal(&tree_view);
                     }

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -120,7 +120,16 @@ impl AppState {
                 self.update_entry_annotations(tree_view);
                 self.reset_message();
             }
-            None => self.message = Some("Top level reached".into()),
+            None => {
+                self.message = Some(
+                    if self.can_scan_parent(tree_view) {
+                        "Top level reached. Press Shift+U to scan the parent directory"
+                    } else {
+                        "Top level reached"
+                    }
+                    .into(),
+                );
+            }
         }
     }
 

--- a/src/interactive/app/state.rs
+++ b/src/interactive/app/state.rs
@@ -61,6 +61,13 @@ pub struct AppState {
     pub walk_options: WalkOptions,
     /// The paths used in the initial traversal, at least 1.
     pub root_paths: Vec<PathBuf>,
+    /// Filesystem directory completely represented by the traversal root, if one exists.
+    ///
+    /// `Some(path)` means the root contains the complete, walk-option-filtered contents of
+    /// `path`; this lets an upward scan reuse the existing tree as that directory's subtree.
+    /// `None` means the root groups explicitly selected paths and may omit their siblings, so it
+    /// cannot itself be treated as a complete directory.
+    pub root_path: Option<PathBuf>,
     /// If true, listed entries will be validated for presence when switching directories.
     pub allow_entry_check: bool,
     /// Whether the next quit/back action should exit the app.
@@ -68,7 +75,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(walk_options: WalkOptions, input: Vec<PathBuf>) -> Self {
+    pub fn new(walk_options: WalkOptions, input: Vec<PathBuf>, root_path: Option<PathBuf>) -> Self {
         AppState {
             navigation: Navigation::default(),
             glob_navigation: None,
@@ -85,6 +92,7 @@ impl AppState {
             stats: TraversalStats::default(),
             walk_options,
             root_paths: input,
+            root_path,
             allow_entry_check: true,
             pending_exit: false,
         }

--- a/src/interactive/app/terminal.rs
+++ b/src/interactive/app/terminal.rs
@@ -32,6 +32,7 @@ impl TerminalApp {
         byte_format: ByteFormat,
         entry_check: bool,
         input: Vec<PathBuf>,
+        root_path: Option<PathBuf>,
         config: Config,
     ) -> Result<TerminalApp>
     where
@@ -47,7 +48,7 @@ impl TerminalApp {
         let display = DisplayOptions::new(byte_format);
         let window = MainWindow::default();
 
-        let mut state = AppState::new(walk_options, input);
+        let mut state = AppState::new(walk_options, input, root_path);
         if config.gitignore == Some(false) {
             state.gitignored_entries = None;
         }

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use pretty_assertions::assert_eq;
-use std::ffi::OsString;
+use std::{ffi::OsString, fs};
 
 use crate::interactive::app::tests::utils::{into_codes, into_events};
 use crate::interactive::widgets::Column;
@@ -10,8 +10,9 @@ use crate::interactive::{
     app::tests::{
         FIXTURE_PATH,
         utils::{
-            fixture_str, index_by_name, initialized_app_and_terminal_from_fixture, into_keys,
-            node_by_index, node_by_name, untraversed_app_and_terminal_from_fixture,
+            fixture, fixture_str, index_by_name, initialized_app_and_terminal_from_fixture,
+            initialized_app_and_terminal_from_paths, into_keys, node_by_index, node_by_name,
+            untraversed_app_and_terminal_from_fixture,
         },
     },
 };
@@ -442,6 +443,101 @@ fn simple_user_journey_read_only() -> Result<()> {
         // tend to just work when they compile, and while experimenting, tests can be in the way.
         // However, if Dua should be more widely used, we need CI and these tests written.
     }
+
+    Ok(())
+}
+
+#[test]
+fn shift_u_scans_the_parent_without_retraversing_the_current_root() -> Result<()> {
+    let (mut terminal, mut app) = initialized_app_and_terminal_from_fixture(&["sample-02/dir"])?;
+    let dir = index_by_name(&app, fixture_str("sample-02/dir"));
+    let sub = index_by_name(&app, "sub");
+    let dir_size = node_by_index(&app, dir).size;
+    let nodes_before = app.traversal.tree.node_count();
+
+    app.process_events(&mut terminal, into_codes("u"))?;
+    assert_eq!(
+        app.state.message.as_deref(),
+        Some("Top level reached. Press Shift+U to scan the parent directory")
+    );
+
+    app.process_events(&mut terminal, into_codes("U"))?;
+    assert!(app.state.scan.is_some(), "Shift+U starts the parent scan");
+    app.run_until_traversed(&mut terminal, into_events([]))?;
+
+    assert_eq!(
+        crate::interactive::path_of(&app.traversal.tree, app.traversal.root_index, None),
+        fixture("sample-02").canonicalize()?,
+        "the shared parent becomes the new root"
+    );
+    assert_eq!(
+        index_by_name(&app, "dir"),
+        dir,
+        "the existing root is reattached instead of replaced"
+    );
+    assert_eq!(
+        index_by_name(&app, "sub"),
+        sub,
+        "the existing subtree keeps its node identities"
+    );
+    assert_eq!(
+        node_by_index(&app, dir).size,
+        dir_size,
+        "an explicit root's own metadata is not counted twice"
+    );
+    assert_eq!(
+        app.traversal.tree.node_count(),
+        nodes_before + 2,
+        "only the two previously unseen siblings are added"
+    );
+    assert_eq!(
+        app.state.stats.entries_traversed, 3,
+        "the existing directory is observed but its descendants are not traversed"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn shift_u_wraps_a_complete_root_at_its_natural_position() -> Result<()> {
+    let current_root = fixture("sample-02/dir").canonicalize()?;
+    let root_paths = fs::read_dir(&current_root)?
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<Result<Vec<_>, _>>()?;
+    let (mut terminal, mut app) = initialized_app_and_terminal_from_paths(&root_paths)?;
+    app.state.root_path = Some(current_root.clone());
+
+    let old_root = app.traversal.root_index;
+    let sub = index_by_name(&app, current_root.join("sub"));
+    let size_before = node_by_index(&app, old_root).size;
+    let count_before = node_by_index(&app, old_root)
+        .entry_count
+        .unwrap_or_default();
+    let nodes_before = app.traversal.tree.node_count();
+
+    app.process_events(&mut terminal, into_codes("U"))?;
+    app.run_until_traversed(&mut terminal, into_events([]))?;
+
+    assert_eq!(
+        crate::interactive::path_of(&app.traversal.tree, app.traversal.root_index, None),
+        current_root.parent().unwrap(),
+        "the complete root's parent becomes the new root"
+    );
+    assert_eq!(
+        index_by_name(&app, "dir"),
+        old_root,
+        "the previous root becomes its naturally named child"
+    );
+    assert_eq!(index_by_name(&app, "sub"), sub);
+    let promoted_root = node_by_index(&app, old_root);
+    assert_eq!(
+        promoted_root.size,
+        size_before + u128::from(current_root.metadata()?.len()),
+        "the promoted node gains the directory entry's own size"
+    );
+    assert_eq!(promoted_root.entry_count, Some(count_before + 1));
+    assert_eq!(app.traversal.tree.node_count(), nodes_before + 3);
+    assert_eq!(app.state.stats.entries_traversed, 3);
 
     Ok(())
 }

--- a/src/interactive/app/tests/journeys_with_writes.rs
+++ b/src/interactive/app/tests/journeys_with_writes.rs
@@ -132,6 +132,7 @@ $precious.tmp
         ByteFormat::Metric,
         true,
         vec![root.to_owned()],
+        None,
         Config::default(),
     )?;
     app.traverse()?;
@@ -270,6 +271,7 @@ fn cleanup_candidates_are_marked_with_one_key_after_entering_project_dir() -> Re
         ByteFormat::Metric,
         true,
         vec![root.to_owned()],
+        None,
         Config::default(),
     )?;
     app.traverse()?;

--- a/src/interactive/app/tests/unit.rs
+++ b/src/interactive/app/tests/unit.rs
@@ -191,6 +191,7 @@ fn it_can_sort_directory_mtimes_by_recursive_entries() {
             metadata_options: dua::TraversalOptions::default(),
         },
         Vec::new(),
+        None,
     );
     state.navigation.view_root = root;
     state.sorting = SortMode::MTimeDescending(MTimeSort::Entry);

--- a/src/interactive/app/tests/utils.rs
+++ b/src/interactive/app/tests/utils.rs
@@ -216,6 +216,7 @@ pub fn untraversed_app_and_terminal_with_closure(
         ByteFormat::Metric,
         false, /* entry-check */
         input_paths,
+        None,
         Config::default(),
     )?;
 

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -8,7 +8,6 @@ mod utils {
     use std::path::PathBuf;
 
     pub fn path_of(tree: &Tree, mut node_idx: TreeIndex, glob_root: Option<TreeIndex>) -> PathBuf {
-        const THE_ROOT: usize = 1;
         let mut entries = Vec::new();
 
         let mut iter = tree.neighbors_directed(node_idx, petgraph::Incoming);
@@ -32,7 +31,7 @@ mod utils {
         entries
             .iter()
             .rev()
-            .skip(THE_ROOT)
+            .filter(|entry| !entry.name.as_os_str().is_empty())
             .fold(PathBuf::new(), |mut acc, entry| {
                 acc.push(&entry.name);
                 acc

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,10 @@ fn main() -> Result<()> {
             let enable_focus_change = config.notifications.any_enabled();
             let byte_format = traversal.byte_format(&config);
             let walk_options = walk_options_from(&traversal)?;
+            let has_complete_root = traversal.input.is_empty()
+                || traversal.input.len() == 1 && traversal.input[0].is_dir();
             let input_paths = extract_paths_maybe_set_cwd(traversal.input, &walk_options)?;
+            let root_path = has_complete_root.then(std::env::current_dir).transpose()?;
 
             let no_tty_msg = "Interactive mode requires a connected terminal";
             if !io::stderr().is_terminal() {
@@ -161,6 +164,7 @@ fn main() -> Result<()> {
                 byte_format,
                 !no_entry_check,
                 input_paths,
+                root_path,
                 config,
             )?;
             app.traverse()?;

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -163,6 +163,7 @@ pub struct BackgroundTraversal {
     skip_root: bool,
     use_root_path: bool,
     retained_depth: Option<usize>,
+    preexisting_nodes: HashMap<PathBuf, (TreeIndex, bool)>,
     /// Receiver used to obtain traversal events from the worker thread.
     pub event_rx: Receiver<TraversalEvent>,
 }
@@ -177,6 +178,62 @@ impl BackgroundTraversal {
         pattern_roots: Option<&[PathBuf]>,
         skip_root: bool,
         use_root_path: bool,
+    ) -> anyhow::Result<BackgroundTraversal> {
+        Self::start_inner(
+            root_idx,
+            walk_options,
+            input,
+            pattern_roots,
+            skip_root,
+            use_root_path,
+            HashMap::new(),
+        )
+    }
+
+    /// Start an incremental traversal that preserves subtrees listed in `preexisting_nodes`.
+    ///
+    /// This is used when extending a traversal to a parent directory: rescanning an existing
+    /// subtree would waste work and duplicate its nodes and totals. Each tuple is
+    /// `(path, node, needs_metadata)`. `needs_metadata` is true when the node was a synthetic
+    /// traversal root that represented the directory's contents but not the directory entry
+    /// itself; once that root becomes a child, its own metadata must be integrated.
+    pub fn start_incremental(
+        root_idx: TreeIndex,
+        walk_options: &WalkOptions,
+        input: Vec<PathBuf>,
+        pattern_roots: Option<&[PathBuf]>,
+        skip_root: bool,
+        use_root_path: bool,
+        preexisting_nodes: Vec<(PathBuf, TreeIndex, bool)>,
+    ) -> anyhow::Result<BackgroundTraversal> {
+        let mut walk_options = walk_options.clone();
+        walk_options.ignore_dirs.extend(
+            preexisting_nodes
+                .iter()
+                .filter_map(|(path, _, _)| gix::path::realpath(path).ok()),
+        );
+        Self::start_inner(
+            root_idx,
+            &walk_options,
+            input,
+            pattern_roots,
+            skip_root,
+            use_root_path,
+            preexisting_nodes
+                .into_iter()
+                .map(|(path, index, needs_metadata)| (path, (index, needs_metadata)))
+                .collect(),
+        )
+    }
+
+    fn start_inner(
+        root_idx: TreeIndex,
+        walk_options: &WalkOptions,
+        input: Vec<PathBuf>,
+        pattern_roots: Option<&[PathBuf]>,
+        skip_root: bool,
+        use_root_path: bool,
+        preexisting_nodes: HashMap<PathBuf, (TreeIndex, bool)>,
     ) -> anyhow::Result<BackgroundTraversal> {
         let num_roots = input.len();
         let (entry_tx, entry_rx) = crossbeam::channel::bounded(100);
@@ -268,6 +325,7 @@ impl BackgroundTraversal {
             skip_root,
             use_root_path,
             retained_depth: None,
+            preexisting_nodes,
             event_rx: entry_rx,
         })
     }
@@ -361,6 +419,7 @@ impl BackgroundTraversal {
 
                 let mut file_size = 0u128;
                 let mut mtime: SystemTime = UNIX_EPOCH;
+                let mut has_mtime = false;
                 data.is_dir = entry.file_type.is_dir();
                 if let Ok(m) = &entry.metadata {
                     if self.walk_options.count_hard_links
@@ -393,6 +452,7 @@ impl BackgroundTraversal {
 
                     if let Ok(modified) = m.modified() {
                         mtime = modified;
+                        has_mtime = true;
                     } else {
                         self.stats.io_errors += 1;
                         data.metadata_io_error = true;
@@ -408,6 +468,38 @@ impl BackgroundTraversal {
                     data.entry_count = Some(1);
                 }
                 let entry_count = u64::from(data.is_dir || data.entry_count != Some(0));
+                if let Some((index, needs_metadata)) = self.preexisting_nodes.remove(&entry.path())
+                {
+                    if needs_metadata {
+                        let existing = &mut traversal.tree[index];
+                        existing.size += file_size;
+                        *existing.entry_count.get_or_insert(0) += entry_count;
+                        if has_mtime {
+                            existing.mtime = data.mtime;
+                        }
+                        existing.metadata_io_error |= data.metadata_io_error;
+                        existing.is_dir = data.is_dir;
+
+                        let mut ancestor = traversal
+                            .tree
+                            .neighbors_directed(index, Direction::Incoming)
+                            .next();
+                        while let Some(ancestor_index) = ancestor {
+                            ancestor = traversal
+                                .tree
+                                .neighbors_directed(ancestor_index, Direction::Incoming)
+                                .next();
+                            let entry = &mut traversal.tree[ancestor_index];
+                            entry.size += file_size;
+                            *entry.entry_count.get_or_insert(0) += entry_count;
+                        }
+                    }
+                    return self
+                        .throttle
+                        .as_ref()
+                        .is_some_and(|t| t.can_update())
+                        .then_some(false);
+                }
                 let retain_entry = self.retained_depth.is_none_or(|depth| walk_depth <= depth);
 
                 let parent_index = if walk_depth == 0 {


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by Codex GPT-5.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

Fixes #82

## Summary

- Advertise `Shift+U` when the interactive view reaches an expandable top level.
- Traverse the unique parent while pruning roots already in the graph, so only unseen paths are scanned.
- Reattach existing roots in their natural positions without changing node identities.
- Preserve size, count, mtime, and error metadata when an existing root is promoted.

## Validation

- `make check-pre-push`
- Regression journeys cover partial roots, complete roots, and roots sharing one parent.

## Commits

- `aee0d91f` feat: traverse beyond the interactive root (#82)
- `03766ee6` fix: account for promoted root metadata
- `fedfad3b` fix: preserve cached mtime on lookup errors
