### PR TITLE
Repaint the interactive screen with Ctrl-L

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -433,6 +433,8 @@ pub struct KeysConfig {
     pub quit_immediately: KeyBindings,
     /// Suspend the process and return control to the shell on Unix.
     pub suspend: KeyBindings,
+    /// Clear and repaint the screen.
+    pub repaint: KeyBindings,
     /// Move focus to the next open pane.
     pub cycle_panes: KeyBindings,
     /// Show or hide help.
@@ -525,6 +527,7 @@ impl Default for KeysConfig {
             quit: KeyBindings::defaults(&["q"]),
             quit_immediately: KeyBindings::defaults(&["ctrl+c"]),
             suspend: KeyBindings::defaults(&["ctrl+z"]),
+            repaint: KeyBindings::defaults(&["ctrl+l"]),
             cycle_panes: KeyBindings::defaults(&["tab"]),
             toggle_help: KeyBindings::defaults(&["?"]),
             open_search: KeyBindings::defaults(&["/"]),
@@ -638,6 +641,7 @@ impl Config {
             "# quit = \"q\"\n",
             "# quit_immediately = \"ctrl+c\"\n",
             "# suspend = \"ctrl+z\" # Unix only.\n",
+            "# repaint = \"ctrl+l\"\n",
             "# cycle_panes = \"tab\"\n",
             "# toggle_help = \"?\"\n",
             "# open_search = \"/\"\n",
@@ -723,6 +727,7 @@ mod tests {
             "quit",
             "quit_immediately",
             "suspend",
+            "repaint",
             "cycle_panes",
             "toggle_help",
             "open_search",

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -580,7 +580,7 @@ impl AppState {
                 return Ok(None);
             }
             Event::Key(key) if key.kind != KeyEventKind::Release => {
-                if key != refresh_key() {
+                if key != refresh_key() && !config.keys.repaint.matches(key) {
                     self.received_events = true;
                 }
                 key
@@ -611,6 +611,13 @@ impl AppState {
                 #[cfg(unix)]
                 _ if keys.suspend.matches(key) => {
                     suspend_terminal(terminal, config.notifications.any_enabled())?;
+                }
+                _ if keys.repaint.matches(key) => {
+                    terminal
+                        .backend_mut()
+                        .clear()
+                        .map_err(|err| anyhow::Error::msg(err.to_string()))?;
+                    terminal.swap_buffers();
                 }
                 _ if keys.cycle_panes.matches(key) => {
                     self.cycle_focus(window);

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use pretty_assertions::assert_eq;
 use std::{ffi::OsString, fs, time::Duration};
+use tui::backend::Backend;
 
 use crate::interactive::app::tests::utils::{into_codes, into_events};
 use crate::interactive::widgets::Column;
@@ -620,6 +621,24 @@ fn tracks_terminal_focus_events() -> Result<()> {
 
     app.process_events(&mut terminal, into_events([Event::FocusGained]))?;
     assert!(app.state.terminal_focus.is_focussed());
+    Ok(())
+}
+
+#[test]
+fn ctrl_l_repaints_the_screen() -> Result<()> {
+    let (mut terminal, mut app) = initialized_app_and_terminal_from_fixture(&["sample-01"])?;
+    let expected = terminal.backend().buffer().clone();
+    terminal.backend_mut().clear()?;
+
+    app.process_events(
+        &mut terminal,
+        into_events([Event::Key(KeyEvent::new(
+            KeyCode::Char('l'),
+            KeyModifiers::CONTROL,
+        ))]),
+    )?;
+
+    assert_eq!(terminal.backend().buffer(), &expected);
     Ok(())
 }
 

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -227,6 +227,9 @@ impl HelpPane {
             }
             title(t.app_title);
             {
+                #[cfg(unix)]
+                hotkey(keys.suspend.to_string(), t.app_suspend, None);
+                hotkey(keys.repaint.to_string(), t.app_repaint, None);
                 hotkey(keys.quit_immediately.to_string(), t.app_quit, None);
                 spacer();
             }
@@ -343,6 +346,8 @@ mod tests {
             r#"
             [keys]
             quit_immediately = ["alt+x"]
+            suspend = ["alt+z"]
+            repaint = ["ctrl+r"]
             descend = ["f"]
             delete_marked = []
             "#,
@@ -351,6 +356,11 @@ mod tests {
 
         let text = rendered_with_keys(Language::English, &config.keys);
         assert!(text.contains("Alt + x"));
+        #[cfg(unix)]
+        assert!(
+            text.contains("Alt + z => Suspend the application and return control to the shell.")
+        );
+        assert!(text.contains("Ctrl + r => Clear and repaint the screen."));
         assert!(text.contains("f => Descent"));
         assert!(text.contains("<unmapped> => Permanently delete all marked entries"));
         assert!(!text.contains("Ctrl + c"));

--- a/src/interactive/widgets/i18n.rs
+++ b/src/interactive/widgets/i18n.rs
@@ -136,6 +136,8 @@ pub struct HelpText {
     pub mark_trash_2: &'static str,
 
     pub app_title: &'static str,
+    pub app_suspend: &'static str,
+    pub app_repaint: &'static str,
     pub app_quit: &'static str,
 }
 
@@ -198,6 +200,8 @@ const EN: HelpText = HelpText {
     mark_trash_2: "The entries can be restored from the trash bin.",
 
     app_title: "Application control",
+    app_suspend: "Suspend the application and return control to the shell.",
+    app_repaint: "Clear and repaint the screen.",
     app_quit: "Close the application. No questions asked!",
 };
 
@@ -260,6 +264,8 @@ const JA: HelpText = HelpText {
     mark_trash_2: "エントリはゴミ箱から復元できる。",
 
     app_title: "アプリ操作",
+    app_suspend: "アプリケーションを一時停止してシェルに戻る。",
+    app_repaint: "画面を消去して再描画する。",
     app_quit: "アプリケーションを終了する。確認なし！",
 };
 


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Add a configurable `Ctrl-L` action that clears and repaints the interactive screen.
- Invalidate Ratatui's cached frame without querying the cursor, avoiding a race with the input thread.
- Cover recovery from a corrupted display with a regression test.

Fixes #392

## Validation

- `cargo test ctrl_l_repaints_the_screen`
- `make check-pre-push`
- `codex review --commit ba1d75199e68635bddfc2852d8b20087ef8e3b03` (no findings)

## Commit

- `ba1d7519 feat: repaint screen with Ctrl-L (#392)`
