### PR TITLE
Fix latest release installation and surface interactive mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,14 @@ jobs:
           asset_name: ${{ env.ASSET }}
           asset_content_type: application/octet-stream
 
+  validate-release-install:
+    name: validate release installation
+    needs: ["build-release"]
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - run: sh ci/validate-release-install.sh "$GITHUB_REF_NAME"
+
   winget-release:
     name: winget-release
     needs: ["build-release"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **dua** (-> _Disk Usage Analyzer_) is a tool to conveniently learn about the usage of disk space of a given directory. It's parallel by default and will max out your SSD, providing relevant information as fast as possible. Optionally delete superfluous data, and do so more quickly than `rm`.
 
+Run `dua i` to launch the [interactive mode](#interactive-mode) for exploring and deleting files.
+
 [![asciicast](https://asciinema.org/a/kDnXUOeqBxZVMoWuFNqzfpeey.svg)](https://asciinema.org/a/kDnXUOeqBxZVMoWuFNqzfpeey)
 
 ### Installation
@@ -14,7 +16,7 @@
 
 ```sh
 curl -LSfs https://raw.githubusercontent.com/Byron/dua-cli/master/ci/install.sh | \
-    sh -s -- --git Byron/dua-cli --crate dua --tag v2.29.0
+    sh -s -- --git Byron/dua-cli --crate dua
 ```
 
 #### MacOS via [MacPorts](https://www.macports.org):
@@ -37,7 +39,7 @@ Linux requires the target to be specified explicitly to obtain the MUSL build.
 
 ```sh
 curl -LSfs https://raw.githubusercontent.com/Byron/dua-cli/master/ci/install.sh | \
-    sh -s -- --git Byron/dua-cli --target x86_64-unknown-linux-musl --crate dua --tag v2.29.0
+    sh -s -- --git Byron/dua-cli --target x86_64-unknown-linux-musl --crate dua
 ```
 
 #### Windows via [Scoop](https://scoop.sh/)

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -88,12 +88,8 @@ need mktemp
 need tar
 
 # Optional dependencies
-if [ -z $crate ] || [ -z $tag ] || [ -z $target ]; then
+if [ -z $crate ] || [ -z $target ]; then
     need cut
-fi
-
-if [ -z $tag ]; then
-    need rev
 fi
 
 if [ -z $target ]; then
@@ -117,7 +113,8 @@ say_err "Crate: $crate"
 url="$url/releases"
 
 if [ -z $tag ]; then
-    tag=$(curl -s "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+    latest_url=$(curl -LSfs -o /dev/null -w '%{url_effective}' "$url/latest") || err "failed to determine latest release"
+    tag=${latest_url##*/}
     say_err "Tag: latest ($tag)"
 else
     say_err "Tag: $tag"
@@ -139,7 +136,10 @@ url="$url/download/$tag/$crate-$tag-$target.tar.gz"
 
 say_err "Downloading: $url"
 td=$(mktemp -d || mktemp -d -t tmp)
-curl -sL $url | tar -C $td -xz
+archive="$td/archive.tar.gz"
+curl -LSfs "$url" -o "$archive" || err "failed to download $url"
+tar -C "$td" -xzf "$archive" || err "failed to extract archive from $url"
+rm "$archive"
 
 for f in $(cd $td && find . -type f); do
     test -x $td/$f || continue

--- a/ci/validate-release-install.sh
+++ b/ci/validate-release-install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+tag=${1:?release tag required}
+install_dir=$(mktemp -d)
+trap 'rm -rf "$install_dir"' EXIT
+
+sh "${0%/*}/install.sh" \
+    --git Byron/dua-cli \
+    --crate dua \
+    --tag "$tag" \
+    --target aarch64-apple-darwin \
+    --to "$install_dir"
+test -x "$install_dir/dua"


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [x] refackiew

----

Everything below this line was generated by `Codex GPT-5`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Summary

- Surface `dua i` and the interactive-mode documentation near the README introduction.
- Stop pinning stale release tags in the documented Unix installation commands.
- Resolve GitHub's latest-release redirect, reject missing or invalid archives clearly, and exercise the installer on macOS CI.

## Reported issue

```text
Make the `interactive` mode discoverable earlier in the README.md.

Also, validate the installation method, it seems on macOS it's not working:

~ $ curl -LSfs https://raw.githubusercontent.com/Byron/dua-cli/master/ci/install.sh | \
    sh -s -- --git Byron/dua-cli --crate dua --tag v2.29.0
install.sh: GitHub repository: https://github.com/Byron/dua-cli
install.sh: Crate: dua
install.sh: Tag: v2.29.0
install.sh: Target: aarch64-apple-darwin
install.sh: Installing to: /Users/kiril/.cargo/bin
install.sh: Downloading: https://github.com/Byron/dua-cli/releases/download/v2.29.0/dua-v2.29.0-aarch64-apple-darwin.tar.gz
tar: Error opening archive: Unrecognized archive format

Maybe add more validation of that to CI.
```

## Root cause

The v2.29.0 release has no `aarch64-apple-darwin` asset, so GitHub returned a 404 body that the installer passed to `tar`. Removing the stale tag also exposed that latest-release discovery did not follow GitHub's redirect and produced an empty tag.

## Validation

- Missing release asset reports `ERROR failed to download` instead of passing an HTTP error body to `tar`.
- Latest-release install selected v2.44.0 on `aarch64-apple-darwin`; installed `dua --version` reports `dua 2.44.0`.
- `sh -n ci/install.sh`
- `shellcheck --severity=warning ci/install.sh`
- Workflow YAML parse and `git diff --check`
- `codex review --commit 9c43695bec3f2f47b9c8fcf68a7ea17a65530ab0` found no regressions.
