### PR TITLE
feat: add `stacks` and `flamegraph` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +273,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -684,6 +703,7 @@ dependencies = [
  "filesize",
  "gix",
  "human_format",
+ "inferno",
  "insta",
  "itertools 0.15.0",
  "jiff",
@@ -867,13 +887,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1605,7 +1637,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1731,6 +1763,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inferno"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c460d4fa06223667240720ab69a8045133755ae6dfbe100cf481b95e3a014f1"
+dependencies = [
+ "ahash 0.8.12",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
 ]
 
 [[package]]
@@ -2001,6 +2049,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2312,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2328,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -2423,6 +2496,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -2711,6 +2793,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f446288b699d66d0fd2e30d1cfe7869194312524b3b9252594868ed26ef056a"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ tui-crossplatform = [
     "crossterm",
     "dep:signal-hook",
     "tui",
-    "open",
     "unicode-segmentation",
     "unicode-width",
 ]
@@ -66,6 +65,7 @@ byte-unit = { version = "5.2.5", features = ["u128"] }
 itertools = "0.15.0"
 num_cpus = "1.10.0"
 anyhow = "1.0.31"
+inferno = { version = "0.12.8", default-features = false }
 trash = { version = "5.2.0", optional = true, default-features = false, features = [
     "coinit_apartmentthreaded", "chrono"
 ] }
@@ -78,7 +78,7 @@ crossterm = { version = "0.29.0", optional = true }
 tui = { package = "ratatui", version = "0.30.2", optional = true, default-features = false, features = [
     "crossterm",
 ] }
-open = { version = "5.0", optional = true }
+open = "5.0"
 wild = "2.0.4"
 owo-colors = "4.0.0"
 human_format = "1.0.3"

--- a/README.md
+++ b/README.md
@@ -245,13 +245,20 @@ LANG=ja_JP.UTF-8 dua i   # then press '?' for the Japanese help screen
 
 ### Flame graphs
 
-The `aggregate --stack` option prints the traversal as folded stacks - the "collapsed" format read
-by flame-graph tools like [`inferno`](https://github.com/jonhoo/inferno).
-Each line is an entry's path with `;` between its components, a space, and its size
-in bytes, so an interactive drill-down can be turned into a single shareable SVG:
+`dua stacks` prints folded stacks—the "collapsed" interchange format read by flame-graph tools.
+Each line is an entry's path with `;` between its components, a space, and its size in bytes:
 
 ```bash
-dua aggregate --stack | inferno-flamegraph > disk-usage.svg
+dua stacks > disk-usage.folded
+```
+
+`dua flamegraph` renders the same data with [`inferno`](https://github.com/jonhoo/inferno), writes
+the SVG to a temporary file, and opens it. Pass an output path to write the SVG without opening it.
+Both commands accept the usual traversal options as well as `--depth` and `--import`:
+
+```bash
+dua flamegraph
+dua flamegraph -o disk-usage.svg
 ```
 
 ### Configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,7 +326,15 @@ fn main() -> Result<()> {
                 stdout.lock(),
             )?
         }
-        Some(Flamegraph { args, output }) => {
+        Some(Flamegraph {
+            args,
+            output,
+            palette,
+            width,
+            min_width,
+            title,
+            inverted,
+        }) => {
             if global_format_used {
                 bail!("flamegraph cannot be used with --format");
             }
@@ -339,7 +347,19 @@ fn main() -> Result<()> {
                 args,
                 &mut stacks,
             )?;
-            let path = write_flamegraph(stacks, output)?;
+            let mut options = inferno::flamegraph::Options::default();
+            options.colors = palette;
+            options.image_width = width;
+            options.min_width = min_width;
+            options.title = title;
+            options.direction = if inverted {
+                inferno::flamegraph::Direction::Inverted
+            } else {
+                inferno::flamegraph::Direction::Straight
+            };
+            "bytes".clone_into(&mut options.count_name);
+            "Path:".clone_into(&mut options.name_type);
+            let path = write_flamegraph(stacks, output, &mut options)?;
             if open {
                 open::that(&path)
                     .with_context(|| format!("Could not open flame graph {}", path.display()))?;
@@ -499,13 +519,16 @@ fn run_stacks(
     }
 }
 
-fn write_flamegraph(stacks: Vec<u8>, output: Option<PathBuf>) -> Result<PathBuf> {
+fn write_flamegraph(
+    stacks: Vec<u8>,
+    output: Option<PathBuf>,
+    options: &mut inferno::flamegraph::Options<'_>,
+) -> Result<PathBuf> {
     let stacks = String::from_utf8(stacks).expect("folded stacks are valid UTF-8");
-    let mut options = inferno::flamegraph::Options::default();
     if let Some(path) = output {
         let file = fs::File::create(&path)
             .with_context(|| format!("Could not create flame graph {}", path.display()))?;
-        inferno::flamegraph::from_lines(&mut options, stacks.lines(), file)
+        inferno::flamegraph::from_lines(options, stacks.lines(), file)
             .with_context(|| format!("Could not write flame graph {}", path.display()))?;
         Ok(path)
     } else {
@@ -514,7 +537,7 @@ fn write_flamegraph(stacks: Vec<u8>, output: Option<PathBuf>) -> Result<PathBuf>
             .suffix(".svg")
             .tempfile()
             .context("Could not create temporary flame graph")?;
-        inferno::flamegraph::from_lines(&mut options, stacks.lines(), &mut file)
+        inferno::flamegraph::from_lines(options, stacks.lines(), &mut file)
             .with_context(|| format!("Could not write flame graph {}", file.path().display()))?;
         let (file, path) = file
             .keep()
@@ -1009,13 +1032,19 @@ mod tests {
     fn writes_explicit_and_temporary_flamegraphs() {
         let dir = tempfile::tempdir().expect("temporary directory");
         let explicit = dir.path().join("usage.svg");
-        let path = write_flamegraph(b"root;child 4\n".to_vec(), Some(explicit.clone()))
-            .expect("explicit flame graph");
+        let mut options = inferno::flamegraph::Options::default();
+        let path = write_flamegraph(
+            b"root;child 4\n".to_vec(),
+            Some(explicit.clone()),
+            &mut options,
+        )
+        .expect("explicit flame graph");
         assert_eq!(path, explicit);
         assert!(fs::read_to_string(&path).unwrap().contains("child"));
 
-        let path =
-            write_flamegraph(b"root;child 4\n".to_vec(), None).expect("temporary flame graph");
+        let mut options = inferno::flamegraph::Options::default();
+        let path = write_flamegraph(b"root;child 4\n".to_vec(), None, &mut options)
+            .expect("temporary flame graph");
         assert_eq!(path.extension().and_then(|ext| ext.to_str()), Some("svg"));
         assert!(fs::read_to_string(&path).unwrap().contains("<svg"));
         fs::remove_file(path).expect("remove retained temporary flame graph");

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,10 +94,12 @@ fn marked_path_for_output(path: &Path, stdout_is_terminal: bool) -> std::borrow:
 fn main() -> Result<()> {
     #[cfg(feature = "tui-crossplatform")]
     use options::Command::Interactive;
-    use options::Command::{Aggregate, Completions, Config, Diff};
+    use options::Command::{Aggregate, Completions, Config, Diff, Flamegraph, Stacks};
 
     let matches = options::Args::command().get_matches_from(wild::args_os());
     let global_traversal_options_used = traversal_options_on_command_line(&matches);
+    let global_format_used =
+        matches.value_source("format") == Some(clap::parser::ValueSource::CommandLine);
     let opt = options::Args::from_arg_matches(&matches)?;
 
     if let Some(log_file) = &opt.log_file {
@@ -160,39 +162,40 @@ fn main() -> Result<()> {
             let snapshot = import.as_deref().map(read_snapshot_file).transpose()?;
             let snapshot_load_duration = snapshot_load_start.map(|start| start.elapsed());
             let read_only = snapshot.is_some();
-            let (input_paths, initial_traversal, walk_options, root_path) =
-                if let Some(snapshot) = snapshot {
-                    let input_paths = snapshot
-                        .roots
-                        .iter()
-                        .map(|root| {
-                            snapshot
-                                .traversal
-                                .tree
-                                .name(*root)
-                                .expect("snapshot root exists")
-                                .into_owned()
-                        })
-                        .collect();
-                    (
-                        input_paths,
-                        snapshot.traversal,
-                        snapshot_walk_options(),
-                        None,
-                    )
-                } else {
-                    let walk_options = walk_options_from(&traversal)?;
-                    let has_complete_root = traversal.input.is_empty()
-                        || traversal.input.len() == 1 && traversal.input[0].is_dir();
-                    let input_paths = extract_paths_maybe_set_cwd(traversal.input, &walk_options)?;
-                    let root_path = has_complete_root.then(std::env::current_dir).transpose()?;
-                    (
-                        input_paths,
-                        dua::traverse::Traversal::new(),
-                        walk_options,
-                        root_path,
-                    )
-                };
+            let (input_paths, initial_traversal, walk_options, root_path) = if let Some(snapshot) =
+                snapshot
+            {
+                let input_paths = snapshot
+                    .roots
+                    .iter()
+                    .map(|root| {
+                        snapshot
+                            .traversal
+                            .tree
+                            .name(*root)
+                            .expect("snapshot root exists")
+                            .into_owned()
+                    })
+                    .collect();
+                (
+                    input_paths,
+                    snapshot.traversal,
+                    snapshot_walk_options(),
+                    None,
+                )
+            } else {
+                let walk_options = walk_options_from(&traversal.scan)?;
+                let has_complete_root = traversal.scan.input.is_empty()
+                    || traversal.scan.input.len() == 1 && traversal.scan.input[0].is_dir();
+                let input_paths = extract_paths_maybe_set_cwd(traversal.scan.input, &walk_options)?;
+                let root_path = has_complete_root.then(std::env::current_dir).transpose()?;
+                (
+                    input_paths,
+                    dua::traverse::Traversal::new(),
+                    walk_options,
+                    root_path,
+                )
+            };
 
             let no_tty_msg = "Interactive mode requires a connected terminal";
             if !io::stderr().is_terminal() {
@@ -311,6 +314,38 @@ fn main() -> Result<()> {
             )?;
             dua::WalkResult::default()
         }
+        Some(Stacks { args }) => {
+            if global_format_used {
+                bail!("stacks cannot be used with --format");
+            }
+            let stdout = io::stdout();
+            run_stacks(
+                &global_traversal.scan,
+                global_traversal_options_used,
+                args,
+                stdout.lock(),
+            )?
+        }
+        Some(Flamegraph { args, output }) => {
+            if global_format_used {
+                bail!("flamegraph cannot be used with --format");
+            }
+            let output = output.map(std::path::absolute).transpose()?;
+            let open = output.is_none();
+            let mut stacks = Vec::new();
+            let result = run_stacks(
+                &global_traversal.scan,
+                global_traversal_options_used,
+                args,
+                &mut stacks,
+            )?;
+            let path = write_flamegraph(stacks, output)?;
+            if open {
+                open::that(&path)
+                    .with_context(|| format!("Could not open flame graph {}", path.display()))?;
+            }
+            result
+        }
         Some(Aggregate {
             traversal: subcommand_traversal,
             import,
@@ -320,25 +355,31 @@ fn main() -> Result<()> {
             stack,
             depth,
         }) => {
-            if import.is_some() && global_traversal_options_used {
-                bail!("--import cannot be used with traversal options or input paths");
-            }
-            let traversal = merge_traversal_args(&global_traversal, &subcommand_traversal);
-            if let Some(path) = import {
-                let mut replay = replay_snapshot_file(&path)?;
-                writeln!(
-                    io::stderr(),
-                    "Results are from a traversal snapshot; no filesystem traversal was performed"
-                )
-                .ok();
+            if stack {
                 let stdout = io::stdout();
-                if stack {
-                    dua::stacks_from_replay(
-                        stdout.lock(),
-                        &mut replay,
-                        depth.map(|depth| depth.saturating_sub(1)),
-                    )?
-                } else {
+                run_stacks(
+                    &global_traversal.scan,
+                    global_traversal_options_used,
+                    options::StackArgs {
+                        traversal: subcommand_traversal.scan,
+                        import,
+                        depth,
+                    },
+                    stdout.lock(),
+                )?
+            } else {
+                if import.is_some() && global_traversal_options_used {
+                    bail!("--import cannot be used with traversal options or input paths");
+                }
+                let traversal = merge_traversal_args(&global_traversal, &subcommand_traversal);
+                if let Some(path) = import {
+                    let mut replay = replay_snapshot_file(&path)?;
+                    writeln!(
+                        io::stderr(),
+                        "Results are from a traversal snapshot; no filesystem traversal was performed"
+                    )
+                    .ok();
+                    let stdout = io::stdout();
                     let config = dua::Config::load()?;
                     let byte_format = traversal.byte_format(&config);
                     let out_supports_colors = stdout.is_terminal();
@@ -360,48 +401,41 @@ fn main() -> Result<()> {
                             byte_format,
                         )?
                     }
-                }
-            } else {
-                let walk_options = walk_options_from(&traversal)?;
-                if stack {
-                    let inputs = extract_paths_maybe_set_cwd(traversal.input, &walk_options)?;
-                    let stdout = io::stdout();
-                    dua::stacks(
-                        stdout.lock(),
-                        stderr_if_tty(),
-                        walk_options,
-                        inputs,
-                        depth.map(|depth| depth.saturating_sub(1)),
-                    )?
-                } else if let Some(depth) = depth {
-                    let config = dua::Config::load()?;
-                    let byte_format = traversal.byte_format(&config);
-                    let paths = extract_paths_maybe_set_cwd(traversal.input, &walk_options)?;
-                    let stdout = io::stdout();
-                    let out_supports_colors = stdout.is_terminal();
-                    dua::aggregate_tree(
-                        (stdout.lock(), out_supports_colors),
-                        stderr_if_tty(),
-                        walk_options,
-                        byte_format,
-                        paths,
-                        depth.saturating_sub(1),
-                        !no_total,
-                        !no_sort,
-                    )?
                 } else {
-                    let config = dua::Config::load()?;
-                    let byte_format = traversal.byte_format(&config);
-                    let inputs =
-                        extract_aggregate_inputs_maybe_set_cwd(traversal.input, &walk_options)?;
-                    run_aggregation(
-                        inputs,
-                        walk_options,
-                        !no_total,
-                        !no_sort,
-                        byte_format,
-                        statistics,
-                    )?
+                    let walk_options = walk_options_from(&traversal.scan)?;
+                    if let Some(depth) = depth {
+                        let config = dua::Config::load()?;
+                        let byte_format = traversal.byte_format(&config);
+                        let paths =
+                            extract_paths_maybe_set_cwd(traversal.scan.input, &walk_options)?;
+                        let stdout = io::stdout();
+                        let out_supports_colors = stdout.is_terminal();
+                        dua::aggregate_tree(
+                            (stdout.lock(), out_supports_colors),
+                            stderr_if_tty(),
+                            walk_options,
+                            byte_format,
+                            paths,
+                            depth.saturating_sub(1),
+                            !no_total,
+                            !no_sort,
+                        )?
+                    } else {
+                        let config = dua::Config::load()?;
+                        let byte_format = traversal.byte_format(&config);
+                        let inputs = extract_aggregate_inputs_maybe_set_cwd(
+                            traversal.scan.input,
+                            &walk_options,
+                        )?;
+                        run_aggregation(
+                            inputs,
+                            walk_options,
+                            !no_total,
+                            !no_sort,
+                            byte_format,
+                            statistics,
+                        )?
+                    }
                 }
             }
         }
@@ -424,14 +458,70 @@ fn main() -> Result<()> {
         None => {
             let config = dua::Config::load()?;
             let byte_format = global_traversal.byte_format(&config);
-            let walk_options = walk_options_from(&global_traversal)?;
+            let walk_options = walk_options_from(&global_traversal.scan)?;
             let inputs =
-                extract_aggregate_inputs_maybe_set_cwd(global_traversal.input, &walk_options)?;
+                extract_aggregate_inputs_maybe_set_cwd(global_traversal.scan.input, &walk_options)?;
             run_aggregation(inputs, walk_options, true, true, byte_format, false)?
         }
     };
 
     process::exit(res.to_exit_code());
+}
+
+fn run_stacks(
+    global: &options::ScanArgs,
+    global_options_used: bool,
+    args: options::StackArgs,
+    out: impl io::Write,
+) -> Result<dua::WalkResult> {
+    let options::StackArgs {
+        traversal,
+        import,
+        depth,
+    } = args;
+    let max_depth = depth.map(|depth| depth.saturating_sub(1));
+    if let Some(path) = import {
+        if global_options_used {
+            bail!("--import cannot be used with traversal options or input paths");
+        }
+        let mut replay = replay_snapshot_file(&path)?;
+        writeln!(
+            io::stderr(),
+            "Results are from a traversal snapshot; no filesystem traversal was performed"
+        )
+        .ok();
+        dua::stacks_from_replay(out, &mut replay, max_depth)
+    } else {
+        let traversal = merge_scan_args(global, &traversal);
+        let walk_options = walk_options_from(&traversal)?;
+        let inputs = extract_paths_maybe_set_cwd(traversal.input, &walk_options)?;
+        dua::stacks(out, stderr_if_tty(), walk_options, inputs, max_depth)
+    }
+}
+
+fn write_flamegraph(stacks: Vec<u8>, output: Option<PathBuf>) -> Result<PathBuf> {
+    let stacks = String::from_utf8(stacks).expect("folded stacks are valid UTF-8");
+    let mut options = inferno::flamegraph::Options::default();
+    if let Some(path) = output {
+        let file = fs::File::create(&path)
+            .with_context(|| format!("Could not create flame graph {}", path.display()))?;
+        inferno::flamegraph::from_lines(&mut options, stacks.lines(), file)
+            .with_context(|| format!("Could not write flame graph {}", path.display()))?;
+        Ok(path)
+    } else {
+        let mut file = tempfile::Builder::new()
+            .prefix("dua-flamegraph-")
+            .suffix(".svg")
+            .tempfile()
+            .context("Could not create temporary flame graph")?;
+        inferno::flamegraph::from_lines(&mut options, stacks.lines(), &mut file)
+            .with_context(|| format!("Could not write flame graph {}", file.path().display()))?;
+        let (file, path) = file
+            .keep()
+            .context("Could not retain temporary flame graph")?;
+        drop(file);
+        Ok(path)
+    }
 }
 
 enum AggregateInputs {
@@ -525,12 +615,21 @@ fn merge_traversal_args(
     subcommand: &options::TraversalArgs,
 ) -> options::TraversalArgs {
     options::TraversalArgs {
+        scan: merge_scan_args(&global.scan, &subcommand.scan),
+        format: global.format.or(subcommand.format),
+    }
+}
+
+fn merge_scan_args(
+    global: &options::ScanArgs,
+    subcommand: &options::ScanArgs,
+) -> options::ScanArgs {
+    options::ScanArgs {
         threads: if global.threads == options::DEFAULT_THREADS {
             subcommand.threads
         } else {
             global.threads
         },
-        format: global.format.or(subcommand.format),
         apparent_size: global.apparent_size || subcommand.apparent_size,
         count_hard_links: global.count_hard_links || subcommand.count_hard_links,
         #[cfg(target_os = "macos")]
@@ -552,7 +651,7 @@ fn merge_traversal_args(
     }
 }
 
-fn walk_options_from(traversal: &options::TraversalArgs) -> Result<dua::WalkOptions> {
+fn walk_options_from(traversal: &options::ScanArgs) -> Result<dua::WalkOptions> {
     let mut walk_options = dua::WalkOptions {
         threads: traversal.threads,
         apparent_size: traversal.apparent_size,
@@ -798,10 +897,33 @@ fn write_default_config_file(path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::traversal_options_on_command_line;
-    use super::{marked_path_for_output, merge_traversal_args, write_default_config_file};
+    use super::{
+        marked_path_for_output, merge_traversal_args, write_default_config_file, write_flamegraph,
+    };
     use clap::CommandFactory as _;
     use std::fs;
     use std::path::PathBuf;
+
+    fn scan_args() -> super::options::ScanArgs {
+        super::options::ScanArgs {
+            threads: super::options::DEFAULT_THREADS,
+            apparent_size: false,
+            count_hard_links: false,
+            #[cfg(target_os = "macos")]
+            deduplicate_apfs_clones: false,
+            stay_on_filesystem: false,
+            ignore_dirs: vec![],
+            ignore_from: vec![],
+            input: vec![],
+        }
+    }
+
+    fn traversal_args() -> super::options::TraversalArgs {
+        super::options::TraversalArgs {
+            scan: scan_args(),
+            format: None,
+        }
+    }
 
     #[test]
     fn marked_paths_are_only_sanitized_for_terminals() {
@@ -883,6 +1005,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn writes_explicit_and_temporary_flamegraphs() {
+        let dir = tempfile::tempdir().expect("temporary directory");
+        let explicit = dir.path().join("usage.svg");
+        let path = write_flamegraph(b"root;child 4\n".to_vec(), Some(explicit.clone()))
+            .expect("explicit flame graph");
+        assert_eq!(path, explicit);
+        assert!(fs::read_to_string(&path).unwrap().contains("child"));
+
+        let path =
+            write_flamegraph(b"root;child 4\n".to_vec(), None).expect("temporary flame graph");
+        assert_eq!(path.extension().and_then(|ext| ext.to_str()), Some("svg"));
+        assert!(fs::read_to_string(&path).unwrap().contains("<svg"));
+        fs::remove_file(path).expect("remove retained temporary flame graph");
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn walk_options_only_request_apfs_clones_for_allocated_size() {
@@ -892,17 +1030,10 @@ mod tests {
             (true, false, false),
             (true, true, false),
         ] {
-            let traversal = super::options::TraversalArgs {
-                threads: 1,
-                format: None,
-                apparent_size,
-                count_hard_links: false,
-                deduplicate_apfs_clones,
-                stay_on_filesystem: false,
-                ignore_dirs: vec![],
-                ignore_from: vec![],
-                input: vec![],
-            };
+            let mut traversal = scan_args();
+            traversal.threads = 1;
+            traversal.apparent_size = apparent_size;
+            traversal.deduplicate_apfs_clones = deduplicate_apfs_clones;
             let walk_options =
                 super::walk_options_from(&traversal).expect("valid traversal options");
 
@@ -918,38 +1049,24 @@ mod tests {
     #[test]
     fn merge_traversal_args_prefers_global_threads() {
         let custom_threads = super::options::DEFAULT_THREADS + 1;
-        let global = super::options::TraversalArgs {
-            threads: custom_threads,
-            format: None,
-            apparent_size: true,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![],
-            ignore_from: vec![PathBuf::from("global-ignore")],
-            input: vec![],
-        };
+        let mut global = traversal_args();
+        global.scan.threads = custom_threads;
+        global.scan.apparent_size = true;
+        global.scan.ignore_from = vec![PathBuf::from("global-ignore")];
 
-        let subcommand = super::options::TraversalArgs {
-            threads: 2,
-            format: None,
-            apparent_size: false,
-            count_hard_links: true,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: true,
-            ignore_dirs: vec![],
-            ignore_from: vec![PathBuf::from("subcommand-ignore")],
-            input: vec![PathBuf::from("subcommand-input")],
-        };
+        let mut subcommand = traversal_args();
+        subcommand.scan.threads = 2;
+        subcommand.scan.count_hard_links = true;
+        subcommand.scan.stay_on_filesystem = true;
+        subcommand.scan.ignore_from = vec![PathBuf::from("subcommand-ignore")];
+        subcommand.scan.input = vec![PathBuf::from("subcommand-input")];
 
         let merged = merge_traversal_args(&global, &subcommand);
 
-        assert_eq!(merged.threads, custom_threads);
-        assert_eq!(merged.input, subcommand.input);
+        assert_eq!(merged.scan.threads, custom_threads);
+        assert_eq!(merged.scan.input, subcommand.scan.input);
         assert_eq!(
-            merged.ignore_from,
+            merged.scan.ignore_from,
             [
                 PathBuf::from("global-ignore"),
                 PathBuf::from("subcommand-ignore")
@@ -959,141 +1076,65 @@ mod tests {
 
     #[test]
     fn merge_traversal_args_uses_subcommand_threads_when_global_is_default() {
-        let global = super::options::TraversalArgs {
-            threads: super::options::DEFAULT_THREADS,
-            format: None,
-            apparent_size: false,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![],
-            ignore_from: vec![],
-            input: vec![],
-        };
-
-        let subcommand = super::options::TraversalArgs {
-            threads: 6,
-            format: None,
-            apparent_size: false,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![],
-            ignore_from: vec![],
-            input: vec![],
-        };
+        let global = traversal_args();
+        let mut subcommand = traversal_args();
+        subcommand.scan.threads = 6;
 
         let merged = merge_traversal_args(&global, &subcommand);
 
-        assert_eq!(merged.threads, 6);
+        assert_eq!(merged.scan.threads, 6);
     }
 
     #[test]
     fn merge_traversal_args_uses_global_format_and_or_booleans() {
-        let global = super::options::TraversalArgs {
-            threads: super::options::DEFAULT_THREADS,
-            format: Some(super::options::ByteFormat::MB),
-            apparent_size: true,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: true,
-            stay_on_filesystem: true,
-            ignore_dirs: vec![],
-            ignore_from: vec![],
-            input: vec![],
-        };
+        let mut global = traversal_args();
+        global.format = Some(super::options::ByteFormat::MB);
+        global.scan.apparent_size = true;
+        #[cfg(target_os = "macos")]
+        {
+            global.scan.deduplicate_apfs_clones = true;
+        }
+        global.scan.stay_on_filesystem = true;
 
-        let subcommand = super::options::TraversalArgs {
-            threads: 4,
-            format: Some(super::options::ByteFormat::GB),
-            apparent_size: false,
-            count_hard_links: true,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![],
-            ignore_from: vec![],
-            input: vec![],
-        };
+        let mut subcommand = traversal_args();
+        subcommand.scan.threads = 4;
+        subcommand.format = Some(super::options::ByteFormat::GB);
+        subcommand.scan.count_hard_links = true;
 
         let merged = merge_traversal_args(&global, &subcommand);
 
         assert_eq!(merged.format, Some(super::options::ByteFormat::MB));
-        assert!(merged.apparent_size);
-        assert!(merged.count_hard_links);
+        assert!(merged.scan.apparent_size);
+        assert!(merged.scan.count_hard_links);
         #[cfg(target_os = "macos")]
-        assert!(merged.deduplicate_apfs_clones);
-        assert!(merged.stay_on_filesystem);
+        assert!(merged.scan.deduplicate_apfs_clones);
+        assert!(merged.scan.stay_on_filesystem);
     }
 
     #[test]
     fn merge_traversal_args_prefers_global_ignore_dirs_when_custom() {
-        let global = super::options::TraversalArgs {
-            threads: super::options::DEFAULT_THREADS,
-            format: None,
-            apparent_size: false,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![PathBuf::from("/custom-global-ignore")],
-            ignore_from: vec![],
-            input: vec![],
-        };
-
-        let subcommand = super::options::TraversalArgs {
-            threads: super::options::DEFAULT_THREADS,
-            format: None,
-            apparent_size: false,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![PathBuf::from("/custom-subcommand-ignore")],
-            ignore_from: vec![],
-            input: vec![],
-        };
+        let mut global = traversal_args();
+        global.scan.ignore_dirs = vec![PathBuf::from("/custom-global-ignore")];
+        let mut subcommand = traversal_args();
+        subcommand.scan.ignore_dirs = vec![PathBuf::from("/custom-subcommand-ignore")];
 
         let merged = merge_traversal_args(&global, &subcommand);
 
-        assert_eq!(merged.ignore_dirs, global.ignore_dirs);
+        assert_eq!(merged.scan.ignore_dirs, global.scan.ignore_dirs);
     }
 
     #[test]
     fn merge_traversal_args_uses_subcommand_ignore_dirs_when_global_is_default() {
-        let global = super::options::TraversalArgs {
-            threads: super::options::DEFAULT_THREADS,
-            format: None,
-            apparent_size: false,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: super::options::DEFAULT_IGNORE_DIRS
-                .iter()
-                .map(PathBuf::from)
-                .collect(),
-            ignore_from: vec![],
-            input: vec![],
-        };
-
-        let subcommand = super::options::TraversalArgs {
-            threads: super::options::DEFAULT_THREADS,
-            format: None,
-            apparent_size: false,
-            count_hard_links: false,
-            #[cfg(target_os = "macos")]
-            deduplicate_apfs_clones: false,
-            stay_on_filesystem: false,
-            ignore_dirs: vec![PathBuf::from("/custom-subcommand-ignore")],
-            ignore_from: vec![],
-            input: vec![],
-        };
+        let mut global = traversal_args();
+        global.scan.ignore_dirs = super::options::DEFAULT_IGNORE_DIRS
+            .iter()
+            .map(PathBuf::from)
+            .collect();
+        let mut subcommand = traversal_args();
+        subcommand.scan.ignore_dirs = vec![PathBuf::from("/custom-subcommand-ignore")];
 
         let merged = merge_traversal_args(&global, &subcommand);
 
-        assert_eq!(merged.ignore_dirs, subcommand.ignore_dirs);
+        assert_eq!(merged.scan.ignore_dirs, subcommand.scan.ignore_dirs);
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,3 +1,4 @@
+use clap::builder::TypedValueParser;
 use clap_complete::Shell;
 use dua::ByteFormat as LibraryByteFormat;
 use std::path::PathBuf;
@@ -36,6 +37,16 @@ fn dft_format() -> ByteFormat {
 }
 
 const DEFAULT_DIFF_SUMMARY_LIMIT: usize = 5;
+
+fn parse_percentage(value: &str) -> Result<f64, String> {
+    let percentage = value
+        .parse::<f64>()
+        .map_err(|_| format!("invalid percentage: {value}"))?;
+    (0.0..=100.0)
+        .contains(&percentage)
+        .then_some(percentage)
+        .ok_or_else(|| "percentage must be between 0 and 100".to_owned())
+}
 
 #[cfg(feature = "tui-crossplatform")]
 fn parse_snapshot_compression_level(value: &str) -> Result<i32, String> {
@@ -299,8 +310,34 @@ pub enum Command {
         #[clap(flatten)]
         args: StackArgs,
         /// Write the SVG to this file instead of opening a temporary file.
-        #[clap(short = 'o', long, value_name = "FILE")]
+        #[clap(short = 'o', long, value_name = "FILE", help_heading = "SVG Options")]
         output: Option<PathBuf>,
+        /// Set the frame color palette.
+        #[clap(
+            long,
+            default_value = inferno::flamegraph::defaults::COLORS,
+            value_parser = clap::builder::PossibleValuesParser::new(inferno::flamegraph::Palette::VARIANTS).map(|name| name.parse::<inferno::flamegraph::Palette>().expect("known palette")),
+            value_name = "PALETTE",
+            help_heading = "SVG Options"
+        )]
+        palette: inferno::flamegraph::Palette,
+        /// Set the image width in pixels. By default, the SVG uses the available width.
+        #[clap(long, value_name = "PIXELS", value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..), help_heading = "SVG Options")]
+        width: Option<usize>,
+        /// Omit frames narrower than this percentage.
+        #[clap(long, default_value_t = inferno::flamegraph::defaults::MIN_WIDTH, value_name = "PERCENT", value_parser = parse_percentage, help_heading = "SVG Options")]
+        min_width: f64,
+        /// Set the graph title.
+        #[clap(
+            long,
+            default_value = "Disk Usage Flame Graph",
+            value_name = "TEXT",
+            help_heading = "SVG Options"
+        )]
+        title: String,
+        /// Grow stacks from top to bottom.
+        #[clap(long, help_heading = "SVG Options")]
+        inverted: bool,
     },
     /// Aggregate the consumed space of one or more directories or files
     #[clap(name = "aggregate", visible_alias = "a")]
@@ -401,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn stack_commands_accept_only_stack_options() {
+    fn stack_commands_accept_only_relevant_options() {
         let args = Args::try_parse_from(["dua", "stacks", "--import", "scan.dua", "--depth", "2"])
             .expect("stacks accepts snapshot and depth options");
         assert!(matches!(
@@ -415,17 +452,47 @@ mod tests {
             }) if path == std::path::Path::new("scan.dua")
         ));
 
-        let args =
-            Args::try_parse_from(["dua", "flamegraph", "--output", "usage.svg", "somewhere"])
-                .expect("flamegraph accepts an output and traversal input");
-        assert!(matches!(
-            args.command,
-            Some(super::Command::Flamegraph {
-                args: super::StackArgs { traversal, .. },
-                output: Some(path),
-            }) if path == std::path::Path::new("usage.svg")
-                && traversal.input == [PathBuf::from("somewhere")]
-        ));
+        let args = Args::try_parse_from([
+            "dua",
+            "flamegraph",
+            "--output",
+            "usage.svg",
+            "--palette",
+            "blue",
+            "--width",
+            "640",
+            "--min-width",
+            "0.5",
+            "--title",
+            "Disk map",
+            "--inverted",
+            "somewhere",
+        ])
+        .expect("flamegraph accepts SVG and traversal options");
+        let Some(super::Command::Flamegraph {
+            args: super::StackArgs { traversal, .. },
+            output: Some(path),
+            palette,
+            width,
+            min_width,
+            title,
+            inverted,
+        }) = args.command
+        else {
+            panic!("expected flamegraph subcommand");
+        };
+        assert_eq!(path, std::path::Path::new("usage.svg"));
+        assert_eq!(traversal.input, [PathBuf::from("somewhere")]);
+        assert_eq!(palette, "blue".parse().unwrap());
+        assert_eq!(width, Some(640));
+        assert!((min_width - 0.5).abs() < f64::EPSILON);
+        assert_eq!(title, "Disk map");
+        assert!(inverted);
+
+        for value in ["-1", "101", "NaN"] {
+            Args::try_parse_from(["dua", "flamegraph", "--min-width", value])
+                .expect_err("minimum width must be a finite percentage");
+        }
 
         for flag in ["--format", "--stats", "--no-sort", "--no-total", "--stack"] {
             let err = Args::try_parse_from(["dua", "stacks", flag])
@@ -609,6 +676,19 @@ mod tests {
             assert!(help.contains("--depth"));
             for irrelevant in ["--format", "--stats", "--no-sort", "--no-total"] {
                 assert!(!help.contains(irrelevant), "{name} exposes {irrelevant}");
+            }
+            for svg_option in [
+                "--palette",
+                "--width",
+                "--min-width",
+                "--title",
+                "--inverted",
+            ] {
+                assert_eq!(
+                    help.contains(svg_option),
+                    name == "flamegraph",
+                    "{name} has the wrong visibility for {svg_option}"
+                );
             }
         }
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -89,24 +89,9 @@ impl TraversalArgs {
 }
 
 #[derive(Debug, Clone, clap::Args)]
-#[cfg_attr(
-    target_os = "macos",
-    expect(
-        clippy::struct_excessive_bools,
-        reason = "independent command-line switches map directly to booleans"
-    )
-)]
 pub struct TraversalArgs {
-    /// The amount of threads to use. Defaults to 0, indicating the amount of logical processors.
-    /// Set to 1 to use only a single thread.
-    #[clap(
-        short = 't',
-        long = "threads",
-        default_value_t = DEFAULT_THREADS,
-        env = "DUA_THREADS",
-        help_heading = "Traversal Options"
-    )]
-    pub threads: usize,
+    #[clap(flatten)]
+    pub scan: ScanArgs,
 
     /// The format with which to print byte counts.
     #[clap(
@@ -118,6 +103,27 @@ pub struct TraversalArgs {
         help_heading = "Traversal Options"
     )]
     pub format: Option<ByteFormat>,
+}
+
+#[derive(Debug, Clone, clap::Args)]
+#[cfg_attr(
+    target_os = "macos",
+    expect(
+        clippy::struct_excessive_bools,
+        reason = "independent command-line switches map directly to booleans"
+    )
+)]
+pub struct ScanArgs {
+    /// The amount of threads to use. Defaults to 0, indicating the amount of logical processors.
+    /// Set to 1 to use only a single thread.
+    #[clap(
+        short = 't',
+        long = "threads",
+        default_value_t = DEFAULT_THREADS,
+        env = "DUA_THREADS",
+        help_heading = "Traversal Options"
+    )]
+    pub threads: usize,
 
     /// Display apparent size instead of disk usage.
     #[clap(
@@ -184,6 +190,33 @@ pub struct TraversalArgs {
     /// One or more input files or directories. If unset, we will use all entries in the current working directory.
     #[clap(value_parser)]
     pub input: Vec<PathBuf>,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct StackArgs {
+    #[clap(flatten)]
+    pub traversal: ScanArgs,
+
+    /// Load a traversal snapshot instead of scanning the filesystem.
+    #[clap(
+        long,
+        value_name = "FILE",
+        conflicts_with_all = [
+            "input",
+            "threads",
+            "apparent_size",
+            "count_hard_links",
+            "stay_on_filesystem",
+            "ignore_dirs",
+            "ignore_from"
+        ]
+    )]
+    #[cfg_attr(target_os = "macos", clap(conflicts_with = "deduplicate_apfs_clones"))]
+    pub import: Option<PathBuf>,
+
+    /// Limit folded output to this many levels. The inputs form the first level.
+    #[clap(short = 'd', long, value_name = "DEPTH", value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..))]
+    pub depth: Option<usize>,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -256,6 +289,19 @@ pub enum Command {
         #[clap(long, value_name = "COUNT", default_value_t = DEFAULT_DIFF_SUMMARY_LIMIT)]
         summary_limit: usize,
     },
+    /// Print folded stacks for flame-graph tools
+    Stacks {
+        #[clap(flatten)]
+        args: StackArgs,
+    },
+    /// Render disk usage as an SVG flame graph
+    Flamegraph {
+        #[clap(flatten)]
+        args: StackArgs,
+        /// Write the SVG to this file instead of opening a temporary file.
+        #[clap(short = 'o', long, value_name = "FILE")]
+        output: Option<PathBuf>,
+    },
     /// Aggregate the consumed space of one or more directories or files
     #[clap(name = "aggregate", visible_alias = "a")]
     Aggregate {
@@ -289,11 +335,14 @@ pub enum Command {
         #[clap(long)]
         no_total: bool,
         /// Print folded stacks for flame-graph tools instead of a table or tree.
-        #[clap(long, conflicts_with_all = ["statistics", "no_sort", "no_total"])]
+        #[clap(
+            long,
+            hide = true,
+            conflicts_with_all = ["statistics", "no_sort", "no_total"]
+        )]
         stack: bool,
         /// Print an indented tree that descends this many levels into each input, instead of the
-        /// flat listing. With `--stack`, limit the folded output to the same depth. The inputs form
-        /// the first level, so a depth of 1 lists just them.
+        /// flat listing. The inputs form the first level, so a depth of 1 lists just them.
         #[clap(short = 'd', long, conflicts_with = "statistics", value_name = "DEPTH", value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..))]
         depth: Option<usize>,
     },
@@ -352,6 +401,40 @@ mod tests {
     }
 
     #[test]
+    fn stack_commands_accept_only_stack_options() {
+        let args = Args::try_parse_from(["dua", "stacks", "--import", "scan.dua", "--depth", "2"])
+            .expect("stacks accepts snapshot and depth options");
+        assert!(matches!(
+            args.command,
+            Some(super::Command::Stacks {
+                args: super::StackArgs {
+                    import: Some(path),
+                    depth: Some(2),
+                    ..
+                }
+            }) if path == std::path::Path::new("scan.dua")
+        ));
+
+        let args =
+            Args::try_parse_from(["dua", "flamegraph", "--output", "usage.svg", "somewhere"])
+                .expect("flamegraph accepts an output and traversal input");
+        assert!(matches!(
+            args.command,
+            Some(super::Command::Flamegraph {
+                args: super::StackArgs { traversal, .. },
+                output: Some(path),
+            }) if path == std::path::Path::new("usage.svg")
+                && traversal.input == [PathBuf::from("somewhere")]
+        ));
+
+        for flag in ["--format", "--stats", "--no-sort", "--no-total", "--stack"] {
+            let err = Args::try_parse_from(["dua", "stacks", flag])
+                .expect_err("display option should not be available to stacks");
+            assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
+        }
+    }
+
+    #[test]
     fn traversal_options_before_aggregate_still_parse_as_subcommand() {
         let args = Args::try_parse_from(["dua", "--format", "metric", "aggregate", "--stats", "."])
             .expect("root traversal options can precede aggregate");
@@ -365,7 +448,7 @@ mod tests {
             panic!("expected aggregate subcommand");
         };
         assert!(statistics);
-        assert_eq!(traversal.input, [std::path::PathBuf::from(".")]);
+        assert_eq!(traversal.scan.input, [std::path::PathBuf::from(".")]);
     }
 
     #[test]
@@ -382,12 +465,12 @@ mod tests {
         ])
         .expect("ignore-from parses at both levels");
 
-        assert_eq!(args.traversal.ignore_from, [PathBuf::from("global")]);
+        assert_eq!(args.traversal.scan.ignore_from, [PathBuf::from("global")]);
         let Some(super::Command::Aggregate { traversal, .. }) = args.command else {
             panic!("expected aggregate subcommand");
         };
         assert_eq!(
-            traversal.ignore_from,
+            traversal.scan.ignore_from,
             [PathBuf::from("sub-one"), PathBuf::from("sub-two")]
         );
     }
@@ -513,6 +596,21 @@ mod tests {
             .to_string();
         assert!(aggregate_help.contains("Traversal Options"));
         assert!(aggregate_help.contains("--format"));
+        assert!(!aggregate_help.contains("--stack"));
+
+        for name in ["stacks", "flamegraph"] {
+            let help = cmd
+                .find_subcommand_mut(name)
+                .expect("stack command")
+                .render_long_help()
+                .to_string();
+            assert!(help.contains("Traversal Options"));
+            assert!(help.contains("--import"));
+            assert!(help.contains("--depth"));
+            for irrelevant in ["--format", "--stats", "--no-sort", "--no-total"] {
+                assert!(!help.contains(irrelevant), "{name} exposes {irrelevant}");
+            }
+        }
     }
 
     #[test]
@@ -646,7 +744,7 @@ mod tests {
         assert_eq!(import, None);
         assert_eq!(export, Some(PathBuf::from("scan.dua")));
         assert_eq!(compression, 2);
-        assert_eq!(traversal.input, [PathBuf::from("somewhere")]);
+        assert_eq!(traversal.scan.input, [PathBuf::from("somewhere")]);
 
         assert!(matches!(
             Args::try_parse_from([

--- a/tests/stack_commands.rs
+++ b/tests/stack_commands.rs
@@ -21,12 +21,30 @@ fn stacks_and_flamegraph_commands_use_the_folded_output() {
 
     let flamegraph = Command::new(env!("CARGO_BIN_EXE_dua"))
         .current_dir(fixture.path())
-        .args(["flamegraph", "--output", "usage.svg", "input"])
+        .args([
+            "flamegraph",
+            "--output",
+            "usage.svg",
+            "--palette",
+            "blue",
+            "--width",
+            "640",
+            "--min-width",
+            "0",
+            "--title",
+            "Fixture Disk Usage",
+            "--inverted",
+            "input",
+        ])
         .output()
         .unwrap();
     assert!(flamegraph.status.success());
     assert!(flamegraph.stdout.is_empty());
     let svg = fs::read_to_string(fixture.path().join("usage.svg")).unwrap();
     assert!(svg.contains("<svg"));
+    assert!(svg.contains("width=\"640\""));
+    assert!(svg.contains(">Fixture Disk Usage</text>"));
+    assert!(svg.contains("bytes"));
+    assert!(svg.contains("Path:"));
     assert!(svg.contains("payload"));
 }

--- a/tests/stack_commands.rs
+++ b/tests/stack_commands.rs
@@ -1,0 +1,32 @@
+use std::{fs, process::Command};
+
+#[test]
+fn stacks_and_flamegraph_commands_use_the_folded_output() {
+    let fixture = tempfile::tempdir().unwrap();
+    let input = fixture.path().join("input");
+    fs::create_dir(&input).unwrap();
+    fs::write(input.join("payload"), b"data").unwrap();
+
+    let stacks = Command::new(env!("CARGO_BIN_EXE_dua"))
+        .args(["stacks", input.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let legacy = Command::new(env!("CARGO_BIN_EXE_dua"))
+        .args(["aggregate", "--stack", input.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(stacks.status.success());
+    assert!(legacy.status.success());
+    assert_eq!(stacks.stdout, legacy.stdout);
+
+    let flamegraph = Command::new(env!("CARGO_BIN_EXE_dua"))
+        .current_dir(fixture.path())
+        .args(["flamegraph", "--output", "usage.svg", "input"])
+        .output()
+        .unwrap();
+    assert!(flamegraph.status.success());
+    assert!(flamegraph.stdout.is_empty());
+    let svg = fs::read_to_string(fixture.path().join("usage.svg")).unwrap();
+    assert!(svg.contains("<svg"));
+    assert!(svg.contains("payload"));
+}


### PR DESCRIPTION

## Tasks

* [x] refackiew

<!-- agent -->
## Summary

- Promote folded output previously at `dua aggregate --stacks` to the first-class `dua stacks` command
- Add `dua flamegraph`, backed by Inferno, with temporary opening by default and `--output` for file-only output.
- Keep `aggregate --stack` as a hidden compatibility path and limit the new commands to relevant traversal flags.
