### PR TITLE
Add Git-aware clean mode with grouped candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,33 @@ LANG=ko_KR.UTF-8 dua i   # Korean interface
 LANG=zh_CN.UTF-8 dua i   # Simplified Chinese interface
 ```
 
+### Cleanup Mode
+
+`dua clean [DIRECTORY]...` finds disposable directories and lists them largest first as sizing
+finishes. With no paths, it searches the current directory. *Nothing is deleted automatically.*
+
+```bash
+dua clean ~/dev
+dua clean --depth 3 ~/dev ~/Downloads
+```
+
+Candidates include `node_modules`, Python caches and virtual environments, Cargo project `target`
+directories, and Zig's `.zig-cache`, `zig-cache`, and `zig-out`. In Git repositories, candidates
+must be ignored and contain no tracked files. Directories containing a `.git` entry (regardless
+of case) and paths excluded by traversal options are skipped.
+
+The hub groups sibling candidates and deeper candidates under their shared parent. Open a group
+to browse, sort, or search within it; go back to return to the hub. Use the usual marking and
+deletion keys. Marking a group selects only its candidates, leaving other contents untouched.
+
+- `R` in the hub repeats discovery; `r` rechecks the selected candidate or existing group members.
+- Inside a candidate, either refresh key rechecks the whole candidate. Refresh clears all marks.
+- Discovery is unlimited by default. `--depth 0` checks only the supplied directories for great speedups;
+  candidates are always sized completely.
+
+Traversal options, `--no-entry-check`, and `--once` are supported. Parent scanning, snapshot
+import, and snapshot export are unavailable.
+
 ### Flame graphs
 
 `dua stacks` prints folded stacks—the "collapsed" interchange format read by flame-graph tools.

--- a/crates/dua-lib/src/lib.rs
+++ b/crates/dua-lib/src/lib.rs
@@ -17,10 +17,13 @@
 //! metadata batches enqueue accepted child directories. Windows and macOS walks consume native
 //! metadata returned by directory enumeration instead. Multi-threaded macOS walks probe the
 //! initial bulk refills and distribute metadata lookups when those reads spend time waiting.
-//! Every worker can run available jobs from its local LIFO queue or steal from a peer. Each
+//! [`stream_roots`] accepts additional roots while walking, using the same worker pool. Workers
+//! check submitted roots before their local LIFO queues so existing trees cannot starve new roots.
+//! Every worker can run available jobs from its local queue or steal from a peer. Each
 //! successful thief wakes another idle worker, ramping up only while work remains stealable. A
 //! worker parks when no queue has work and is unparked when new work arrives or the walk stops. The
-//! last completed job emits the finished event; dropping the iterator stops and joins all workers.
+//! last completed job emits the finished event once root submissions are closed; dropping the
+//! iterator stops and joins all workers.
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 
@@ -29,7 +32,7 @@ use crossbeam::{
     sync::{Parker, Unparker},
 };
 use std::{
-    collections::HashMap,
+    collections::HashSet,
     fs, io,
     num::NonZeroU32,
     path::{Path, PathBuf},
@@ -212,10 +215,24 @@ pub struct Entry {
     pub parent_directory_id: Option<DirectoryId>,
 }
 
+struct Root {
+    /// Root identifier passed to the descent predicate and attached to emitted events.
+    index: usize,
+    /// Queued and running jobs for this root; completing the last job emits `RootFinished`.
+    pending: AtomicUsize,
+    /// Shared predicate receiving this root's index and a directory entry.
+    /// Returning `false` prunes its children while still yielding the directory itself.
+    descend: Arc<Descend>,
+}
+
 enum Job {
+    /// Prepare a newly submitted root on a worker, including its metadata.
+    StartRoot { root: Arc<Root>, path: PathBuf },
+    /// Release the open-input completion guard on a worker, where sending events can block.
+    CloseInput,
     /// Read a directory and schedule processing of its entries.
     ReadDir {
-        root_idx: usize,
+        root: Arc<Root>,
         path: Arc<Path>,
         /// Dense identifier of the directory being read.
         directory_id: usize,
@@ -226,25 +243,14 @@ enum Job {
     /// Fetch metadata for a chunk of entries from a completed directory read.
     #[cfg(not(windows))]
     Stat {
-        root_idx: usize,
+        root: Arc<Root>,
         path: Arc<Path>,
         /// Dense identifier of the directory containing these entries.
         directory_id: usize,
-        /// Depth assigned to every entry in this chunk; always at least `1`, i.e. a file in a directory.
+        /// Depth assigned to every entry in this chunk; always at least `1`.
         entry_depth: usize,
         entries: Vec<StatEntry>,
     },
-}
-
-impl Job {
-    /// Return the index of the root path that this job belongs to.
-    fn root_idx(&self) -> usize {
-        match self {
-            Job::ReadDir { root_idx, .. } => *root_idx,
-            #[cfg(not(windows))]
-            Job::Stat { root_idx, .. } => *root_idx,
-        }
-    }
 }
 
 /// Internal worker-channel events, including batches, per-root completion, and pool completion.
@@ -275,17 +281,13 @@ pub enum RootEvent {
 }
 
 struct PoolShared {
-    /// Global queue that makes the initial root job available to whichever worker starts first.
+    /// Shared queue for initial roots, newly submitted roots, and input closure.
     injector: Injector<Job>,
     stealers: Vec<Stealer<Job>>,
     stop: AtomicBool,
-    descend: Arc<Descend>,
     events: SyncSender<Event>,
-    /// Number of roots with queued or running jobs.
+    /// Active roots, plus one while a streaming input remains open.
     active_roots: AtomicUsize,
-    /// Number of queued or running jobs for each root index.
-    /// A counter reaching zero emits that root's [`Event::RootFinished`].
-    jobs_per_root: HashMap<usize, AtomicUsize>,
     order: Order,
     options: Options,
     /// Handles used to wake workers, indexed by worker number.
@@ -314,6 +316,84 @@ pub struct RootWalk {
     pool: Option<Pool>,
 }
 
+/// Submits roots to a running [`RootWalk`] without starting additional workers.
+/// Drop this handle after discovery finishes to allow the iterator to end.
+pub struct RootSender {
+    shared: Arc<PoolShared>,
+    indices: HashSet<usize>,
+}
+
+impl RootSender {
+    /// Queue a root and its descent predicate. Metadata is collected by the worker pool.
+    ///
+    /// * `index` identifies this root in [`RootWalk`] events and must be unique across all roots
+    ///   submitted through this sender, including roots that have already finished.
+    /// * `path` is the filesystem entry to walk, yielded at depth `0`. Symbolic links are not
+    ///   followed. Filesystem errors are delivered through [`RootWalk`].
+    /// * `descend` decides whether to traverse a directory's children, including the root's.
+    ///   Returning `false` still yields the directory itself. The predicate runs on worker
+    ///   threads and may be called concurrently for different directories.
+    ///
+    /// Returns an error for a duplicate index or a dropped walker.
+    pub fn add_root(
+        &mut self,
+        index: usize,
+        path: PathBuf,
+        descend: impl Fn(&Entry) -> bool + Send + Sync + 'static,
+    ) -> io::Result<()> {
+        if self.shared.stop.load(AtomicOrdering::Relaxed) {
+            return Err(io::Error::new(io::ErrorKind::BrokenPipe, "walker stopped"));
+        }
+        if !self.indices.insert(index) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "duplicate root index",
+            ));
+        }
+        let root = Arc::new(Root {
+            index,
+            pending: AtomicUsize::new(1),
+            descend: Arc::new(move |_, entry| descend(entry)),
+        });
+        self.shared
+            .active_roots
+            .fetch_add(1, AtomicOrdering::Relaxed);
+        self.shared.injector.push(Job::StartRoot { root, path });
+        self.shared.wake_worker();
+        Ok(())
+    }
+}
+
+impl Drop for RootSender {
+    fn drop(&mut self) {
+        // Sending the final event may block on a full output channel; leave it to a worker.
+        self.shared.injector.push(Job::CloseInput);
+        self.shared.wake_worker();
+    }
+}
+
+/// Start a fixed-size worker pool that accepts roots while its events are consumed.
+///
+/// The iterator waits during gaps in submissions. It ends only after the sender is dropped
+/// and every submitted root has emitted [`RootEvent::Finished`]. Each root has its own predicate,
+/// allowing callers to retain discovery context without shared mutable lookup tables.
+#[must_use]
+pub fn stream_roots(threads: usize, order: Order, options: Options) -> (RootSender, RootWalk) {
+    let pool = start_pool(threads.max(1), order, options, 0);
+    pool.shared.active_roots.store(1, AtomicOrdering::Relaxed);
+    let sender = RootSender {
+        shared: Arc::clone(&pool.shared),
+        indices: HashSet::new(),
+    };
+    (
+        sender,
+        RootWalk {
+            next: Vec::new(),
+            pool: Some(pool),
+        },
+    )
+}
+
 /// A single-root directory iterator whose directory reads happen in parallel.
 /// Unlike `RootWalk`, it yields entries directly and hides root identity and completion events.
 pub struct Walk {
@@ -329,6 +409,7 @@ pub struct Walk {
     /// Clearing or dropping it requests shutdown, unparks every worker, and joins their threads.
     pool: Option<Pool>,
     root: PathBuf,
+    root_state: Arc<Root>,
     options: Options,
     /// Whether the worker pool has finished the current traversal.
     finished: bool,
@@ -359,6 +440,11 @@ pub fn walk(
     descend: impl Fn(&Entry) -> bool + Send + Sync + 'static,
 ) -> Walk {
     let root_path = root.to_owned();
+    let root_state = Arc::new(Root {
+        index: 0,
+        pending: AtomicUsize::new(0),
+        descend: Arc::new(move |_, entry| descend(entry)),
+    });
     let mut root = Entry::from_path(root, options);
     if let Ok(entry) = &mut root
         && entry.file_type.is_dir()
@@ -366,20 +452,13 @@ pub fn walk(
         entry.directory_id = Some(DirectoryId::new(0));
     }
     let pool = match &root {
-        Ok(entry) if entry.file_type.is_dir() && descend(entry) => {
+        Ok(entry) if entry.file_type.is_dir() && (root_state.descend)(0, entry) => {
             let path = Arc::from(entry.path());
-            let pool = start_pool(
-                threads.max(1),
-                HashMap::from([(0, AtomicUsize::new(0))]),
-                order,
-                Arc::new(move |_, entry| descend(entry)),
-                options,
-                1,
-            );
+            let pool = start_pool(threads.max(1), order, options, 1);
             start_jobs(
                 &pool,
                 vec![Job::ReadDir {
-                    root_idx: 0,
+                    root: Arc::clone(&root_state),
                     path,
                     directory_id: 0,
                     entry_depth: 1,
@@ -393,6 +472,7 @@ pub fn walk(
         next: vec![root],
         pool,
         root: root_path,
+        root_state,
         options,
         finished: false,
     }
@@ -417,9 +497,9 @@ impl Walk {
             entry.directory_id = Some(DirectoryId::new(0));
         }
         let job = match &root {
-            Ok(entry) if entry.file_type.is_dir() && (pool.shared.descend)(0, entry) => {
+            Ok(entry) if entry.file_type.is_dir() && (self.root_state.descend)(0, entry) => {
                 Some(Job::ReadDir {
-                    root_idx: 0,
+                    root: Arc::clone(&self.root_state),
                     path: Arc::from(entry.path()),
                     directory_id: 0,
                     entry_depth: 1,
@@ -437,13 +517,27 @@ impl Walk {
         }
         true
     }
-}
 
-impl Iterator for Walk {
-    type Item = io::Result<Entry>;
+    /// Yield the next entry, polling `cancelled` while waiting for directory reads.
+    ///
+    /// Once cancelled, discard buffered entries and stop and join the worker pool before
+    /// returning `None`. In-progress filesystem calls are allowed to finish, and the cancelled
+    /// walk cannot be restarted.
+    pub fn next_cancellable(&mut self, cancelled: &AtomicBool) -> Option<io::Result<Entry>> {
+        self.next_with_cancellation(Some(cancelled))
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn next_with_cancellation(
+        &mut self,
+        cancelled: Option<&AtomicBool>,
+    ) -> Option<io::Result<Entry>> {
         loop {
+            if cancelled.is_some_and(|cancelled| cancelled.load(AtomicOrdering::Relaxed)) {
+                self.next.clear();
+                self.finished = true;
+                self.pool = None;
+                return None;
+            }
             if let Some(entry) = self.next.pop() {
                 return Some(entry);
             }
@@ -451,23 +545,48 @@ impl Iterator for Walk {
                 return None;
             }
 
-            match self.pool.as_ref()?.events.recv() {
-                Ok(Event::Batch {
+            let pool = self.pool.as_ref()?;
+            let event = if cancelled.is_some() {
+                match pool
+                    .events
+                    .recv_timeout(std::time::Duration::from_millis(100))
+                {
+                    Ok(event) => event,
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        return Some(Err(io::Error::other("directory worker stopped")));
+                    }
+                }
+            } else {
+                match pool.events.recv() {
+                    Ok(event) => event,
+                    Err(_) => return Some(Err(io::Error::other("directory worker stopped"))),
+                }
+            };
+            match event {
+                Event::Batch {
                     batch: Ok(entries), ..
-                }) => {
+                } => {
                     self.next.extend(entries.into_iter().rev());
                 }
-                Ok(Event::Batch {
+                Event::Batch {
                     batch: Err(err), ..
-                }) => return Some(Err(err)),
-                Ok(Event::RootFinished { .. }) => {}
-                Ok(Event::Finished) => {
+                } => return Some(Err(err)),
+                Event::RootFinished { .. } => {}
+                Event::Finished => {
                     self.finished = true;
                     return None;
                 }
-                Err(_) => return Some(Err(io::Error::other("directory worker stopped"))),
             }
         }
+    }
+}
+
+impl Iterator for Walk {
+    type Item = io::Result<Entry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_with_cancellation(None)
     }
 }
 
@@ -533,33 +652,22 @@ fn start_root_walk<Root>(
     prepare: impl Fn(Root) -> io::Result<Entry>,
     options: Options,
 ) -> RootWalk {
-    let jobs_per_root = roots
+    let indices = roots
         .iter()
-        .map(|(root_idx, _)| (*root_idx, AtomicUsize::new(0)))
-        .collect::<HashMap<_, _>>();
-    assert_eq!(
-        jobs_per_root.len(),
-        roots.len(),
-        "root indices must be unique"
-    );
-    let descend = Arc::new(descend);
+        .map(|(index, _)| *index)
+        .collect::<HashSet<_>>();
+    assert_eq!(indices.len(), roots.len(), "root indices must be unique");
+    let descend: Arc<Descend> = Arc::new(descend);
     let (next, root_jobs, next_directory_id) = begin_walks(
         roots
             .into_iter()
             .map(|(root_idx, root)| (root_idx, prepare(root))),
-        descend.as_ref(),
+        &descend,
     );
     let pool = if root_jobs.is_empty() {
         None
     } else {
-        let pool = start_pool(
-            threads.max(1),
-            jobs_per_root,
-            order,
-            descend,
-            options,
-            next_directory_id,
-        );
+        let pool = start_pool(threads.max(1), order, options, next_directory_id);
         start_jobs(&pool, root_jobs);
         Some(pool)
     };
@@ -673,14 +781,7 @@ impl Entry {
     }
 }
 
-fn start_pool(
-    threads: usize,
-    jobs_per_root: HashMap<usize, AtomicUsize>,
-    order: Order,
-    descend: Arc<Descend>,
-    options: Options,
-    next_directory_id: usize,
-) -> Pool {
+fn start_pool(threads: usize, order: Order, options: Options, next_directory_id: usize) -> Pool {
     let workers: Vec<_> = (0..threads).map(|_| Worker::new_lifo()).collect();
     let parkers: Vec<_> = (0..threads).map(|_| Parker::new()).collect();
     let (event_tx, event_rx) = sync_channel(threads * 2);
@@ -688,10 +789,8 @@ fn start_pool(
         injector: Injector::new(),
         stealers: workers.iter().map(Worker::stealer).collect(),
         stop: AtomicBool::new(false),
-        descend,
         events: event_tx,
         active_roots: AtomicUsize::new(0),
-        jobs_per_root,
         order,
         options,
         unparkers: parkers
@@ -726,7 +825,7 @@ fn start_pool(
 /// Returns events in stack order for [`RootWalk::next`] to pop, plus jobs requiring a worker pool.
 fn begin_walks(
     roots: impl IntoIterator<Item = (usize, io::Result<Entry>)>,
-    descend: &Descend,
+    descend: &Arc<Descend>,
 ) -> (Vec<(usize, RootEvent)>, Vec<Job>, usize) {
     let mut next = Vec::new();
     let mut jobs = Vec::new();
@@ -751,7 +850,11 @@ fn begin_walks(
                 .directory_id
                 .expect("directory roots receive an identifier");
             jobs.push(Job::ReadDir {
-                root_idx,
+                root: Arc::new(Root {
+                    index: root_idx,
+                    pending: AtomicUsize::new(0),
+                    descend: Arc::clone(descend),
+                }),
                 path: Arc::from(entry.path()),
                 directory_id: directory_id.index(),
                 entry_depth: 1,
@@ -778,19 +881,14 @@ fn start_jobs(pool: &Pool, root_jobs: Vec<Job>) {
         0,
         "initial jobs must be started on an idle pool"
     );
-    debug_assert!(
-        root_jobs.iter().all(|j| match j {
-            Job::ReadDir { entry_depth, .. } => *entry_depth,
-            #[cfg(not(windows))]
-            Job::Stat { entry_depth, .. } => *entry_depth,
-        } == 1),
-        "the first jobs should be root jobs, so active_root counts match"
-    );
     pool.shared
         .active_roots
         .store(root_jobs.len(), AtomicOrdering::Relaxed);
     for job in &root_jobs {
-        add_pending(job.root_idx(), 1, &pool.shared);
+        let Job::ReadDir { root, .. } = job else {
+            unreachable!("initial directory jobs")
+        };
+        root.pending.store(1, AtomicOrdering::Relaxed);
     }
     for job in root_jobs {
         pool.shared.injector.push(job);
@@ -830,32 +928,31 @@ impl Drop for Pool {
     fn drop(&mut self) {
         self.shared.stop.store(true, AtomicOrdering::Relaxed);
         self.shared.wake_workers();
+        // Workers blocked on the bounded output channel must be released before joining them.
+        let (_, disconnected) = sync_channel(0);
+        drop(std::mem::replace(&mut self.events, disconnected));
         for handle in self.handles.drain(..) {
             handle.join().ok();
         }
     }
 }
 
-/// Find work in order of increasing synchronization cost.
+/// Find newly submitted roots, then local work, then work from peers.
 ///
-/// The worker checks its own LIFO queue first, favoring locality and avoiding
-/// shared-queue contention. It next takes a batch from the injector, keeping one job and moving
-/// the rest into its local queue. Only then does it inspect other workers, because stealing from a
-/// peer is the most contentious path. Consequently, a worker with local jobs keeps processing
-/// them before helping elsewhere, and injector jobs take priority over peer jobs.
+/// Check submitted roots before local directory jobs so a large existing tree cannot starve
+/// newly discovered roots. Local LIFO work still takes priority over stealing from peers.
 ///
 /// Returns the selected job and whether it was stolen from another worker; the caller uses a
 /// successful steal to wake another idle worker. Returns `None` when a full scan finds no work.
 fn find_job(worker: &Worker<Job>, shared: &PoolShared) -> Option<(Job, bool)> {
     loop {
-        if let Some(job) = worker.pop() {
-            return Some((job, false));
-        }
-
-        match shared.injector.steal_batch_and_pop(worker) {
-            Steal::Success(job) => return Some((job, false)),
+        match shared.injector.steal() {
+            Steal::Success(job) => return Some((job, true)),
             Steal::Retry => continue,
             Steal::Empty => {}
+        }
+        if let Some(job) = worker.pop() {
+            return Some((job, false));
         }
 
         let mut retry = false;
@@ -874,30 +971,65 @@ fn find_job(worker: &Worker<Job>, shared: &PoolShared) -> Option<(Job, bool)> {
 
 fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
     match job {
+        Job::StartRoot { root, path } => {
+            let mut entry = Entry::from_path(&path, shared.options);
+            let mut jobs = Vec::new();
+            if let Ok(entry) = &mut entry
+                && entry.file_type.is_dir()
+            {
+                entry.directory_id = Some(allocate_directory_id(shared));
+                if entry.metadata.as_ref().is_none_or(Result::is_ok)
+                    && (root.descend)(root.index, entry)
+                {
+                    jobs.push(Job::ReadDir {
+                        root: Arc::clone(&root),
+                        path: Arc::from(path),
+                        directory_id: entry.directory_id.unwrap().index(),
+                        entry_depth: 1,
+                    });
+                }
+            }
+            // Root entries precede descendants in either traversal order.
+            root.pending.fetch_add(jobs.len(), AtomicOrdering::Relaxed);
+            if shared
+                .events
+                .send(Event::Batch {
+                    root_idx: root.index,
+                    batch: Ok(vec![entry]),
+                })
+                .is_err()
+            {
+                shared.stop.store(true, AtomicOrdering::Relaxed);
+                return;
+            }
+            schedule_jobs(jobs, worker, shared);
+            finish_pending(&root, shared);
+        }
+        Job::CloseInput => finish_root(shared),
         Job::ReadDir {
-            root_idx: root,
+            root,
             path,
             directory_id,
             entry_depth,
         } => {
             #[cfg(any(windows, target_os = "macos"))]
-            read_dir_native(root, path, directory_id, entry_depth, worker, shared);
+            read_dir_native(&root, path, directory_id, entry_depth, worker, shared);
             #[cfg(not(any(windows, target_os = "macos")))]
             if matches!(shared.order, Order::Completion) {
-                read_dir_parallel(root, path, directory_id, entry_depth, worker, shared);
+                read_dir_parallel(&root, path, directory_id, entry_depth, worker, shared);
             } else {
-                read_dir_parent_first(root, path, directory_id, entry_depth, worker, shared);
+                read_dir_parent_first(&root, path, directory_id, entry_depth, worker, shared);
             }
         }
         #[cfg(not(windows))]
         Job::Stat {
-            root_idx: root,
+            root,
             path,
             directory_id,
             entry_depth,
             entries,
         } => stat_entries(
-            root,
+            &root,
             path,
             directory_id,
             entry_depth,
@@ -915,7 +1047,7 @@ fn run_job(job: Job, worker: &Worker<Job>, shared: &PoolShared) {
 /// Type-only walks convert entries inline instead, avoiding metadata-job overhead.
 #[cfg(not(any(windows, target_os = "macos")))]
 fn read_dir_parallel(
-    root_idx: usize,
+    root: &Arc<Root>,
     path: Arc<Path>,
     directory_id: usize,
     entry_depth: usize,
@@ -923,7 +1055,7 @@ fn read_dir_parallel(
     shared: &PoolShared,
 ) {
     if shared.options.skip_metadata {
-        read_dir_inline(root_idx, path, directory_id, entry_depth, worker, shared);
+        read_dir_inline(root, path, directory_id, entry_depth, worker, shared);
         return;
     }
     let dir_entries = match fs::read_dir(&path) {
@@ -932,14 +1064,14 @@ fn read_dir_parallel(
             if shared
                 .events
                 .send(Event::Batch {
-                    root_idx,
+                    root_idx: root.index,
                     batch: Err(err),
                 })
                 .is_err()
             {
                 shared.stop.store(true, AtomicOrdering::Relaxed);
             }
-            finish_pending(root_idx, shared);
+            finish_pending(root, shared);
             return;
         }
     };
@@ -947,7 +1079,7 @@ fn read_dir_parallel(
     let mut errors = Vec::new();
     for entry in dir_entries {
         if shared.stop.load(AtomicOrdering::Relaxed) {
-            finish_pending(root_idx, shared);
+            finish_pending(root, shared);
             return;
         }
         match entry {
@@ -955,7 +1087,7 @@ fn read_dir_parallel(
                 chunk.push(entry);
                 if chunk.len() == ENTRY_CHUNK_SIZE {
                     schedule_stat_entries(
-                        root_idx,
+                        root,
                         &path,
                         directory_id,
                         entry_depth,
@@ -970,7 +1102,7 @@ fn read_dir_parallel(
     }
     if !chunk.is_empty() {
         schedule_stat_entries(
-            root_idx,
+            root,
             &path,
             directory_id,
             entry_depth,
@@ -983,14 +1115,14 @@ fn read_dir_parallel(
         && shared
             .events
             .send(Event::Batch {
-                root_idx,
+                root_idx: root.index,
                 batch: Ok(errors),
             })
             .is_err()
     {
         shared.stop.store(true, AtomicOrdering::Relaxed);
     }
-    finish_pending(root_idx, shared);
+    finish_pending(root, shared);
 }
 
 /// Read a directory in either traversal order.
@@ -1000,7 +1132,7 @@ fn read_dir_parallel(
 /// is sent before its child jobs become stealable.
 #[cfg(any(windows, target_os = "macos"))]
 fn read_dir_native(
-    root_idx: usize,
+    root: &Arc<Root>,
     path: Arc<Path>,
     directory_id: usize,
     depth: usize,
@@ -1010,8 +1142,8 @@ fn read_dir_native(
     let dir_entries = match ReadDir::open(Arc::clone(&path), depth, shared.options) {
         Ok(entries) => entries,
         Err(err) => {
-            publish_directory(root_idx, Err(err), Vec::new(), worker, shared);
-            finish_pending(root_idx, shared);
+            publish_directory(root, Err(err), Vec::new(), worker, shared);
+            finish_pending(root, shared);
             return;
         }
     };
@@ -1040,7 +1172,7 @@ fn read_dir_native(
     let mut jobs = Vec::new();
     for mut entry in dir_entries {
         if shared.stop.load(AtomicOrdering::Relaxed) {
-            finish_pending(root_idx, shared);
+            finish_pending(root, shared);
             return;
         }
         #[cfg(target_os = "macos")]
@@ -1050,7 +1182,7 @@ fn read_dir_native(
             deferred.push(entry.expect("metadata-free entry was checked"));
             if deferred.len() == ENTRY_CHUNK_SIZE {
                 schedule_stat_entries(
-                    root_idx,
+                    root,
                     &path,
                     directory_id,
                     depth,
@@ -1066,10 +1198,10 @@ fn read_dir_native(
         }
         if let Ok(entry) = &entry
             && entry.file_type.is_dir()
-            && (shared.descend)(root_idx, entry)
+            && (root.descend)(root.index, entry)
         {
             jobs.push(Job::ReadDir {
-                root_idx,
+                root: Arc::clone(root),
                 path: Arc::from(entry.path()),
                 directory_id: entry
                     .directory_id
@@ -1081,7 +1213,7 @@ fn read_dir_native(
         entries.push(entry);
         if entries.len() == ENTRY_CHUNK_SIZE
             && !publish_directory(
-                root_idx,
+                root,
                 Ok(std::mem::replace(
                     &mut entries,
                     Vec::with_capacity(ENTRY_CHUNK_SIZE),
@@ -1091,31 +1223,23 @@ fn read_dir_native(
                 shared,
             )
         {
-            finish_pending(root_idx, shared);
+            finish_pending(root, shared);
             return;
         }
     }
     if !entries.is_empty() {
-        publish_directory(root_idx, Ok(entries), jobs, worker, shared);
+        publish_directory(root, Ok(entries), jobs, worker, shared);
     }
     #[cfg(target_os = "macos")]
     if !deferred.is_empty() {
-        schedule_stat_entries(
-            root_idx,
-            &path,
-            directory_id,
-            depth,
-            deferred,
-            worker,
-            shared,
-        );
+        schedule_stat_entries(root, &path, directory_id, depth, deferred, worker, shared);
     }
-    finish_pending(root_idx, shared);
+    finish_pending(root, shared);
 }
 
 #[cfg(not(windows))]
 fn schedule_stat_entries(
-    root_idx: usize,
+    root: &Arc<Root>,
     path: &Arc<Path>,
     directory_id: usize,
     entry_depth: usize,
@@ -1124,13 +1248,13 @@ fn schedule_stat_entries(
     shared: &PoolShared,
 ) {
     let job = Job::Stat {
-        root_idx,
+        root: Arc::clone(root),
         path: Arc::clone(path),
         directory_id,
         entry_depth,
         entries,
     };
-    add_pending(root_idx, 1, shared);
+    root.pending.fetch_add(1, AtomicOrdering::Relaxed);
     if worker.len() >= MAX_QUEUED_STAT_JOBS {
         run_job(job, worker, shared);
     } else {
@@ -1141,7 +1265,7 @@ fn schedule_stat_entries(
 
 #[cfg(not(windows))]
 fn stat_entries(
-    root_idx: usize,
+    root: &Arc<Root>,
     path: Arc<Path>,
     directory_id: usize,
     depth: usize,
@@ -1161,9 +1285,9 @@ fn stat_entries(
             let entry = Entry::from_dir_entry(depth, Arc::clone(&path), entry, shared.options);
             entry.map(|mut entry| {
                 assign_directory_ids(&mut entry, directory_id, shared);
-                if entry.file_type.is_dir() && (shared.descend)(root_idx, &entry) {
+                if entry.file_type.is_dir() && (root.descend)(root.index, &entry) {
                     jobs.push(Job::ReadDir {
-                        root_idx,
+                        root: Arc::clone(root),
                         path: Arc::from(entry.path()),
                         directory_id: entry
                             .directory_id
@@ -1176,8 +1300,8 @@ fn stat_entries(
             })
         })
         .collect();
-    publish_directory(root_idx, Ok(entries), jobs, worker, shared);
-    finish_pending(root_idx, shared);
+    publish_directory(root, Ok(entries), jobs, worker, shared);
+    finish_pending(root, shared);
 }
 
 /// Read a directory for parent-first traversal.
@@ -1189,14 +1313,14 @@ fn stat_entries(
 /// bottleneck.
 #[cfg(not(any(windows, target_os = "macos")))]
 fn read_dir_parent_first(
-    root_idx: usize,
+    root: &Arc<Root>,
     path: Arc<Path>,
     directory_id: usize,
     depth: usize,
     worker: &Worker<Job>,
     shared: &PoolShared,
 ) {
-    read_dir_inline(root_idx, path, directory_id, depth, worker, shared);
+    read_dir_inline(root, path, directory_id, depth, worker, shared);
 }
 
 /// Convert a directory's entries on the worker that enumerates it, then schedule its children.
@@ -1204,7 +1328,7 @@ fn read_dir_parent_first(
 /// Parent-first traversal converts each entry inline to preserve ordering.
 #[cfg(not(any(windows, target_os = "macos")))]
 fn read_dir_inline(
-    root_idx: usize,
+    root: &Arc<Root>,
     path: Arc<Path>,
     directory_id: usize,
     depth: usize,
@@ -1214,8 +1338,8 @@ fn read_dir_inline(
     let dir_entries = match fs::read_dir(&path) {
         Ok(entries) => entries,
         Err(err) => {
-            publish_directory(root_idx, Err(err), Vec::new(), worker, shared);
-            finish_pending(root_idx, shared);
+            publish_directory(root, Err(err), Vec::new(), worker, shared);
+            finish_pending(root, shared);
             return;
         }
     };
@@ -1228,9 +1352,9 @@ fn read_dir_inline(
                 })
                 .map(|mut entry| {
                     assign_directory_ids(&mut entry, directory_id, shared);
-                    if entry.file_type.is_dir() && (shared.descend)(root_idx, &entry) {
+                    if entry.file_type.is_dir() && (root.descend)(root.index, &entry) {
                         jobs.push(Job::ReadDir {
-                            root_idx,
+                            root: Arc::clone(root),
                             path: Arc::from(entry.path()),
                             directory_id: entry
                                 .directory_id
@@ -1243,22 +1367,27 @@ fn read_dir_inline(
                 })
         })
         .collect();
-    publish_directory(root_idx, Ok(entries), jobs, worker, shared);
-    finish_pending(root_idx, shared);
+    publish_directory(root, Ok(entries), jobs, worker, shared);
+    finish_pending(root, shared);
 }
 
 fn assign_directory_ids(entry: &mut Entry, parent_directory_id: usize, shared: &PoolShared) {
     entry.parent_directory_id = Some(DirectoryId::new(parent_directory_id));
-    entry.directory_id = entry.file_type.is_dir().then(|| {
-        DirectoryId::new(
-            shared
-                .next_directory_id
-                .fetch_update(AtomicOrdering::Relaxed, AtomicOrdering::Relaxed, |id| {
-                    id.checked_add(1)
-                })
-                .expect("directory identifier overflow"),
-        )
-    });
+    entry.directory_id = entry
+        .file_type
+        .is_dir()
+        .then(|| allocate_directory_id(shared));
+}
+
+fn allocate_directory_id(shared: &PoolShared) -> DirectoryId {
+    DirectoryId::new(
+        shared
+            .next_directory_id
+            .fetch_update(AtomicOrdering::Relaxed, AtomicOrdering::Relaxed, |id| {
+                id.checked_add(1)
+            })
+            .expect("directory identifier overflow"),
+    )
 }
 
 /// Publish a directory batch and schedule its accepted child-directory jobs.
@@ -1268,19 +1397,22 @@ fn assign_directory_ids(entry: &mut Entry, parent_directory_id: usize, shared: &
 /// Returns `true` if the batch was sent and child jobs were scheduled, or `false` if the event
 /// receiver disconnected, in which case traversal is marked to stop.
 fn publish_directory(
-    root_idx: usize,
+    root: &Arc<Root>,
     batch: Batch,
     jobs: Vec<Job>,
     worker: &Worker<Job>,
     shared: &PoolShared,
 ) -> bool {
-    add_pending(root_idx, jobs.len(), shared);
+    root.pending.fetch_add(jobs.len(), AtomicOrdering::Relaxed);
 
     match shared.order {
         Order::ParentFirst => {
             if shared
                 .events
-                .send(Event::Batch { root_idx, batch })
+                .send(Event::Batch {
+                    root_idx: root.index,
+                    batch,
+                })
                 .is_err()
             {
                 shared.stop.store(true, AtomicOrdering::Relaxed);
@@ -1292,7 +1424,10 @@ fn publish_directory(
             schedule_jobs(jobs, worker, shared);
             if shared
                 .events
-                .send(Event::Batch { root_idx, batch })
+                .send(Event::Batch {
+                    root_idx: root.index,
+                    batch,
+                })
                 .is_err()
             {
                 shared.stop.store(true, AtomicOrdering::Relaxed);
@@ -1304,18 +1439,22 @@ fn publish_directory(
     true
 }
 
-fn add_pending(root: usize, count: usize, shared: &PoolShared) {
-    shared.jobs_per_root[&root].fetch_add(count, AtomicOrdering::Relaxed);
+/// Complete a job, publishing root completion before releasing its pool-wide count.
+fn finish_pending(root: &Root, shared: &PoolShared) {
+    if root.pending.fetch_sub(1, AtomicOrdering::AcqRel) == 1 {
+        shared
+            .events
+            .send(Event::RootFinished {
+                root_idx: root.index,
+            })
+            .ok();
+        finish_root(shared);
+    }
 }
 
-/// Mark one job complete for `root`.
-/// The last job emits `RootFinished`; if this was also the last active root, `Finished` follows.
-fn finish_pending(root_idx: usize, shared: &PoolShared) {
-    if shared.jobs_per_root[&root_idx].fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
-        shared.events.send(Event::RootFinished { root_idx }).ok();
-        if shared.active_roots.fetch_sub(1, AtomicOrdering::Relaxed) == 1 {
-            shared.events.send(Event::Finished).ok();
-        }
+fn finish_root(shared: &PoolShared) {
+    if shared.active_roots.fetch_sub(1, AtomicOrdering::AcqRel) == 1 {
+        shared.events.send(Event::Finished).ok();
     }
 }
 
@@ -1332,6 +1471,299 @@ fn schedule_jobs(jobs: Vec<Job>, worker: &Worker<Job>, shared: &PoolShared) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn roots_added_during_a_blocked_walk_finish_independently() {
+        use std::time::Duration;
+
+        let directory = tempfile::tempdir().unwrap();
+        let slow = directory.path().join("slow");
+        let fast = directory.path().join("fast");
+        fs::create_dir(&slow).unwrap();
+        fs::create_dir(&fast).unwrap();
+        let (started_tx, started_rx) = crossbeam::channel::bounded(1);
+        let (release_tx, release_rx) = crossbeam::channel::bounded(1);
+        let (mut roots, walk) = stream_roots(2, Order::ParentFirst, Options::default());
+        assert_eq!(walk.pool.as_ref().unwrap().handles.len(), 2);
+        let (finished_tx, finished_rx) = crossbeam::channel::unbounded();
+        let reader = thread::spawn(move || {
+            for (index, event) in walk {
+                match event {
+                    RootEvent::Entry(entry) => {
+                        entry.unwrap();
+                    }
+                    RootEvent::Finished => finished_tx.send(index).unwrap(),
+                }
+            }
+        });
+        roots
+            .add_root(0, slow, move |entry| {
+                if entry.depth == 0 {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                }
+                true
+            })
+            .unwrap();
+        let started = started_rx.recv_timeout(Duration::from_secs(5));
+        roots.add_root(1, fast.clone(), |_| true).unwrap();
+        let first_finished = finished_rx.recv_timeout(Duration::from_secs(5));
+        release_tx.send(()).unwrap();
+        let second_finished = finished_rx.recv_timeout(Duration::from_secs(5));
+
+        // Finishing every current root must leave the pool available for later submissions.
+        roots.add_root(2, fast, |_| true).unwrap();
+        drop(roots);
+        let last_finished = finished_rx.recv_timeout(Duration::from_secs(5));
+        reader.join().unwrap();
+        assert!(started.is_ok());
+        assert_eq!(first_finished.unwrap(), 1);
+        assert_eq!(second_finished.unwrap(), 0);
+        assert_eq!(last_finished.unwrap(), 2);
+        assert!(finished_rx.recv().is_err());
+    }
+
+    #[test]
+    fn submitted_roots_are_not_starved_by_existing_subdirectories() {
+        use std::time::Duration;
+
+        let directory = tempfile::tempdir().unwrap();
+        let old = directory.path().join("old");
+        let new = directory.path().join("new");
+        fs::create_dir_all(old.join("child/grandchild")).unwrap();
+        fs::create_dir(&new).unwrap();
+        let (started_tx, started_rx) = crossbeam::channel::bounded(1);
+        let (release_tx, release_rx) = crossbeam::channel::bounded(1);
+        let (order_tx, order_rx) = crossbeam::channel::unbounded();
+        let old_order = order_tx.clone();
+        let (mut roots, walk) = stream_roots(1, Order::ParentFirst, Options::default());
+        let reader = thread::spawn(move || walk.for_each(drop));
+        roots
+            .add_root(0, old, move |entry| {
+                if entry.depth == 1 {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                } else if entry.depth == 2 {
+                    old_order.send("old descendants").unwrap();
+                }
+                true
+            })
+            .unwrap();
+        let started = started_rx.recv_timeout(Duration::from_secs(5));
+        roots
+            .add_root(1, new, move |_| {
+                order_tx.send("new root").unwrap();
+                true
+            })
+            .unwrap();
+        drop(roots);
+        release_tx.send(()).unwrap();
+        let next = order_rx.recv_timeout(Duration::from_secs(5));
+        reader.join().unwrap();
+        assert!(started.is_ok());
+        assert_eq!(next.unwrap(), "new root");
+    }
+
+    #[test]
+    fn streaming_input_closes_and_cancels_without_draining_output() {
+        use std::time::Duration;
+
+        let directory = tempfile::tempdir().unwrap();
+        let (mut roots, walk) = stream_roots(1, Order::ParentFirst, Options::default());
+        let (started_tx, started_rx) = crossbeam::channel::unbounded();
+        let (release_tx, release_rx) = crossbeam::channel::bounded(1);
+        for index in 0..8 {
+            let started_tx = started_tx.clone();
+            let release_rx = release_rx.clone();
+            roots
+                .add_root(index, directory.path().to_owned(), move |_| {
+                    if index == 0 {
+                        release_rx.recv().unwrap();
+                    }
+                    started_tx.send(()).unwrap();
+                    true
+                })
+                .unwrap();
+        }
+        // Queue every root before allowing the worker to choose between roots and local work.
+        release_tx.send(()).unwrap();
+        // Two root batches fill the output; the third reaches its predicate before blocking.
+        for _ in 0..3 {
+            started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        }
+        let (dropped_tx, dropped_rx) = crossbeam::channel::bounded(1);
+        let closer = thread::spawn(move || {
+            drop(roots);
+            drop(walk);
+            dropped_tx.send(()).unwrap();
+        });
+        dropped_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("closing input and dropping the walker cannot block on output");
+        closer.join().unwrap();
+
+        let (roots, walk) = stream_roots(1, Order::ParentFirst, Options::default());
+        drop(roots);
+        assert_eq!(walk.count(), 0);
+        let (mut roots, walk) = stream_roots(1, Order::ParentFirst, Options::default());
+        roots
+            .add_root(usize::MAX, directory.path().to_owned(), |_| true)
+            .unwrap();
+        assert_eq!(
+            roots
+                .add_root(usize::MAX, directory.path().to_owned(), |_| true)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidInput
+        );
+        drop(walk);
+        assert_eq!(
+            roots
+                .add_root(0, directory.path().to_owned(), |_| true)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::BrokenPipe
+        );
+    }
+
+    #[test]
+    fn dropping_a_walk_disconnects_workers_blocked_on_full_output() {
+        use std::{sync::mpsc::channel, time::Duration};
+
+        let dir = tempfile::tempdir().unwrap();
+        let roots = [dir.path().join("first"), dir.path().join("second")];
+        for root in &roots {
+            fs::create_dir_all(root.join("child")).unwrap();
+        }
+        for order in [Order::ParentFirst, Order::Completion] {
+            let (started_tx, started_rx) = channel();
+            let walk = walk_roots(
+                roots.clone().into_iter().enumerate(),
+                1,
+                order,
+                Options::default(),
+                move |_, entry| {
+                    if entry.depth == 0 {
+                        true
+                    } else {
+                        started_tx.send(()).unwrap();
+                        false
+                    }
+                },
+            );
+            // One worker has two output slots: the first root's batch and completion fill them.
+            // Reaching the second root guarantees its worker must send to the full queue next.
+            for _ in &roots {
+                started_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            }
+            let (dropped_tx, dropped_rx) = channel();
+            thread::spawn(move || {
+                drop(walk);
+                dropped_tx.send(()).unwrap();
+            });
+            dropped_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("dropping a walk must unblock workers before joining them");
+        }
+    }
+
+    #[test]
+    fn cancelling_a_walk_waits_for_active_reads_and_discards_buffered_entries() {
+        use std::time::{Duration, Instant};
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("child")).unwrap();
+        let (started_tx, started_rx) = crossbeam::channel::bounded(1);
+        let (release_tx, release_rx) = crossbeam::channel::bounded(1);
+        let mut walk = walk(
+            dir.path(),
+            1,
+            Order::ParentFirst,
+            Options::default().skip_metadata(),
+            move |entry| {
+                if entry.depth == 1 {
+                    started_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                }
+                true
+            },
+        );
+        let cancelled = Arc::new(AtomicBool::new(false));
+        assert!(walk.next_cancellable(&cancelled).unwrap().is_ok());
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        let shared = Arc::clone(&walk.pool.as_ref().unwrap().shared);
+        let (done_tx, done_rx) = crossbeam::channel::bounded(1);
+        let reader_cancelled = Arc::clone(&cancelled);
+        let reader = thread::spawn(move || {
+            assert!(walk.next_cancellable(&reader_cancelled).is_none());
+            assert!(walk.next.is_empty());
+            assert!(walk.pool.is_none());
+            assert!(!walk.restart());
+            assert!(walk.next().is_none());
+            done_tx.send(()).unwrap();
+        });
+
+        assert!(done_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        cancelled.store(true, AtomicOrdering::Relaxed);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !shared.stop.load(AtomicOrdering::Relaxed) && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(1));
+        }
+        let stopped_without_output = shared.stop.load(AtomicOrdering::Relaxed);
+        let still_joining = done_rx.try_recv().is_err();
+        release_tx.send(()).unwrap();
+        done_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        reader.join().unwrap();
+
+        assert!(
+            stopped_without_output,
+            "cancellation must wake a waiting reader"
+        );
+        assert!(
+            still_joining,
+            "cancellation must wait for active worker calls"
+        );
+    }
+
+    #[test]
+    fn cancelling_a_walk_disconnects_workers_blocked_on_full_output() {
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["first", "second", "third"] {
+            fs::create_dir_all(dir.path().join(name).join("child")).unwrap();
+        }
+        let (started_tx, started_rx) = crossbeam::channel::unbounded();
+        let mut walk = walk(
+            dir.path(),
+            1,
+            Order::ParentFirst,
+            Options::default().skip_metadata(),
+            move |entry| {
+                if entry.depth == 2 {
+                    started_tx.send(()).unwrap();
+                    return false;
+                }
+                true
+            },
+        );
+        // The root-directory batch and first child-directory batch fill the two output slots.
+        // The second child directory then reaches its predicate before sending to the full queue.
+        for _ in 0..2 {
+            started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        }
+        let (done_tx, done_rx) = crossbeam::channel::bounded(1);
+        let reader = thread::spawn(move || {
+            assert!(walk.next_cancellable(&AtomicBool::new(true)).is_none());
+            assert!(walk.next.is_empty(), "the buffered root is also discarded");
+            done_tx.send(()).unwrap();
+        });
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("cancellation disconnects full output before joining workers");
+        reader.join().unwrap();
+    }
 
     #[test]
     fn directory_ids_are_compact_dense_and_match_parents() {
@@ -1770,14 +2202,12 @@ mod tests {
             fs::write(dir.path().join(idx.to_string()), b"metadata").unwrap();
         }
 
-        let pool = start_pool(
-            1,
-            HashMap::from([(0, AtomicUsize::new(0))]),
-            Order::ParentFirst,
-            Arc::new(|_, _| true),
-            Options::default(),
-            1,
-        );
+        let pool = start_pool(1, Order::ParentFirst, Options::default(), 1);
+        let root = Arc::new(Root {
+            index: 7,
+            pending: AtomicUsize::new(0),
+            descend: Arc::new(|_, _| true),
+        });
         // Leave this queue unconsumed to model workers stalled on metadata lookups.
         let worker = Worker::new_lifo();
         let path = Arc::from(dir.path());
@@ -1788,7 +2218,7 @@ mod tests {
         let mut entries = entries.map(Result::unwrap);
         for _ in 0..=MAX_QUEUED_STAT_JOBS {
             schedule_stat_entries(
-                0,
+                &root,
                 &path,
                 0,
                 1,
@@ -1799,9 +2229,10 @@ mod tests {
         }
 
         assert_eq!(worker.len(), MAX_QUEUED_STAT_JOBS);
-        let Event::Batch { batch, .. } = pool.events.try_recv().unwrap() else {
+        let Event::Batch { root_idx, batch } = pool.events.try_recv().unwrap() else {
             panic!("a full queue must process the next metadata batch inline");
         };
+        assert_eq!(root_idx, 7);
         let entries = batch.unwrap();
         assert_eq!(entries.len(), ENTRY_CHUNK_SIZE);
         for entry in entries {

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -1,0 +1,577 @@
+use std::{
+    collections::{BTreeSet, VecDeque},
+    ffi::{OsStr, OsString},
+    fs,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+mod git;
+
+/// Conservatively protect Git markers in every ASCII case, including on case-sensitive disks.
+pub(crate) fn is_git_dir_name(name: &OsStr) -> bool {
+    name.as_encoded_bytes().eq_ignore_ascii_case(b".git")
+}
+
+/// Return whether a directory name is a known cleanup candidate.
+#[must_use]
+pub fn is_cleanup_dir_name(name: &OsStr) -> bool {
+    [
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        ".zig-cache",
+        "__pycache__",
+        "node_modules",
+        "target",
+        "venv",
+        "zig-cache",
+        "zig-out",
+    ]
+    .binary_search_by(|candidate| OsStr::new(candidate).cmp(name))
+    .is_ok()
+}
+
+pub(crate) enum DiscoveryEvent {
+    Candidate { path: PathBuf, search_root: PathBuf },
+    Progress { entries: u64, io_errors: u64 },
+}
+
+pub(crate) fn discover(
+    input: Vec<PathBuf>,
+    walk_options: crate::WalkOptions,
+    depth: Option<usize>,
+    pattern_root: Option<PathBuf>,
+    mut send: impl FnMut(DiscoveryEvent) -> bool,
+) {
+    let mut progress = Progress::default();
+    if !progress.send(&mut send, true) {
+        return;
+    }
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(err) => {
+            progress.error(Path::new("."), err);
+            progress.send(&mut send, true);
+            return;
+        }
+    };
+    let input = if input.is_empty() {
+        vec![cwd.clone()]
+    } else {
+        input
+    };
+    let pattern_root = pattern_root.map(|root| {
+        root.canonicalize().unwrap_or_else(|_| {
+            gix::path::normalize(root.as_path().into(), &cwd)
+                .map_or_else(|| root.clone(), |path| path.into_owned())
+        })
+    });
+    let mut roots = Vec::new();
+    for path in input {
+        progress.entries += 1;
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.is_dir() => match path.canonicalize() {
+                Ok(path) => roots.push(path),
+                Err(err) => progress.error(&path, err),
+            },
+            Ok(_) => {}
+            Err(err) => progress.error(&path, err),
+        }
+        if !progress.send(&mut send, false) {
+            return;
+        }
+    }
+    roots.sort_by(|left, right| {
+        left.components()
+            .count()
+            .cmp(&right.components().count())
+            .then_with(|| left.cmp(right))
+    });
+    roots.dedup();
+    let mut searched = Vec::<PathBuf>::new();
+    let mut candidates = BTreeSet::<PathBuf>::new();
+    let mut git = git::Filter::default();
+    // ponytail: one discovery reader; use directory workers if enumeration becomes the bottleneck.
+    for root in roots {
+        if root
+            .components()
+            .any(|component| is_git_dir_name(component.as_os_str()))
+        {
+            continue;
+        }
+        if depth.is_none() && searched.iter().any(|parent| root.starts_with(parent)) {
+            continue;
+        }
+        searched.push(root.clone());
+        let pattern_root = pattern_root.as_ref().unwrap_or(&root);
+        let device = if walk_options.cross_filesystems {
+            0
+        } else {
+            match crate::crossdev::init(&root) {
+                Ok(device) => device,
+                Err(err) => {
+                    progress.error(&root, err);
+                    continue;
+                }
+            }
+        };
+        // Finish an ancestor input before nested inputs, preserving each input's depth budget.
+        let mut pending = VecDeque::from([(root.clone(), 0, None)]);
+        while let Some((path, level, parent_has_cargo)) = pending.pop_front() {
+            if !progress.send(&mut send, false) {
+                return;
+            }
+            if path.file_name().is_some_and(is_git_dir_name)
+                || path
+                    .ancestors()
+                    .any(|ancestor| candidates.contains(ancestor))
+                || is_excluded(&path, pattern_root, &cwd, &walk_options)
+            {
+                continue;
+            }
+            if !walk_options.cross_filesystems {
+                match crate::crossdev::init(&path) {
+                    Ok(found) if found != device => continue,
+                    Ok(_) => {}
+                    Err(err) => {
+                        progress.error(&path, err);
+                        continue;
+                    }
+                }
+            }
+            let name = path.file_name().unwrap_or_default();
+            let qualifies = is_cleanup_dir_name(name)
+                && if name == "target" {
+                    parent_has_cargo.unwrap_or_else(|| {
+                        path.parent().is_some_and(|parent| {
+                            has_regular_file(parent, "Cargo.toml", &mut progress, &mut send)
+                        })
+                    })
+                } else if name == ".venv" || name == "venv" {
+                    has_regular_file(&path, "pyvenv.cfg", &mut progress, &mut send)
+                } else {
+                    true
+                };
+            if progress.cancelled {
+                return;
+            }
+            if qualifies {
+                match git.is_candidate(&path) {
+                    Ok(true) => {
+                        candidates.insert(path.clone());
+                        if !send(DiscoveryEvent::Candidate {
+                            path,
+                            search_root: pattern_root.clone(),
+                        }) {
+                            return;
+                        }
+                        continue;
+                    }
+                    Ok(false) => {}
+                    Err(err) => {
+                        progress.error(&path, err);
+                        continue;
+                    }
+                }
+            }
+            if depth.is_some_and(|limit| level >= limit) {
+                continue;
+            }
+            let Some(entries) = read_directory(&path, &mut progress, &mut send) else {
+                if progress.cancelled {
+                    return;
+                }
+                continue;
+            };
+            // The complete batch identifies repository markers before processing any children.
+            // Bare repository contents are administrative, whereas worktrees remain searchable.
+            let has = |name: &str, directory: bool| {
+                entries.iter().any(|(entry_name, kind)| {
+                    entry_name == name
+                        && if directory {
+                            kind.is_dir()
+                        } else {
+                            kind.is_file()
+                        }
+                })
+            };
+            if has("HEAD", false) && has("objects", true) && has("refs", true) {
+                continue;
+            }
+            let has_cargo = has("Cargo.toml", false);
+            pending.extend(entries.into_iter().filter_map(|(name, kind)| {
+                (kind.is_dir() && !is_git_dir_name(&name))
+                    .then(|| (path.join(name), level + 1, Some(has_cargo)))
+            }));
+        }
+    }
+    progress.send(&mut send, true);
+}
+
+fn is_excluded(path: &Path, root: &Path, cwd: &Path, options: &crate::WalkOptions) -> bool {
+    options
+        .ignore_dirs
+        .iter()
+        .any(|ignored| path.starts_with(ignored))
+        || options.ignore_patterns.as_ref().is_some_and(|patterns| {
+            crate::pattern_relative_path(path, cwd, root)
+                .is_some_and(|relative| patterns.is_excluded(relative, true))
+        })
+}
+
+fn has_regular_file(
+    path: &Path,
+    name: &str,
+    progress: &mut Progress,
+    send: &mut impl FnMut(DiscoveryEvent) -> bool,
+) -> bool {
+    read_directory(path, progress, send).is_some_and(|entries| {
+        entries
+            .iter()
+            .any(|(entry_name, kind)| entry_name == name && kind.is_file())
+    })
+}
+
+fn read_directory(
+    path: &Path,
+    progress: &mut Progress,
+    send: &mut impl FnMut(DiscoveryEvent) -> bool,
+) -> Option<Vec<(OsString, fs::FileType)>> {
+    let entries = match fs::read_dir(path) {
+        Ok(entries) => entries,
+        Err(err) => {
+            progress.error(path, err);
+            return None;
+        }
+    };
+    let mut result = Vec::new();
+    for entry in entries {
+        progress.entries += 1;
+        match entry.and_then(|entry| entry.file_type().map(|kind| (entry.file_name(), kind))) {
+            Ok((name, kind)) => {
+                if kind.is_dir()
+                    || matches!(
+                        name.to_str(),
+                        Some("Cargo.toml" | "pyvenv.cfg" | "HEAD" | ".git")
+                    )
+                {
+                    result.push((name, kind));
+                }
+            }
+            Err(err) => progress.error(path, err),
+        }
+        if progress.entries.is_multiple_of(128) && !progress.send(send, false) {
+            return None;
+        }
+    }
+    Some(result)
+}
+
+struct Progress {
+    entries: u64,
+    io_errors: u64,
+    last_sent: Instant,
+    cancelled: bool,
+}
+
+impl Default for Progress {
+    fn default() -> Self {
+        Self {
+            entries: 0,
+            io_errors: 0,
+            last_sent: Instant::now(),
+            cancelled: false,
+        }
+    }
+}
+
+impl Progress {
+    fn error(&mut self, path: &Path, error: impl std::fmt::Display) {
+        self.io_errors += 1;
+        log::warn!("Cannot search {}: {error}", path.display());
+    }
+
+    fn send(&mut self, send: &mut impl FnMut(DiscoveryEvent) -> bool, force: bool) -> bool {
+        if force || self.last_sent.elapsed() >= Duration::from_millis(100) {
+            self.cancelled = !send(DiscoveryEvent::Progress {
+                entries: std::mem::take(&mut self.entries),
+                io_errors: std::mem::take(&mut self.io_errors),
+            });
+            self.last_sent = Instant::now();
+        }
+        !self.cancelled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeSet, fs, path::Path};
+
+    use super::*;
+
+    fn options() -> crate::WalkOptions {
+        crate::WalkOptions {
+            threads: 1,
+            count_hard_links: false,
+            apparent_size: true,
+            cross_filesystems: true,
+            ignore_dirs: BTreeSet::new(),
+            ignore_patterns: None,
+            metadata_options: crate::TraversalOptions::default(),
+        }
+    }
+
+    fn scan(
+        input: Vec<PathBuf>,
+        options: crate::WalkOptions,
+        depth: Option<usize>,
+    ) -> (Vec<PathBuf>, u64, u64) {
+        let mut paths = Vec::new();
+        let (mut entries, mut errors) = (0, 0);
+        discover(input, options, depth, None, |event| {
+            match event {
+                DiscoveryEvent::Candidate { path, .. } => paths.push(path),
+                DiscoveryEvent::Progress {
+                    entries: count,
+                    io_errors,
+                } => {
+                    entries += count;
+                    errors += io_errors;
+                }
+            }
+            true
+        });
+        paths.sort();
+        (paths, entries, errors)
+    }
+
+    fn directory(root: &Path, path: &str) -> PathBuf {
+        let path = root.join(path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn matches_cleanup_names() {
+        for name in [
+            ".mypy_cache",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".tox",
+            ".venv",
+            ".zig-cache",
+            "__pycache__",
+            "node_modules",
+            "target",
+            "venv",
+            "zig-cache",
+            "zig-out",
+        ] {
+            assert!(is_cleanup_dir_name(OsStr::new(name)), "{name}");
+        }
+        for name in ["build", "dist", "Target", ".git", "project/target"] {
+            assert!(!is_cleanup_dir_name(OsStr::new(name)), "{name}");
+        }
+    }
+
+    #[test]
+    fn discovers_zig_caches_and_build_outputs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        fs::write(root.join("build.zig"), "").unwrap();
+        fs::write(root.join("build.zig.zon"), "").unwrap();
+        let mut expected = Vec::new();
+        for name in [".zig-cache", "zig-cache", "zig-out"] {
+            let path = directory(&root, name);
+            directory(&path, "nested/.zig-cache");
+            expected.push(path);
+        }
+        let (paths, _, errors) = scan(vec![root], options(), None);
+        assert_eq!(paths, expected);
+        assert_eq!(errors, 0);
+    }
+
+    #[test]
+    fn discovers_qualified_directories_and_prunes_claimed_subtrees() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let node = directory(&root, "web/node_modules");
+        directory(&node, "nested/node_modules");
+        let target = directory(&root, "rust/target");
+        fs::write(root.join("rust/Cargo.toml"), "").unwrap();
+        let venv = directory(&root, "python/.venv");
+        fs::write(venv.join("pyvenv.cfg"), "").unwrap();
+        let cache = directory(&root, "misc/__pycache__");
+        let below_target = directory(&root, "ordinary/target/nested/node_modules");
+        let below_venv = directory(&root, "ordinary/venv/nested/node_modules");
+        directory(&root, "ordinary/venv/pyvenv.cfg");
+        directory(&root, "metadata/.git/node_modules");
+        fs::write(root.join("target"), "a file is not a candidate").unwrap();
+        assert_eq!(
+            scan(vec![target.clone()], options(), Some(0)).0,
+            vec![target.clone()]
+        );
+        let (paths, entries, errors) = scan(vec![root], options(), None);
+        let mut expected = vec![node, target, venv, cache, below_target, below_venv];
+        expected.sort();
+        assert_eq!(paths, expected);
+        assert!(entries > paths.len() as u64);
+        assert_eq!(errors, 0);
+    }
+
+    #[test]
+    fn depth_limits_discovery_and_an_input_candidate_has_depth_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let direct = directory(&root, "node_modules");
+        let nested = directory(&root, "project/__pycache__");
+        assert!(scan(vec![root.clone()], options(), Some(0)).0.is_empty());
+        assert_eq!(
+            scan(vec![root.clone()], options(), Some(1)).0,
+            vec![direct.clone()]
+        );
+        let mut expected = vec![direct.clone(), nested.clone()];
+        expected.sort();
+        assert_eq!(
+            scan(vec![root.clone(), root.join("project")], options(), Some(1)).0,
+            expected
+        );
+        assert_eq!(scan(vec![root], options(), None).0, expected);
+        assert_eq!(
+            scan(vec![direct.clone()], options(), Some(0)).0,
+            vec![direct]
+        );
+    }
+
+    #[test]
+    fn overlapping_inputs_do_not_duplicate_or_nest_candidates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let artifact = directory(&root, "project/node_modules");
+        let nested = directory(&artifact, "inner/node_modules");
+        assert_eq!(
+            scan(
+                vec![nested, artifact.clone(), root.clone(), root.join(".")],
+                options(),
+                None
+            )
+            .0,
+            vec![artifact]
+        );
+    }
+
+    #[test]
+    fn exclusions_keep_the_original_search_root_scope() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        directory(&root, "node_modules");
+        let nested = directory(&root, "project/node_modules");
+        directory(&root, "ignored/__pycache__");
+        directory(&root, "bare.git/objects");
+        directory(&root, "bare.git/refs");
+        fs::write(root.join("bare.git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        directory(&root, "bare.git/node_modules");
+        let patterns = root.join("patterns");
+        fs::write(&patterns, "/node_modules/\n").unwrap();
+        let mut opts = options();
+        opts.ignore_patterns = crate::IgnorePatterns::from_files(&[patterns]).unwrap();
+        opts.ignore_dirs.insert(root.join("ignored"));
+        assert_eq!(scan(vec![root], opts, None).0, vec![nested]);
+    }
+
+    #[test]
+    fn refresh_uses_the_supplied_discovery_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let artifact = directory(&root, "project/node_modules");
+        let project = root.join("project");
+        let patterns = root.join("patterns");
+        fs::write(&patterns, "/node_modules/\n").unwrap();
+        let mut opts = options();
+        opts.ignore_patterns = crate::IgnorePatterns::from_files(&[patterns]).unwrap();
+        let mut found = false;
+        discover(
+            vec![artifact.clone()],
+            opts.clone(),
+            None,
+            Some(project),
+            |event| {
+                found |= matches!(event, DiscoveryEvent::Candidate { .. });
+                true
+            },
+        );
+        assert!(!found, "refresh must not change the anchored pattern base");
+        discover(
+            vec![artifact.clone()],
+            opts,
+            None,
+            Some(root.clone()),
+            |event| {
+                if let DiscoveryEvent::Candidate { path, search_root } = event {
+                    assert_eq!(path, artifact);
+                    assert_eq!(search_root, root);
+                    found = true;
+                }
+                true
+            },
+        );
+        assert!(found);
+    }
+
+    #[test]
+    fn explicit_paths_inside_git_administration_are_pruned() {
+        for marker in [".git", ".GIT", ".Git"] {
+            let tmp = tempfile::tempdir().unwrap();
+            let root = tmp.path().canonicalize().unwrap();
+            directory(&root, &format!("{marker}/objects/node_modules"));
+            let (paths, entries, errors) =
+                scan(vec![root.join(marker).join("objects")], options(), None);
+            assert!(paths.is_empty());
+            assert_eq!(entries, 1);
+            assert_eq!(errors, 0);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_and_symlink_markers_are_not_followed() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        let real = directory(&root, "real/__pycache__");
+        symlink(root.join("real"), root.join("node_modules")).unwrap();
+        directory(&root, "rust/target");
+        fs::write(root.join("manifest"), "").unwrap();
+        symlink(root.join("manifest"), root.join("rust/Cargo.toml")).unwrap();
+        let venv = directory(&root, "python/venv");
+        symlink(root.join("manifest"), venv.join("pyvenv.cfg")).unwrap();
+        assert_eq!(scan(vec![root.clone()], options(), None).0, vec![real]);
+        assert!(
+            scan(vec![root.join("node_modules")], options(), None)
+                .0
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn progress_reports_empty_search_errors_and_allows_cancellation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().canonicalize().unwrap();
+        fs::write(root.join("ordinary-file"), "").unwrap();
+        let (paths, entries, errors) =
+            scan(vec![root.clone(), root.join("missing")], options(), None);
+        assert!(paths.is_empty());
+        assert!(entries > 0);
+        assert_eq!(errors, 1);
+        directory(&root, "node_modules");
+        let mut calls = 0;
+        discover(vec![root], options(), None, None, |_| {
+            calls += 1;
+            false
+        });
+        assert_eq!(calls, 1);
+    }
+}

--- a/src/clean/git.rs
+++ b/src/clean/git.rs
@@ -1,0 +1,368 @@
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use gix::bstr::ByteSlice;
+
+#[derive(Default)]
+pub(super) struct Filter {
+    repositories: HashMap<PathBuf, gix::Repository>,
+}
+
+impl Filter {
+    pub(super) fn is_candidate(&mut self, path: &Path) -> anyhow::Result<bool> {
+        let path = path.canonicalize()?;
+        let Some(repo) = self.repository(&path)? else {
+            return Ok(true);
+        };
+        let Some(workdir) = repo.workdir() else {
+            return Ok(false);
+        };
+        let workdir = workdir.canonicalize()?;
+        let relative = path.strip_prefix(&workdir)?;
+        if relative.as_os_str().is_empty() {
+            return Ok(false);
+        }
+
+        // gix-index 0.55 can panic before decoding an index shorter than its checksum.
+        match repo.index_path().metadata() {
+            Ok(metadata) => anyhow::ensure!(
+                metadata.len() >= 12 + repo.object_hash().len_in_bytes() as u64,
+                "Truncated Git index in {}",
+                workdir.display()
+            ),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+        // A missing index is also possible in an existing repository, so consult HEAD.
+        let index = repo.index_or_load_from_head_or_empty()?;
+        let ignore_case = repo.filesystem_options()?.ignore_case;
+        let relative_bytes =
+            gix::path::to_unix_separators_on_windows(gix::path::into_bstr(relative));
+        if has_tracked_paths(&index, &relative_bytes, ignore_case) {
+            return Ok(false);
+        }
+        let mut excludes = repo.excludes(
+            &index,
+            None,
+            gix::worktree::stack::state::ignore::Source::WorktreeThenIdMappingIfNotSkipped,
+        )?;
+        Ok(matches!(
+            excludes
+                .at_path(relative, Some(gix::index::entry::Mode::DIR))?
+                .excluded_kind(),
+            Some(gix::ignore::Kind::Expendable)
+        ))
+    }
+
+    fn repository(&mut self, path: &Path) -> anyhow::Result<Option<&gix::Repository>> {
+        for directory in path.ancestors() {
+            let dot_git = directory.join(".git");
+            // Discovery normally skips broken .git markers; cleanup must fail closed instead.
+            let git_dir = if exists(&dot_git)? {
+                dot_git
+            } else if exists(&directory.join("HEAD"))? && exists(&directory.join("objects"))? {
+                directory.to_owned()
+            } else {
+                continue;
+            };
+            let repo = match self.repositories.entry(git_dir) {
+                Entry::Occupied(entry) => entry.into_mut(),
+                Entry::Vacant(entry) => {
+                    use gix::sec::trust::DefaultForLevel;
+
+                    let trust = gix::sec::Trust::from_path_ownership(entry.key())?;
+                    let options = gix::open::Options::default_for_level(trust)
+                        .open_path_as_is(true)
+                        .strict_config(true)
+                        .config_overrides(["gitoxide.parsePrecious=true"]);
+                    let repo = gix::open_opts(entry.key(), options).with_context(|| {
+                        format!("Could not inspect Git repository {}", entry.key().display())
+                    })?;
+                    entry.insert(repo)
+                }
+            };
+            return Ok(Some(repo));
+        }
+        Ok(None)
+    }
+}
+
+fn exists(path: &Path) -> std::io::Result<bool> {
+    match path.symlink_metadata() {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn has_tracked_paths(index: &gix::index::State, path: &[u8], ignore_case: bool) -> bool {
+    let contains = |entry_path: &[u8], directory: &[u8]| {
+        entry_path.get(..directory.len()).is_some_and(|prefix| {
+            (if ignore_case {
+                prefix.eq_ignore_ascii_case(directory)
+            } else {
+                prefix == directory
+            }) && (entry_path.len() == directory.len()
+                || entry_path.get(directory.len()) == Some(&b'/'))
+        })
+    };
+    if ignore_case {
+        // ponytail: scan case-folded indexes per candidate; cache folded paths if this becomes a bottleneck.
+        return index.entries().iter().any(|entry| {
+            let entry_path = entry.path(index).trim_end_with(|c| c == '/');
+            contains(entry_path, path)
+                || ((entry.mode.is_sparse() || entry.mode.is_submodule())
+                    && contains(path, entry_path))
+        });
+    }
+    if index.entry_index_by_path(path.as_bstr()).is_ok() || index.path_is_directory(path.as_bstr())
+    {
+        return true;
+    }
+    for (end, byte) in path.iter().enumerate() {
+        if *byte != b'/' {
+            continue;
+        }
+        // Sparse directory paths include a trailing slash; inspect every conflict stage.
+        for ancestor in [&path[..end], &path[..=end]] {
+            if index
+                .prefixed_entries(ancestor.as_bstr())
+                .is_some_and(|entries| {
+                    entries
+                        .iter()
+                        .take_while(|entry| entry.path(index).as_bytes() == ancestor)
+                        .any(|entry| entry.mode.is_sparse() || entry.mode.is_submodule())
+                })
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::Result;
+    use gix::index::entry::{Flags, Mode, Stage};
+
+    use super::*;
+
+    fn repository() -> Result<tempfile::TempDir> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".git/objects"))?;
+        fs::create_dir_all(dir.path().join(".git/refs/heads"))?;
+        fs::write(dir.path().join(".git/HEAD"), b"ref: refs/heads/main\n")?;
+        fs::write(
+            dir.path().join(".git/config"),
+            b"[core]\nrepositoryformatversion = 0\nbare = false\nignorecase = false\n",
+        )?;
+        Ok(dir)
+    }
+
+    fn write_index(root: &Path, entries: &[(&str, Mode, Flags)]) -> Result<()> {
+        let mut state = gix::index::State::new(gix::hash::Kind::Sha1);
+        for (path, mode, flags) in entries {
+            state.dangerously_push_entry(
+                gix::index::entry::Stat::default(),
+                gix::hash::Kind::Sha1.null(),
+                *flags,
+                *mode,
+                (*path).into(),
+            );
+        }
+        state.sort_entries();
+        gix::index::File::from_state(state, root.join(".git/index"))
+            .write(gix::index::write::Options::default())?;
+        Ok(())
+    }
+
+    #[test]
+    fn requires_ignored_untracked_directories() -> Result<()> {
+        let dir = repository()?;
+        let root = dir.path();
+        fs::write(
+            root.join(".gitignore"),
+            b"ignored/\ntracked/\nconflicted/\nsubmodule/\nreplaced-file/\nreplaced-conflict/\ntarget/\n$precious/\n.zig-cache/\nzig-out/\n",
+        )?;
+        write_index(
+            root,
+            &[
+                ("tracked/keep", Mode::FILE, Flags::empty()),
+                ("conflicted/keep", Mode::FILE, Stage::Theirs.into()),
+                ("submodule", Mode::COMMIT, Flags::empty()),
+                ("replaced-file", Mode::FILE, Flags::empty()),
+                ("replaced-conflict", Mode::FILE, Stage::Theirs.into()),
+                ("target-other/keep", Mode::FILE, Flags::empty()),
+                ("zig-out/keep", Mode::FILE, Flags::empty()),
+            ],
+        )?;
+        let mut filter = Filter::default();
+        for (name, expected) in [
+            ("ignored", true),
+            ("target", true),
+            ("tracked", false),
+            ("conflicted", false),
+            ("submodule", false),
+            ("replaced-file", false),
+            ("replaced-conflict", false),
+            ("precious", false),
+            ("not-ignored-by-clean", false),
+            (".zig-cache", true),
+            ("zig-cache", false),
+            ("zig-out", false),
+        ] {
+            let path = root.join(name);
+            fs::create_dir(&path)?;
+            assert_eq!(filter.is_candidate(&path)?, expected, "{name}");
+        }
+        assert!(!filter.is_candidate(root)?, "worktree roots are protected");
+        let outside = tempfile::tempdir()?;
+        assert!(filter.is_candidate(outside.path())?);
+
+        fs::rename(root.join(".git"), root.join("git-data"))?;
+        fs::write(
+            root.join(".git"),
+            format!("gitdir: {}\n", root.join("git-data").display()),
+        )?;
+        let mut filter = Filter::default();
+        assert!(filter.is_candidate(&root.join("ignored"))?);
+        assert!(!filter.is_candidate(&root.join("tracked"))?);
+        assert!(
+            !filter.is_candidate(root)?,
+            "gitfile worktrees are protected"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn consults_head_when_the_index_is_missing() -> Result<()> {
+        let dir = repository()?;
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), b"target/\n")?;
+        fs::create_dir(root.join("target"))?;
+        let repo = gix::open(root)?;
+        let blob = repo.write_blob(b"keep")?;
+        let tree = repo.write_object(gix::objs::Tree {
+            entries: vec![gix::objs::tree::Entry {
+                mode: gix::objs::tree::EntryKind::Blob.into(),
+                filename: "target".into(),
+                oid: blob.detach(),
+            }],
+        })?;
+        let signature = gix::actor::SignatureRef {
+            name: "Test".into(),
+            email: "test@example.com".into(),
+            time: "0 +0000",
+        };
+        repo.commit_as(
+            signature,
+            signature,
+            "HEAD",
+            "fixture",
+            tree.detach(),
+            std::iter::empty::<gix::ObjectId>(),
+        )?;
+        assert!(!root.join(".git/index").exists());
+        assert!(!Filter::default().is_candidate(&root.join("target"))?);
+        Ok(())
+    }
+
+    #[test]
+    fn protects_case_folded_paths_and_sparse_ancestors() -> Result<()> {
+        let dir = repository()?;
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), b"target/\n")?;
+        fs::create_dir_all(root.join("project/target"))?;
+        fs::create_dir(root.join("target"))?;
+        write_index(
+            root,
+            &[
+                ("TARGET/keep", Mode::FILE, Flags::empty()),
+                ("project/", Mode::DIR, Flags::SKIP_WORKTREE),
+            ],
+        )?;
+        for ignore_case in [false, true] {
+            fs::write(
+                root.join(".git/config"),
+                format!(
+                    "[core]\nrepositoryformatversion = 0\nbare = false\nignorecase = {ignore_case}\n"
+                ),
+            )?;
+            let mut filter = Filter::default();
+            assert_eq!(filter.is_candidate(&root.join("target"))?, !ignore_case);
+            assert!(!filter.is_candidate(&root.join("project/target"))?);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn protects_submodule_descendants_without_a_git_marker() -> Result<()> {
+        let dir = repository()?;
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), b"node_modules/\n")?;
+        fs::create_dir_all(root.join("sub/node_modules"))?;
+        fs::create_dir_all(root.join("sub-other/node_modules"))?;
+        assert!(!root.join("sub/.git").exists());
+        for ignore_case in [false, true] {
+            fs::write(
+                root.join(".git/config"),
+                format!(
+                    "[core]\nrepositoryformatversion = 0\nbare = false\nignorecase = {ignore_case}\n"
+                ),
+            )?;
+            for stage in [Stage::Unconflicted, Stage::Base, Stage::Ours, Stage::Theirs] {
+                let path = if ignore_case { "SUB" } else { "sub" };
+                write_index(root, &[(path, Mode::COMMIT, stage.into())])?;
+                let mut filter = Filter::default();
+                assert!(
+                    !filter.is_candidate(&root.join("sub/node_modules"))?,
+                    "gitlink ancestor at {stage:?}, ignore_case={ignore_case}"
+                );
+                assert!(filter.is_candidate(&root.join("sub-other/node_modules"))?);
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn git_failures_do_not_fall_back_to_name_heuristics() -> Result<()> {
+        let dir = repository()?;
+        let root = dir.path();
+        fs::write(root.join(".gitignore"), b"target/\n")?;
+        fs::create_dir(root.join("target"))?;
+        fs::write(root.join(".git/index"), b"broken index")?;
+        assert!(
+            Filter::default()
+                .is_candidate(&root.join("target"))
+                .is_err()
+        );
+
+        #[cfg(unix)]
+        {
+            fs::remove_file(root.join(".git/index"))?;
+            fs::remove_file(root.join(".gitignore"))?;
+            std::os::unix::fs::symlink(".gitignore", root.join(".gitignore"))?;
+            assert!(
+                Filter::default()
+                    .is_candidate(&root.join("target"))
+                    .is_err()
+            );
+        }
+
+        let outside = tempfile::tempdir()?;
+        fs::write(outside.path().join(".git"), b"not a gitdir file")?;
+        fs::create_dir(outside.path().join("target"))?;
+        assert!(
+            Filter::default()
+                .is_candidate(&outside.path().join("target"))
+                .is_err()
+        );
+        Ok(())
+    }
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -410,7 +410,7 @@ pub fn canonicalize_ignore_dirs(ignore_dirs: &[PathBuf]) -> BTreeSet<PathBuf> {
 /// the directory it was given, if it was given exactly one - so that is what patterns should see.
 /// Roots outside via `traversal_root` of the current directory have no such path, and fall back to
 /// being relative to the root they were found under.
-fn pattern_relative_path<'a>(
+pub(crate) fn pattern_relative_path<'a>(
     path: &'a Path,
     cwd: &Path,
     traversal_root: &Path,

--- a/src/inodefilter.rs
+++ b/src/inodefilter.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 const UNRESOLVED_DIRECTORY_LINKS: u64 = u64::MAX;
 
 /// Tracks hard-linked inodes and, on macOS, fully shared APFS data streams.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub(crate) struct InodeFilter {
     inner: HashMap<(u64, u64), u64>,
     #[cfg(target_os = "macos")]
@@ -13,6 +13,39 @@ pub(crate) struct InodeFilter {
 }
 
 impl InodeFilter {
+    /// Whether accepting this entry can affect accounting in another cleanup candidate.
+    pub(crate) fn needs_tracking(entry: &crate::walk::Entry, options: &crate::WalkOptions) -> bool {
+        let Some(Ok(metadata)) = &entry.metadata else {
+            return false;
+        };
+        if !options.count_hard_links {
+            #[cfg(unix)]
+            {
+                #[cfg(not(target_os = "macos"))]
+                use std::os::unix::fs::MetadataExt;
+                if metadata.nlink() > 1 {
+                    return true;
+                }
+                #[cfg(target_os = "macos")]
+                if entry.file_type.is_dir() {
+                    return true;
+                }
+            }
+            #[cfg(windows)]
+            if metadata.hard_link_id().is_some() {
+                return true;
+            }
+        }
+        #[cfg(target_os = "macos")]
+        if !options.apparent_size
+            && options.metadata_options.apfs_clone_metadata
+            && metadata.clone_id().is_some()
+        {
+            return true;
+        }
+        false
+    }
+
     #[cfg(unix)]
     /// Register file metadata and return `true` if this link should be counted.
     pub(crate) fn add(
@@ -153,7 +186,7 @@ mod apfs {
         }
     }
 
-    #[derive(Debug, Default, Clone)]
+    #[derive(Debug, Default)]
     pub(super) struct ApfsFilter {
         streams: HashSet<(u64, u64)>,
         inodes: HashSet<(u64, u64)>,

--- a/src/interactive/app/clean_hub.rs
+++ b/src/interactive/app/clean_hub.rs
@@ -1,0 +1,413 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use crossterm::event::KeyEvent;
+use dua::{
+    Config,
+    traverse::{BackgroundTraversal, EntryData, Traversal, TreeIndex},
+};
+use tui::{buffer::Buffer, layout::Rect};
+
+use super::{
+    CursorDirection, EntryCheck, EntryDataBundle, SortMode,
+    eventloop::Refresh,
+    navigation::Navigation,
+    sorted_entries,
+    state::{AppState, FocussedPane},
+    tree_view::TreeView,
+};
+use crate::interactive::widgets::{Entries, EntriesProps, EntryMarkMap, EntryRow, MainWindow};
+
+/// Candidate discovery and grouping stay outside the ordinary filesystem browser.
+pub struct CleanHub {
+    pub inputs: Vec<PathBuf>,
+    pub depth: Option<usize>,
+    /// Detached browser root while a row is open; `None` displays the hub.
+    pub root: Option<TreeIndex>,
+    pub(super) rows: Vec<HubRow>,
+    selected: usize,
+}
+
+pub(super) struct HubRow {
+    pub entry: EntryDataBundle,
+    pub members: Vec<TreeIndex>,
+}
+
+impl CleanHub {
+    pub fn new(inputs: Vec<PathBuf>, depth: Option<usize>) -> Self {
+        Self {
+            inputs,
+            depth,
+            root: None,
+            rows: Vec::new(),
+            selected: 0,
+        }
+    }
+
+    pub fn title(&self) -> PathBuf {
+        self.inputs
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+            .into()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn selected_path(&self) -> Option<&Path> {
+        self.rows
+            .get(self.selected)
+            .map(|row| row.entry.name.as_path())
+    }
+
+    pub fn selected_members(&self) -> &[TreeIndex] {
+        self.rows
+            .get(self.selected)
+            .map_or(&[], |row| row.members.as_slice())
+    }
+
+    pub fn select_path(&mut self, path: &Path) {
+        if let Some(position) = self
+            .rows
+            .iter()
+            .position(|row| row.entry.name == path)
+            .or_else(|| {
+                self.rows.iter().position(|row| {
+                    row.entry.name.starts_with(path) || path.starts_with(&row.entry.name)
+                })
+            })
+        {
+            self.selected = position;
+        }
+    }
+
+    pub fn update(&mut self, traversal: &mut Traversal, navigation: &mut Navigation) {
+        let tree = &traversal.tree;
+        if let Some(root) = self.root {
+            let path = tree.name(root).expect("open cleanup root exists");
+            let mut members = Vec::new();
+            for index in tree.children(traversal.root_index) {
+                let name = tree.name(index).expect("candidate exists");
+                if name == path {
+                    members.extend(tree.children(index));
+                } else if name.starts_with(path.as_ref()) {
+                    members.push(index);
+                }
+            }
+            members.sort_unstable();
+            navigation.matches = members.into();
+            return;
+        }
+
+        let candidates = sorted_entries(
+            tree,
+            tree.children(traversal.root_index),
+            SortMode::default(),
+            false,
+            EntryCheck::Disabled,
+        );
+        let mut parents = BTreeMap::new();
+        for entry in &candidates {
+            *parents
+                .entry(entry.name.parent().expect("absolute candidate"))
+                .or_insert(0) += 1;
+        }
+        let parents: BTreeSet<_> = parents
+            .into_iter()
+            .filter(|(_, count)| *count > 1)
+            .map(|(path, _)| path.to_owned())
+            .collect();
+        let mut rows = BTreeMap::<PathBuf, HubRow>::new();
+        for mut entry in candidates {
+            if let Some(parent) = entry
+                .name
+                .ancestors()
+                .skip(1)
+                .filter_map(|path| parents.get(path))
+                .last()
+            {
+                entry.name.clone_from(parent);
+            }
+            match rows.entry(entry.name.clone()) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    let index = entry.index;
+                    slot.insert(HubRow {
+                        entry,
+                        members: vec![index],
+                    });
+                }
+                std::collections::btree_map::Entry::Occupied(mut slot) => {
+                    let row = slot.get_mut();
+                    row.entry.size += entry.size;
+                    row.entry.mtime = row.entry.mtime.max(entry.mtime);
+                    *row.entry.entry_count.get_or_insert(0) += entry.entry_count.unwrap_or(0);
+                    row.members.push(entry.index);
+                }
+            }
+        }
+        let selected = self.selected_path().map(Path::to_owned);
+        self.rows = rows.into_values().collect();
+        self.rows
+            .sort_by_key(|row| std::cmp::Reverse(row.entry.size));
+        self.selected = self.selected.min(self.rows.len().saturating_sub(1));
+        if let Some(path) = selected {
+            self.select_path(&path);
+        }
+    }
+
+    fn move_selection(&mut self, direction: CursorDirection) {
+        self.selected = direction
+            .move_cursor(self.selected)
+            .min(self.rows.len().saturating_sub(1));
+    }
+
+    pub fn render(
+        &self,
+        widget: &mut Entries,
+        props: EntriesProps<'_>,
+        marked: Option<&EntryMarkMap>,
+        cleanup: bool,
+        area: Rect,
+        buffer: &mut Buffer,
+    ) {
+        let language = props.language;
+        let entries = self.rows.iter().map(|row| EntryRow {
+            entry: &row.entry,
+            marked: marked
+                .is_some_and(|marks| row.members.iter().all(|member| marks.contains_key(member))),
+            cleanup,
+            gitignored: false,
+            suffix: (row.members.len() > 1)
+                .then(|| language.cleanup_group_label(row.members.len())),
+        });
+        let hint = props.is_focussed.then(|| {
+            format!(
+                " → = {} | {} = {} | ↻ = {}/{} ",
+                props.keys.descend.primary(),
+                props.language.ui_text().entries_mark_toggle,
+                props.keys.toggle_mark.primary(),
+                props.keys.refresh_selected.primary(),
+                props.keys.refresh_all.primary(),
+            )
+        });
+        let style = props.border_style;
+        widget.render(
+            EntriesProps {
+                current_path: self.title(),
+                selected: (!self.rows.is_empty()).then_some(self.selected),
+                sort_mode: SortMode::SizeDescending,
+                show_hints: false,
+                ..props
+            },
+            entries,
+            area,
+            buffer,
+        );
+        if let Some(hint) = hint
+            && area.height > 0
+            && area.width > 2
+        {
+            buffer.set_stringn(
+                area.x + 1,
+                area.bottom() - 1,
+                hint,
+                area.width.saturating_sub(2) as usize,
+                style,
+            );
+        }
+    }
+}
+
+impl AppState {
+    pub(super) fn clean_refresh(
+        &self,
+        tree: &TreeView<'_>,
+        index: TreeIndex,
+    ) -> Result<(Vec<TreeIndex>, BackgroundTraversal)> {
+        let root = tree.traversal.root_index;
+        let hub = self.clean_hub.as_ref().expect("clean refresh");
+        if index == root {
+            return Ok((
+                tree.tree().children(root).collect(),
+                BackgroundTraversal::start_clean(
+                    root,
+                    &self.walk_options,
+                    hub.inputs.clone(),
+                    hub.depth,
+                    None,
+                )?,
+            ));
+        }
+        let indices = if hub.root.is_none() {
+            hub.selected_members().to_vec()
+        } else if hub.root == Some(index) {
+            let path = tree.path_of(index);
+            tree.tree()
+                .children(root)
+                .filter(|&candidate| tree.path_of(candidate).starts_with(&path))
+                .collect()
+        } else {
+            // Any interior refresh revalidates the entire candidate's deletion scope.
+            vec![
+                std::iter::successors(Some(index), |index| tree.fs_parent_of(*index))
+                    .find(|index| tree.fs_parent_of(*index) == Some(root))
+                    .context("Cleanup entry has no candidate root")?,
+            ]
+        };
+        let candidates = indices
+            .iter()
+            .map(|&index| {
+                let path = tree.path_of(index);
+                let search_root = tree
+                    .traversal
+                    .clean_search_roots
+                    .get(&path)
+                    .context("Cleanup candidate has no discovery root")?
+                    .clone();
+                Ok((path, search_root))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok((
+            indices,
+            BackgroundTraversal::refresh_clean_candidates(root, &self.walk_options, candidates)?,
+        ))
+    }
+
+    pub(super) fn sync_clean_hub(&mut self, tree: &mut TreeView<'_>) {
+        if let Some(hub) = &mut self.clean_hub {
+            hub.update(tree.traversal, &mut self.navigation);
+            tree.scope = hub
+                .root
+                .map(|root| (root, Arc::clone(&self.navigation.matches)));
+        }
+    }
+
+    pub(super) fn process_clean_key(
+        &mut self,
+        key: KeyEvent,
+        window: &mut MainWindow,
+        tree: &mut TreeView<'_>,
+        config: &Config,
+    ) -> anyhow::Result<bool> {
+        let Some(hub) = &mut self.clean_hub else {
+            return Ok(false);
+        };
+        let keys = &config.keys;
+        if let Some(root) = hub.root {
+            if self.focussed == FocussedPane::Main
+                && self.glob_navigation.is_none()
+                && self.navigation.view_root == root
+                && (keys.ascend.matches(key)
+                    || (keys.esc_navigates_back && keys.close_pane.matches(key)))
+            {
+                tree.tree_mut().remove_subtree(root);
+                hub.root = None;
+                self.navigation = Navigation {
+                    tree_root: tree.traversal.root_index,
+                    view_root: tree.traversal.root_index,
+                    ..Navigation::default()
+                };
+                self.sorting = SortMode::default();
+                self.sync_clean_hub(tree);
+                self.update_entries(tree);
+                self.reset_message();
+                return Ok(true);
+            }
+            return Ok(false);
+        }
+        if keys.open_search.matches(key) {
+            return Ok(true);
+        }
+        if self.focussed != FocussedPane::Main {
+            return Ok(false);
+        }
+
+        if let Some(direction) = CursorDirection::from_key(key, keys) {
+            hub.move_selection(direction);
+        } else if keys.descend.matches(key) {
+            if let Some(path) = hub.selected_path() {
+                let root = tree.tree_mut().add_detached(
+                    path,
+                    EntryData {
+                        is_dir: true,
+                        ..EntryData::default()
+                    },
+                );
+                hub.root = Some(root);
+                self.navigation = Navigation {
+                    tree_root: root,
+                    view_root: root,
+                    ..Navigation::default()
+                };
+                self.sync_clean_hub(tree);
+                self.update_entries(tree);
+            }
+        } else if keys.refresh_selected.matches(key) {
+            self.refresh(tree, window, Refresh::Selected)?;
+        } else if keys.refresh_all.matches(key) {
+            self.refresh(tree, window, Refresh::AllInView)?;
+        } else if keys.toggle_mark.matches(key)
+            || keys.mark_for_deletion.matches(key)
+            || keys.toggle_mark_and_move_down.matches(key)
+            || keys.toggle_all.matches(key)
+            || keys.mark_cleanup.matches(key)
+        {
+            if self.block_deletion_changes() {
+                return Ok(true);
+            }
+            let hub = self.clean_hub.as_mut().expect("cleanup hub");
+            let all = keys.toggle_all.matches(key) || keys.mark_cleanup.matches(key);
+            let toggle = !keys.mark_for_deletion.matches(key) && !keys.mark_cleanup.matches(key);
+            for (_, row) in hub
+                .rows
+                .iter()
+                .enumerate()
+                .filter(|(position, _)| all || *position == hub.selected)
+            {
+                let unmark = toggle
+                    && window.mark.as_ref().is_some_and(|pane| {
+                        row.members
+                            .iter()
+                            .all(|index| pane.marked().contains_key(index))
+                    });
+                for &index in &row.members {
+                    window.mark = window
+                        .mark
+                        .take()
+                        .unwrap_or_default()
+                        .toggle_index(index, tree, true, unmark);
+                }
+            }
+            if keys.mark_for_deletion.matches(key) || keys.toggle_mark_and_move_down.matches(key) {
+                hub.move_selection(CursorDirection::Down);
+            }
+        } else if keys.open_entry.matches(key) {
+            let path = hub.selected_path().map(Path::to_owned);
+            self.open_path(path);
+            return Ok(true);
+        } else if !(keys.sort_by_size.matches(key)
+            || keys.sort_by_name.matches(key)
+            || keys.sort_by_mtime.matches(key)
+            || keys.sort_by_count.matches(key)
+            || keys.cycle_mtime_mode.matches(key)
+            || keys.toggle_count_column.matches(key)
+            || keys.cycle_visualization.matches(key)
+            || keys.toggle_cleanup.matches(key)
+            || keys.toggle_gitignore.matches(key)
+            || keys.mark_gitignore.matches(key)
+            || keys.scan_parent.matches(key)
+            || keys.ascend.matches(key))
+        {
+            return Ok(false);
+        }
+        self.reset_message();
+        Ok(true)
+    }
+}

--- a/src/interactive/app/cleanup.rs
+++ b/src/interactive/app/cleanup.rs
@@ -1,21 +1,8 @@
-use std::{collections::BTreeSet, ffi::OsStr};
+use std::collections::BTreeSet;
 
 use dua::traverse::TreeIndex;
 
 use super::EntryDataBundle;
-
-/// Refresh with: `sed -n '/^const CLEANUP_DIR_NAMES_SORTED/,/^];/p' src/interactive/app/cleanup.rs | rg -o '"[^"]+"' | LC_ALL=C sort | sed 's/^/    /; s/$/,/'`.
-const CLEANUP_DIR_NAMES_SORTED_FOR_BISECT: &[&str] = &[
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    ".tox",
-    ".venv",
-    "__pycache__",
-    "node_modules",
-    "target",
-    "venv",
-];
 
 /// Return the indices of existing directories that match known cleanup names.
 pub fn cleanup_candidates(entries: &[EntryDataBundle]) -> BTreeSet<TreeIndex> {
@@ -29,18 +16,12 @@ pub fn cleanup_candidates(entries: &[EntryDataBundle]) -> BTreeSet<TreeIndex> {
 fn is_cleanup_candidate(entry: &EntryDataBundle) -> bool {
     entry.exists
         && entry.is_dir
-        && is_cleanup_dir_name(
+        && dua::clean::is_cleanup_dir_name(
             entry
                 .name
                 .file_name()
                 .unwrap_or_else(|| entry.name.as_os_str()),
         )
-}
-
-fn is_cleanup_dir_name(name: &OsStr) -> bool {
-    CLEANUP_DIR_NAMES_SORTED_FOR_BISECT
-        .binary_search_by(|candidate| OsStr::new(candidate).cmp(name))
-        .is_ok()
 }
 
 #[cfg(test)]
@@ -80,15 +61,5 @@ mod tests {
         }
         assert!(!is_cleanup_candidate(&entry("build", true)));
         assert!(!is_cleanup_candidate(&entry("dist", true)));
-    }
-
-    #[test]
-    fn cleanup_directory_names_remain_sorted_for_bisection() {
-        assert!(
-            CLEANUP_DIR_NAMES_SORTED_FOR_BISECT
-                .windows(2)
-                .all(|names| OsStr::new(names[0]) < OsStr::new(names[1])),
-            "CLEANUP_DIR_NAMES_SORTED must remain sorted for binary search"
-        );
     }
 }

--- a/src/interactive/app/common.rs
+++ b/src/interactive/app/common.rs
@@ -1,4 +1,3 @@
-use crate::interactive::path_of;
 use dua::traverse::{Tree, TreeIndex};
 use std::time::SystemTime;
 use std::{cmp::Ordering, path::PathBuf};
@@ -128,14 +127,12 @@ impl EntryCheck {
     }
 }
 
-/// Note that with `glob_root` present, we will not obtain metadata anymore as we might be seeing
-/// a lot of entries. That way, displaying 250k entries is no problem.
+/// Full-path views skip per-entry metadata queries to keep large glob views responsive.
 pub fn sorted_entries(
     tree: &Tree,
-    node_idx: TreeIndex,
+    indices: impl IntoIterator<Item = TreeIndex>,
     sorting: SortMode,
-    glob_root: Option<TreeIndex>,
-    glob_matches: Option<&[TreeIndex]>,
+    use_full_path: bool,
     check: EntryCheck,
 ) -> Vec<EntryDataBundle> {
     use SortMode::{
@@ -157,20 +154,14 @@ pub fn sorted_entries(
         }
     }
     let mtime_sort = sorting.mtime_sort().unwrap_or_default();
-    let use_glob_path = glob_root == Some(node_idx);
-    let indices = if use_glob_path {
-        glob_matches.unwrap_or_default().to_vec()
-    } else {
-        tree.children(node_idx).collect()
-    };
     let mut entries = indices
         .into_iter()
         .filter_map(|idx| {
             tree.entry(idx).map(|entry| {
                 let data = entry.data;
                 let (path, exists, is_dir) = {
-                    let path = path_of(tree, idx, glob_root);
-                    if matches!(check, EntryCheck::Disabled) || glob_root == Some(node_idx) {
+                    let path = tree.path_of(idx);
+                    if matches!(check, EntryCheck::Disabled) || use_full_path {
                         (path, true, data.is_dir)
                     } else {
                         let meta = path.symlink_metadata();
@@ -180,7 +171,7 @@ pub fn sorted_entries(
                 };
                 EntryDataBundle {
                     index: idx,
-                    name: if use_glob_path {
+                    name: if use_full_path {
                         path
                     } else {
                         entry.name.into_owned()

--- a/src/interactive/app/deletion.rs
+++ b/src/interactive/app/deletion.rs
@@ -1,0 +1,472 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+    thread::{self, JoinHandle},
+    time::Instant,
+};
+
+use crossbeam::channel::{Receiver, Sender, bounded, never};
+
+use crate::interactive::widgets::MarkMode;
+
+#[derive(Debug)]
+pub(super) enum DeletionEvent {
+    /// The path was removed, or disappeared after the directory walk found it.
+    Removed { target: usize, path: PathBuf },
+    /// Work on this target stopped, possibly because cancellation was requested.
+    TargetFinished { target: usize, errors: usize },
+    Finished {
+        entries: usize,
+        errors: usize,
+        cancelled: bool,
+    },
+}
+
+pub(super) struct DeletionTask {
+    pub events: Receiver<DeletionEvent>,
+    pub cancel: Arc<AtomicBool>,
+    pub started: Instant,
+    pub mode: MarkMode,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl DeletionTask {
+    #[cfg(test)]
+    pub fn from_events(events: Receiver<DeletionEvent>) -> Self {
+        Self {
+            events,
+            cancel: Arc::new(AtomicBool::new(false)),
+            started: Instant::now(),
+            mode: MarkMode::Delete,
+            handle: None,
+        }
+    }
+
+    pub fn start(paths: Vec<PathBuf>, threads: usize, mode: MarkMode) -> io::Result<Self> {
+        let started = Instant::now();
+        let (send, events) = bounded(1024);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let worker_cancel = Arc::clone(&cancel);
+        let handle = thread::Builder::new()
+            .name("dua-delete".into())
+            .spawn(move || delete_paths(paths, threads, mode, &send, &worker_cancel))?;
+        Ok(Self {
+            events,
+            cancel,
+            started,
+            mode,
+            handle: Some(handle),
+        })
+    }
+
+    /// Join after consuming `Finished`, so a full event channel cannot block the worker.
+    pub fn join(&mut self) -> thread::Result<()> {
+        self.handle.take().map_or(Ok(()), JoinHandle::join)
+    }
+}
+
+impl Drop for DeletionTask {
+    fn drop(&mut self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        // Unblock publishers before waiting for in-flight filesystem calls to finish.
+        drop(std::mem::replace(&mut self.events, never()));
+        let _ = self.join();
+    }
+}
+
+#[derive(Default)]
+struct RemovalStats {
+    entries: usize,
+    errors: usize,
+}
+
+fn delete_paths(
+    paths: Vec<PathBuf>,
+    threads: usize,
+    mode: MarkMode,
+    events: &Sender<DeletionEvent>,
+    cancel: &AtomicBool,
+) {
+    let mut total = RemovalStats::default();
+    for (target, path) in paths.into_iter().enumerate() {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let stats = match mode {
+            MarkMode::Delete => {
+                delete_directory_recursively(&path, threads, target, events, cancel)
+            }
+            #[cfg(feature = "trash-move")]
+            MarkMode::Trash => {
+                let mut stats = RemovalStats::default();
+                if trash::delete(&path).is_ok() {
+                    stats.entries = 1;
+                    publish_removed(&path, target, events, cancel);
+                } else {
+                    stats.errors = 1;
+                }
+                stats
+            }
+        };
+        total.entries += stats.entries;
+        total.errors += stats.errors;
+        if events
+            .send(DeletionEvent::TargetFinished {
+                target,
+                errors: stats.errors,
+            })
+            .is_err()
+        {
+            cancel.store(true, Ordering::Relaxed);
+            break;
+        }
+    }
+    let _ = events.send(DeletionEvent::Finished {
+        entries: total.entries,
+        errors: total.errors,
+        cancelled: cancel.load(Ordering::Relaxed),
+    });
+}
+
+/// Walk without metadata or following symlinks, unlink files in parallel, then remove
+/// directories deepest-first. The walker finishes before the unlink worker pool starts.
+fn delete_directory_recursively(
+    path: &Path,
+    threads: usize,
+    target: usize,
+    events: &Sender<DeletionEvent>,
+    cancel: &AtomicBool,
+) -> RemovalStats {
+    let mut stats = RemovalStats::default();
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+    let mut walk = dua_core::walk(
+        path,
+        threads,
+        dua_core::Order::Completion,
+        dua_core::Options::default().skip_metadata(),
+        |_| true,
+    );
+    while let Some(entry) = walk.next_cancellable(cancel) {
+        match entry {
+            Ok(entry) => {
+                let path = entry.path();
+                if entry.file_type.is_dir() {
+                    dirs.push((path, entry.depth));
+                } else {
+                    files.push(path);
+                }
+            }
+            Err(_) => stats.errors += 1,
+        }
+    }
+    drop(walk);
+    if cancel.load(Ordering::Relaxed) {
+        return stats;
+    }
+
+    let next_file = AtomicUsize::new(0);
+    let file_stats = thread::scope(|scope| {
+        let handles = (0..threads.max(1).min(files.len()))
+            .map(|_| {
+                scope.spawn(|| {
+                    let mut total = RemovalStats::default();
+                    while let Some(path) = files.get(next_file.fetch_add(1, Ordering::Relaxed)) {
+                        if cancel.load(Ordering::Relaxed) {
+                            break;
+                        }
+                        let result = fs::remove_file(path);
+                        // Windows directory symlinks and junctions require RemoveDirectory.
+                        #[cfg(windows)]
+                        let result = result.or_else(|err| {
+                            if cancel.load(Ordering::Relaxed) {
+                                Err(err)
+                            } else {
+                                fs::remove_dir(path)
+                            }
+                        });
+                        record_removal(result, path, target, events, cancel, &mut total);
+                    }
+                    total
+                })
+            })
+            .collect::<Vec<_>>();
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("deletion worker does not panic"))
+            .fold(RemovalStats::default(), |mut total, stats| {
+                total.entries += stats.entries;
+                total.errors += stats.errors;
+                total
+            })
+    });
+    stats.entries += file_stats.entries;
+    stats.errors += file_stats.errors;
+
+    dirs.sort_by_key(|(_, depth)| std::cmp::Reverse(*depth));
+    for (dir, _) in dirs {
+        if cancel.load(Ordering::Relaxed) {
+            break;
+        }
+        let result = fs::remove_dir(&dir).or_else(|err| {
+            if cancel.load(Ordering::Relaxed) {
+                Err(err)
+            } else {
+                fs::remove_file(&dir)
+            }
+        });
+        record_removal(result, &dir, target, events, cancel, &mut stats);
+    }
+    stats
+}
+
+fn record_removal(
+    result: io::Result<()>,
+    path: &Path,
+    target: usize,
+    events: &Sender<DeletionEvent>,
+    cancel: &AtomicBool,
+    stats: &mut RemovalStats,
+) {
+    match result {
+        Ok(()) => {
+            stats.entries += 1;
+            publish_removed(path, target, events, cancel);
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            publish_removed(path, target, events, cancel);
+        }
+        Err(_) => stats.errors += 1,
+    }
+}
+
+fn publish_removed(
+    path: &Path,
+    target: usize,
+    events: &Sender<DeletionEvent>,
+    cancel: &AtomicBool,
+) {
+    if events
+        .send(DeletionEvent::Removed {
+            target,
+            path: path.to_owned(),
+        })
+        .is_err()
+    {
+        cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn finish(task: &mut DeletionTask) -> Vec<DeletionEvent> {
+        let events = task.events.iter().collect();
+        task.join().expect("deletion worker completes");
+        events
+    }
+
+    fn assert_finished(events: &[DeletionEvent], entries: usize, errors: usize, cancelled: bool) {
+        assert!(matches!(
+            events.last(),
+            Some(DeletionEvent::Finished {
+                entries: actual_entries,
+                errors: actual_errors,
+                cancelled: actual_cancelled,
+            }) if (*actual_entries, *actual_errors, *actual_cancelled) == (entries, errors, cancelled)
+        ));
+    }
+
+    #[test]
+    fn removes_a_single_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        fs::write(&file, b"hello").unwrap();
+
+        let mut task = DeletionTask::start(vec![file.clone()], 1, MarkMode::Delete).unwrap();
+        let events = finish(&mut task);
+
+        assert_finished(&events, 1, 0, false);
+        assert!(matches!(&events[0], DeletionEvent::Removed { target: 0, path } if *path == file));
+        assert!(!file.exists());
+    }
+
+    #[test]
+    fn removes_a_nested_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        let nested = root.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(root.join("top.txt"), b"12345").unwrap();
+        fs::write(nested.join("deep.txt"), b"abc").unwrap();
+
+        let mut task = DeletionTask::start(vec![root.clone()], 2, MarkMode::Delete).unwrap();
+        let events = finish(&mut task);
+
+        assert_finished(&events, 4, 0, false);
+        let removed = events
+            .iter()
+            .filter_map(|event| match event {
+                DeletionEvent::Removed { target: 0, path } => Some(path),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(&removed[2..], [&nested, &root]);
+        assert!(!root.exists());
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn removes_symlink_without_following_it() {
+        for delete_parent in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let target = dir.path().join("target");
+            fs::create_dir(&target).unwrap();
+            fs::write(target.join("keep.txt"), b"keep").unwrap();
+
+            let root = dir.path().join("root");
+            fs::create_dir(&root).unwrap();
+            let link = root.join("link");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            #[cfg(windows)]
+            match std::os::windows::fs::symlink_dir(&target, &link) {
+                Ok(()) => {}
+                Err(err) if err.kind() == io::ErrorKind::PermissionDenied => return,
+                Err(err) => panic!("directory symlink can be created: {err}"),
+            }
+
+            let mut task = DeletionTask::start(
+                vec![if delete_parent { root } else { link.clone() }],
+                2,
+                MarkMode::Delete,
+            )
+            .unwrap();
+            let events = finish(&mut task);
+
+            assert_finished(&events, if delete_parent { 2 } else { 1 }, 0, false);
+            assert!(!link.exists(), "the symlink itself should be gone");
+            assert!(
+                target.join("keep.txt").exists(),
+                "the symlink target must not be deleted"
+            );
+        }
+    }
+
+    #[test]
+    fn reports_an_error_for_a_missing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut task =
+            DeletionTask::start(vec![dir.path().join("does-not-exist")], 1, MarkMode::Delete)
+                .unwrap();
+
+        assert_finished(&finish(&mut task), 0, 1, false);
+    }
+
+    #[test]
+    fn disappearance_after_enumeration_updates_the_tree_without_counting_a_removal() {
+        let (send, receive) = bounded(1);
+        let cancel = AtomicBool::new(false);
+        let mut stats = RemovalStats::default();
+        let path = Path::new("vanished");
+        record_removal(
+            Err(io::Error::from(io::ErrorKind::NotFound)),
+            path,
+            4,
+            &send,
+            &cancel,
+            &mut stats,
+        );
+        assert!(matches!(
+            receive.recv().unwrap(),
+            DeletionEvent::Removed { target: 4, path: removed } if removed == path
+        ));
+        assert_eq!((stats.entries, stats.errors), (0, 0));
+    }
+
+    fn task_with_capacity(paths: Vec<PathBuf>, capacity: usize) -> DeletionTask {
+        let started = Instant::now();
+        let (send, events) = bounded(capacity);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let worker_cancel = Arc::clone(&cancel);
+        let handle = thread::spawn(move || {
+            delete_paths(paths, 1, MarkMode::Delete, &send, &worker_cancel);
+        });
+        DeletionTask {
+            events,
+            cancel,
+            started,
+            mode: MarkMode::Delete,
+            handle: Some(handle),
+        }
+    }
+
+    fn wait_until(mut condition: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !condition() {
+            assert!(
+                Instant::now() < deadline,
+                "worker did not reach the test gate"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn cancellation_finishes_the_current_removal_and_preserves_remaining_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        fs::write(root.join("first"), b"first").unwrap();
+        fs::write(root.join("second"), b"second").unwrap();
+        let next_root = dir.path().join("keep");
+        fs::write(&next_root, b"keep").unwrap();
+        let mut task = task_with_capacity(vec![root.clone(), next_root.clone()], 0);
+
+        // The first successful unlink is blocked publishing its event. No second unlink
+        // can start until we consume it, making cancellation independent of scheduling.
+        wait_until(|| fs::read_dir(&root).unwrap().count() == 1);
+        task.cancel.store(true, Ordering::Relaxed);
+        let events = finish(&mut task);
+
+        assert_finished(&events, 1, 0, true);
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+        assert!(next_root.exists());
+        assert!(matches!(
+            events.get(1),
+            Some(DeletionEvent::TargetFinished {
+                target: 0,
+                errors: 0
+            })
+        ));
+    }
+
+    #[test]
+    fn dropping_a_task_disconnects_a_full_channel_before_joining() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("root");
+        fs::create_dir(&root).unwrap();
+        for name in ["first", "second", "third"] {
+            fs::write(root.join(name), name).unwrap();
+        }
+        let task = task_with_capacity(vec![root.clone()], 1);
+        wait_until(|| fs::read_dir(&root).unwrap().count() == 1);
+        assert_eq!(task.events.len(), 1);
+
+        let (finished, receive) = bounded(1);
+        thread::spawn(move || {
+            drop(task);
+            finished.send(()).unwrap();
+        });
+        receive
+            .recv_timeout(Duration::from_secs(5))
+            .expect("dropping a task must unblock publishers and join the worker");
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+    }
+}

--- a/src/interactive/app/deletion_progress.rs
+++ b/src/interactive/app/deletion_progress.rs
@@ -1,0 +1,440 @@
+//! Apply confirmed filesystem removals to the UI's scanned tree.
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::atomic::Ordering,
+    time::{Duration, Instant},
+};
+
+use anyhow::Result;
+use crossbeam::channel::Receiver;
+use dua::{
+    ByteFormat, Config, WalkResult,
+    traverse::{Traversal, TreeIndex},
+};
+
+use super::{
+    deletion::{DeletionEvent, DeletionTask},
+    navigation::Navigation,
+    notification,
+    state::{AppState, FocussedPane},
+    tree_view::TreeView,
+};
+use crate::interactive::{
+    DisplayOptions,
+    widgets::{Language, MainWindow, MarkMode},
+};
+
+struct Target {
+    path: PathBuf,
+    // Clear this as soon as the root disappears: glob searches can reuse vacant tree slots.
+    index: Option<TreeIndex>,
+}
+
+pub(super) struct FilesystemDeletion {
+    pub task: DeletionTask,
+    pub tick: Receiver<Instant>,
+    pub input_closed: bool,
+    pub pending: Vec<DeletionEvent>,
+    targets: Vec<Target>,
+    children: HashMap<TreeIndex, HashMap<OsString, TreeIndex>>,
+    format: ByteFormat,
+    remaining: u128,
+    bytes_removed: u128,
+    entries_removed: usize,
+}
+
+impl FilesystemDeletion {
+    pub fn message(&self, language: Language) -> String {
+        if self.task.cancel.load(Ordering::Relaxed) {
+            language.ui_text().cancelling_deletion.into()
+        } else {
+            language.deletion_progress(
+                self.entries_removed,
+                &self.format.display(self.remaining).to_string(),
+                self.is_trash(),
+            )
+        }
+    }
+
+    fn is_trash(&self) -> bool {
+        match self.task.mode {
+            MarkMode::Delete => false,
+            #[cfg(feature = "trash-move")]
+            MarkMode::Trash => true,
+        }
+    }
+
+    fn lookup(&mut self, target: usize, path: &Path, tree: &TreeView<'_>) -> Option<TreeIndex> {
+        let target = self.targets.get(target)?;
+        let mut index = target.index?;
+        for name in path.strip_prefix(&target.path).ok()?.components() {
+            let children = self.children.entry(index).or_insert_with(|| {
+                tree.tree()
+                    .children(index)
+                    .filter_map(|child| {
+                        Some((
+                            tree.tree().name(child)?.into_owned().into_os_string(),
+                            child,
+                        ))
+                    })
+                    .collect()
+            });
+            index = *children.get(name.as_os_str())?;
+        }
+        Some(index)
+    }
+}
+
+impl AppState {
+    pub fn is_deleting(&self) -> bool {
+        self.deletion.is_some()
+    }
+
+    pub(super) fn block_deletion_changes(&mut self) -> bool {
+        if self.is_deleting() {
+            self.message = Some(self.language.ui_text().deletion_running.into());
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(super) fn start_deletion(
+        &mut self,
+        window: &MainWindow,
+        tree: &TreeView<'_>,
+        display: DisplayOptions,
+        mode: MarkMode,
+    ) -> Result<()> {
+        if self.block_deletion_changes() {
+            return Ok(());
+        }
+        if self.read_only {
+            anyhow::bail!(self.language.ui_text().snapshots_read_only);
+        }
+        if self.scan.is_some() {
+            anyhow::bail!(self.language.ui_text().traversal_running);
+        }
+        let Some(pane) = &window.mark else {
+            return Ok(());
+        };
+        let mut targets: Vec<_> = pane
+            .marked()
+            .keys()
+            .filter_map(|&index| {
+                let data = tree.tree().data(index)?;
+                (index != tree.traversal.root_index)
+                    .then(|| (tree.path_of(index), index, data.is_dir))
+            })
+            .collect();
+        targets.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        let mut roots: Vec<Target> = Vec::new();
+        let mut last_directory: Option<PathBuf> = None;
+        for (path, index, is_dir) in targets {
+            if roots.last().is_some_and(|root| root.path == path)
+                || last_directory
+                    .as_ref()
+                    .is_some_and(|parent| path.starts_with(parent))
+            {
+                continue;
+            }
+            last_directory = is_dir.then(|| path.clone());
+            roots.push(Target {
+                path,
+                index: Some(index),
+            });
+        }
+        if roots.is_empty() {
+            return Ok(());
+        }
+        let task = DeletionTask::start(
+            roots.iter().map(|target| target.path.clone()).collect(),
+            self.walk_options.threads,
+            mode,
+        )?;
+        self.deletion = Some(FilesystemDeletion {
+            task,
+            tick: crossbeam::channel::tick(Duration::from_secs(1)),
+            input_closed: false,
+            pending: Vec::new(),
+            targets: roots,
+            children: HashMap::new(),
+            format: display.byte_format,
+            remaining: pane.total_size(),
+            bytes_removed: 0,
+            entries_removed: 0,
+        });
+        self.pending_exit = false;
+        self.reset_message();
+        Ok(())
+    }
+
+    /// Turn an actual exit request into cancellation followed by draining the worker.
+    pub(super) fn exit_after_deletion(&mut self) -> Option<WalkResult> {
+        if let Some(deletion) = &self.deletion {
+            deletion.task.cancel.store(true, Ordering::Relaxed);
+            self.pending_exit = false;
+            self.reset_message();
+            None
+        } else {
+            Some(WalkResult {
+                num_errors: self.stats.io_errors,
+            })
+        }
+    }
+
+    pub(super) fn flush_deletion(
+        &mut self,
+        traversal: &mut Traversal,
+        window: &mut MainWindow,
+        config: &Config,
+    ) -> Result<Option<WalkResult>> {
+        let Some(mut deletion) = self.deletion.take() else {
+            return Ok(None);
+        };
+        if deletion.pending.is_empty() {
+            self.deletion = Some(deletion);
+            self.reset_message();
+            return Ok(None);
+        }
+        let mut tree = self.tree_view(traversal);
+        let mut removed = HashSet::new();
+        let mut target_errors = Vec::new();
+        let mut finished = None;
+        for event in std::mem::take(&mut deletion.pending) {
+            match event {
+                DeletionEvent::Removed { target, path } => {
+                    if let Some(index) = deletion.lookup(target, &path, &tree) {
+                        removed.insert(index);
+                    }
+                }
+                DeletionEvent::TargetFinished { target, errors } => {
+                    target_errors.push((target, errors));
+                }
+                DeletionEvent::Finished {
+                    entries,
+                    errors,
+                    cancelled,
+                } => {
+                    finished = Some((entries, errors, cancelled));
+                }
+            }
+        }
+        // A successful directory removal subsumes its descendants in the same batch.
+        let roots: HashSet<_> = removed
+            .iter()
+            .copied()
+            .filter(|&index| {
+                let mut parent = tree.fs_parent_of(index);
+                while let Some(index) = parent {
+                    if removed.contains(&index) {
+                        return false;
+                    }
+                    parent = tree.fs_parent_of(index);
+                }
+                true
+            })
+            .collect();
+        repair_removed_navigation(&mut self.navigation, &tree, &roots);
+        if let Some(navigation) = &mut self.glob_navigation {
+            repair_removed_navigation(navigation, &tree, &roots);
+            tree.glob_matches = Some(navigation.matches.clone());
+        }
+
+        let mut deltas = HashMap::<TreeIndex, (u128, u64)>::new();
+        let mut parents = HashMap::<TreeIndex, HashSet<TreeIndex>>::new();
+        for &index in &roots {
+            let Some(data) = tree.tree().data(index) else {
+                continue;
+            };
+            let Some(parent) = tree.fs_parent_of(index) else {
+                continue;
+            };
+            deletion.bytes_removed += data.size;
+            let mut ancestor = Some(parent);
+            while let Some(index) = ancestor {
+                let delta = deltas.entry(index).or_default();
+                delta.0 += data.size;
+                delta.1 += data.entry_count.unwrap_or(1);
+                ancestor = tree.fs_parent_of(index);
+            }
+            parents.entry(parent).or_default().insert(index);
+            if let Some(children) = deletion.children.get_mut(&parent)
+                && let Some(name) = tree.tree().name(index)
+            {
+                children.remove(name.as_os_str());
+            }
+            // Invalidate only removed directory caches, without scanning every cached parent.
+            let mut pending = vec![index];
+            while let Some(index) = pending.pop() {
+                deletion.children.remove(&index);
+                pending.extend(tree.tree().children(index));
+            }
+        }
+        for target in &mut deletion.targets {
+            if target.index.is_some_and(|index| roots.contains(&index)) {
+                target.index = None;
+            }
+        }
+        for (parent, children) in parents {
+            deletion.entries_removed += tree.traversal.remove_children(parent, &children);
+        }
+        for (index, (bytes, count)) in deltas {
+            tree.tree_mut().update(index, |entry| {
+                entry.size = entry.size.saturating_sub(bytes);
+                if let Some(entries) = &mut entry.entry_count {
+                    *entries = entries.saturating_sub(count);
+                }
+            });
+        }
+        if let Some(pane) = &mut window.mark {
+            pane.reconcile(&tree);
+            for (target, errors) in target_errors {
+                if errors == 0 {
+                    continue;
+                }
+                let path = &deletion.targets[target].path;
+                let indices: Vec<_> = pane
+                    .marked()
+                    .iter()
+                    .filter_map(|(&index, mark)| mark.path.starts_with(path).then_some(index))
+                    .collect();
+                for index in indices {
+                    pane.set_deletion_error(index, errors);
+                }
+            }
+            deletion.remaining = pane.total_size();
+            if pane.is_empty() {
+                window.mark = None;
+                if self.focussed == FocussedPane::Mark {
+                    self.focussed = FocussedPane::Main;
+                }
+            }
+        }
+        self.stats.total_bytes = Some(tree.total_size());
+        let should_exit = deletion.task.cancel.load(Ordering::Relaxed) || deletion.input_closed;
+        self.deletion = Some(deletion);
+        self.sync_clean_hub(&mut tree);
+        self.update_entries(&tree);
+        self.reset_message();
+        if let Some((entries, errors, cancelled)) = finished {
+            let mut deletion = self.deletion.take().expect("active deletion");
+            deletion
+                .task
+                .join()
+                .map_err(|_| anyhow::anyhow!("Deletion worker panicked"))?;
+            if !cancelled && !deletion.task.cancel.load(Ordering::Relaxed) {
+                let action = match deletion.task.mode {
+                    MarkMode::Delete => self.language.ui_text().notification_deletion,
+                    #[cfg(feature = "trash-move")]
+                    MarkMode::Trash => self.language.ui_text().notification_trash,
+                };
+                let message = notification::deletion_finished(
+                    self.language,
+                    action,
+                    if deletion.is_trash() {
+                        deletion.entries_removed
+                    } else {
+                        entries
+                    },
+                    (errors == 0).then_some(deletion.bytes_removed),
+                    deletion.task.started.elapsed(),
+                    errors,
+                    deletion.format,
+                );
+                if let Err(err) = notification::emit_if_unfocused(
+                    config.notifications.delete_finished,
+                    self.terminal_focus.is_focussed(),
+                    &message,
+                ) {
+                    log::debug!("Could not emit terminal notification: {err}");
+                }
+            }
+            if should_exit {
+                self.reset_message();
+                return Ok(Some(WalkResult {
+                    num_errors: self.stats.io_errors,
+                }));
+            }
+            self.update_entry_annotations(&tree);
+            self.reset_message();
+        }
+        Ok(None)
+    }
+}
+
+fn repair_removed_navigation(
+    navigation: &mut Navigation,
+    tree: &TreeView<'_>,
+    removed: &HashSet<TreeIndex>,
+) {
+    let is_removed = |mut index| {
+        loop {
+            if removed.contains(&index) {
+                return true;
+            }
+            match tree.fs_parent_of(index) {
+                Some(parent) => index = parent,
+                None => return false,
+            }
+        }
+    };
+    while is_removed(navigation.view_root) {
+        navigation.view_root = if navigation
+            .matches
+            .binary_search(&navigation.view_root)
+            .is_ok()
+        {
+            navigation.tree_root
+        } else {
+            tree.fs_parent_of(navigation.view_root)
+                .unwrap_or(navigation.tree_root)
+        };
+    }
+    navigation.selected = navigation.selected.filter(|&index| !is_removed(index));
+    navigation
+        .bookmarks
+        .retain(|&view, selected| !is_removed(view) && !is_removed(*selected));
+    if navigation.matches.iter().any(|&index| is_removed(index)) {
+        navigation.matches = navigation
+            .matches
+            .iter()
+            .copied()
+            .filter(|&index| !is_removed(index))
+            .collect();
+    }
+}
+
+#[cfg(test)]
+impl FilesystemDeletion {
+    pub(super) fn for_test(
+        tree: &TreeView<'_>,
+        targets: Vec<TreeIndex>,
+        events: Receiver<DeletionEvent>,
+    ) -> Self {
+        let remaining = targets
+            .iter()
+            .filter_map(|&index| tree.tree().data(index).map(|entry| entry.size))
+            .sum();
+        Self {
+            task: DeletionTask::from_events(events),
+            tick: crossbeam::channel::tick(Duration::from_secs(1)),
+            input_closed: false,
+            pending: Vec::new(),
+            targets: targets
+                .into_iter()
+                .map(|index| Target {
+                    path: tree.path_of(index),
+                    index: Some(index),
+                })
+                .collect(),
+            children: HashMap::new(),
+            format: ByteFormat::Metric,
+            remaining,
+            bytes_removed: 0,
+            entries_removed: 0,
+        }
+    }
+}

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -20,6 +20,7 @@ use tui::{
     Terminal, backend::Backend, buffer::Buffer, layout::Rect, style::Color, widgets::Widget,
 };
 
+use super::deletion::DeletionEvent;
 use super::notification;
 use super::state::{AppState, Cursor};
 #[cfg(unix)]
@@ -89,21 +90,35 @@ impl AppState {
         if self.read_only {
             bail!(self.language.ui_text().snapshots_read_only);
         }
-        let bg_traversal = BackgroundTraversal::start(
-            traversal.root_index,
-            &self.walk_options,
-            self.root_paths.clone(),
-            self.walk_options
-                .ignore_patterns
-                .as_ref()
-                .map(|_| self.root_paths.as_slice()),
-            false,
-            true,
-        )?;
+        if self.is_deleting() {
+            bail!(self.language.ui_text().deletion_running);
+        }
+        let bg_traversal = if let Some(hub) = &self.clean_hub {
+            BackgroundTraversal::start_clean(
+                traversal.root_index,
+                &self.walk_options,
+                hub.inputs.clone(),
+                hub.depth,
+                None,
+            )?
+        } else {
+            BackgroundTraversal::start(
+                traversal.root_index,
+                &self.walk_options,
+                self.root_paths.clone(),
+                self.walk_options
+                    .ignore_patterns
+                    .as_ref()
+                    .map(|_| self.root_paths.as_slice()),
+                false,
+                true,
+            )?
+        };
         self.navigation_mut().view_root = traversal.root_index;
         self.scan = Some(FilesystemScan {
             active_traversal: bg_traversal,
             previous_selection: None,
+            previous_cleanup_view: None,
             snapshot_export,
         });
         Ok(())
@@ -114,7 +129,7 @@ impl AppState {
     }
 
     /// Return the path displayed for the current view without resolving snapshot paths on disk.
-    fn display_path(&self, tree_view: &TreeView<'_>) -> PathBuf {
+    pub(super) fn display_path(&self, tree_view: &TreeView<'_>) -> PathBuf {
         if self.read_only {
             let path = tree_view.path_of(self.navigation().view_root);
             if path.as_os_str().is_empty() {
@@ -129,7 +144,9 @@ impl AppState {
 
     fn parent_scan_target(&self, tree: &TreeView<'_>) -> Option<ParentScan> {
         if self.read_only
+            || self.clean_hub.is_some()
             || self.scan.is_some()
+            || self.is_deleting()
             || self.glob_navigation.is_some()
             || self.navigation.view_root != tree.traversal.root_index
         {
@@ -172,6 +189,9 @@ impl AppState {
     }
 
     fn scan_parent(&mut self, tree: &mut TreeView<'_>) -> Result<()> {
+        if self.block_deletion_changes() {
+            return Ok(());
+        }
         if self.read_only {
             self.message = Some(self.language.ui_text().snapshots_read_only.into());
             return Ok(());
@@ -302,6 +322,7 @@ impl AppState {
         self.scan = Some(FilesystemScan {
             active_traversal,
             previous_selection,
+            previous_cleanup_view: None,
             snapshot_export: None,
         });
         self.reset_message();
@@ -404,7 +425,7 @@ impl AppState {
         B: Backend,
     {
         let (_keep_alive, no_events) = crossbeam::channel::bounded(0);
-        while self.scan.is_some() {
+        while self.scan.is_some() || self.is_deleting() {
             if let Some(result) =
                 self.process_event(window, traversal, display, terminal, &no_events, config)?
             {
@@ -426,9 +447,52 @@ impl AppState {
     where
         B: Backend,
     {
-        if let Some(FilesystemScan {
+        if let Some(deletion) = &self.deletion {
+            let input = if deletion.input_closed {
+                crossbeam::channel::never()
+            } else {
+                events.clone()
+            };
+            let removals = deletion.task.events.clone();
+            let tick = deletion.tick.clone();
+            crossbeam::select! {
+                recv(input) -> event => {
+                    match event {
+                        Ok(event) => {
+                            if let Some(result) = self.flush_deletion(traversal, window, config)? {
+                                return Ok(Some(result));
+                            }
+                            return self.process_terminal_event(window, traversal, display, terminal, event, config);
+                        }
+                        Err(_) => {
+                            self.deletion.as_mut().expect("active deletion").input_closed = true;
+                        }
+                    }
+                },
+                recv(removals) -> event => {
+                    let event = event.context("Deletion worker stopped unexpectedly")?;
+                    let deletion = self.deletion.as_mut().expect("active deletion");
+                    deletion.pending.push(event);
+                    deletion.pending.extend(removals.try_iter().take(1023));
+                    // Bound pending path storage as well as the worker channel. The timer is
+                    // independent of traffic, so a busy worker cannot starve progress redraws.
+                    if deletion.pending.len() >= 16_384
+                        || deletion.pending.iter().any(|event| matches!(event, DeletionEvent::Finished { .. })) {
+                        let result = self.flush_deletion(traversal, window, config)?;
+                        self.refresh_screen(window, traversal, display, terminal, config)?;
+                        return Ok(result);
+                    }
+                },
+                recv(tick) -> _ => {
+                    let result = self.flush_deletion(traversal, window, config)?;
+                    self.refresh_screen(window, traversal, display, terminal, config)?;
+                    return Ok(result);
+                }
+            }
+        } else if let Some(FilesystemScan {
             active_traversal,
             previous_selection,
+            previous_cleanup_view,
             snapshot_export,
         }) = self.scan.as_mut()
         {
@@ -450,13 +514,12 @@ impl AppState {
                     }
                 },
                 recv(&active_traversal.event_rx) -> event => {
-                    let Ok(event) = event else {
-                        return Ok(None);
-                    };
+                    let event = event.context("Filesystem traversal stopped unexpectedly")?;
 
                     if let Some(is_finished) = active_traversal.integrate_traversal_event(traversal, event) {
                         self.stats = active_traversal.stats;
                         let previous_selection = previous_selection.clone();
+                        let previous_cleanup_view = previous_cleanup_view.clone();
                         if is_finished {
                             let root_index = active_traversal.root_idx;
                             let export = snapshot_export
@@ -483,6 +546,21 @@ impl AppState {
                             self.scan = None;
                             traversal.cost = Some(traversal.start_time.elapsed());
                         }
+                        if is_finished && !self.received_events
+                            && let Some((source_path, view_path)) = &previous_cleanup_view
+                        {
+                            let mut tree = self.tree_view(traversal);
+                            if let Some(source) = tree.index_at_path(source_path) {
+                                self.navigation.view_root = source;
+                                if self.glob_navigation.is_some() && let Some(glob) = &window.glob {
+                                    // Rebuild replaced IDs within the original search directory.
+                                    self.search_glob_pattern(&mut tree, &glob.input, glob.case);
+                                }
+                            }
+                            if let Some(view) = tree.index_at_path(view_path) {
+                                self.navigation_mut().view_root = view;
+                            }
+                        }
                         self.update_state_during_traversal(traversal, previous_selection.as_ref(), is_finished);
                         self.refresh_screen(window, traversal, display, terminal, config)?;
                         if is_finished {
@@ -503,6 +581,13 @@ impl AppState {
                             }
                         }
                     }
+                },
+                default(std::time::Duration::from_secs(1)) => {
+                    // Keep progress visible while discovery or filesystem I/O is waiting.
+                    self.stats = active_traversal.stats;
+                    let previous_selection = previous_selection.clone();
+                    self.update_state_during_traversal(traversal, previous_selection.as_ref(), false);
+                    self.refresh_screen(window, traversal, display, terminal, config)?;
                 }
             }
         } else {
@@ -527,14 +612,15 @@ impl AppState {
         is_finished: bool,
     ) {
         let tree_view = self.tree_view(traversal);
-        self.entries = tree_view.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(&tree_view);
+        self.update_entries(&tree_view);
 
         if !self.received_events {
+            if let Some(hub) = &mut self.clean_hub
+                && hub.root.is_none()
+                && let Some((path, _)) = previous_selection
+            {
+                hub.select_path(path);
+            }
             let previously_selected_entry =
                 previous_selection.and_then(|(selected_name, selected_idx)| {
                     self.entries
@@ -553,7 +639,7 @@ impl AppState {
 
     pub(crate) fn entry_check(&self) -> EntryCheck {
         EntryCheck::new(
-            self.scan.is_some(),
+            self.scan.is_some() || self.is_deleting(),
             self.allow_entry_check && !self.read_only,
         )
     }
@@ -600,12 +686,17 @@ impl AppState {
         let close_pane = keys.close_pane.matches(key);
         let quit = !glob_focussed && keys.quit.matches(key);
         let mut handled = true;
-        if keys.esc_navigates_back && close_pane && self.focussed == Main {
+        if self.process_clean_key(key, window, &mut tree_view, config)? {
+            self.pending_exit = false;
+        } else if keys.esc_navigates_back && close_pane && self.focussed == Main {
             self.pending_exit = false;
             self.exit_node_with_traversal(&tree_view, &keys.scan_parent.primary());
         } else if close_pane || quit {
             if let Some(result) = self.handle_quit(&mut tree_view, window) {
-                return Ok(Some(result?));
+                result?;
+                if let Some(result) = self.exit_after_deletion() {
+                    return Ok(Some(result));
+                }
             }
         } else {
             self.pending_exit = false;
@@ -634,9 +725,9 @@ impl AppState {
                     self.toggle_help_pane(window);
                 }
                 _ if !glob_focussed && keys.quit_immediately.matches(key) => {
-                    return Ok(Some(WalkResult {
-                        num_errors: self.stats.io_errors,
-                    }));
+                    if let Some(result) = self.exit_after_deletion() {
+                        return Ok(Some(result));
+                    }
                 }
                 _ => {
                     handled = false;
@@ -646,14 +737,7 @@ impl AppState {
 
         if !handled {
             match self.focussed {
-                Mark => self.dispatch_to_mark_pane(
-                    key,
-                    window,
-                    &mut tree_view,
-                    *display,
-                    terminal,
-                    config,
-                ),
+                Mark => self.dispatch_to_mark_pane(key, window, &mut tree_view, *display, config),
                 Help => {
                     window
                         .help
@@ -671,7 +755,11 @@ impl AppState {
                 }
                 Main => {
                     if keys.open_entry.matches(key) {
-                        self.open_that(&tree_view);
+                        self.open_path(
+                            self.navigation()
+                                .selected
+                                .map(|index| tree_view.path_of(index)),
+                        );
                     } else if keys.toggle_mark.matches(key) {
                         self.mark_entry(
                             CursorMode::KeepPosition,
@@ -702,18 +790,8 @@ impl AppState {
                         self.refresh(&mut tree_view, window, Refresh::Selected)?;
                     } else if keys.refresh_all.matches(key) {
                         self.refresh(&mut tree_view, window, Refresh::AllInView)?;
-                    } else if keys.move_to_top.matches(key) {
-                        self.change_entry_selection(CursorDirection::ToTop);
-                    } else if keys.move_to_bottom.matches(key) {
-                        self.change_entry_selection(CursorDirection::ToBottom);
-                    } else if keys.page_up.matches(key) {
-                        self.change_entry_selection(CursorDirection::PageUp);
-                    } else if keys.move_up.matches(key) {
-                        self.change_entry_selection(CursorDirection::Up);
-                    } else if keys.move_down.matches(key) {
-                        self.change_entry_selection(CursorDirection::Down);
-                    } else if keys.page_down.matches(key) {
-                        self.change_entry_selection(CursorDirection::PageDown);
+                    } else if let Some(direction) = CursorDirection::from_key(key, keys) {
+                        self.change_entry_selection(direction);
                     } else if keys.sort_by_size.matches(key) {
                         self.cycle_sorting(&tree_view);
                     } else if keys.sort_by_mtime.matches(key) {
@@ -748,12 +826,15 @@ impl AppState {
         Ok(None)
     }
 
-    fn refresh(
+    pub(super) fn refresh(
         &mut self,
         tree: &mut TreeView<'_>,
         window: &mut MainWindow,
         what: Refresh,
     ) -> anyhow::Result<()> {
+        if self.block_deletion_changes() {
+            return Ok(());
+        }
         if self.read_only {
             self.message = Some(self.language.ui_text().snapshots_read_only.into());
             return Ok(());
@@ -764,18 +845,18 @@ impl AppState {
             return Ok(());
         }
 
-        let previous_selection = self.navigation().selected.and_then(|sel_index| {
-            tree.tree().name(sel_index).map(|name| {
-                (
-                    name.into_owned(),
-                    self.entries
-                        .iter()
-                        .enumerate()
-                        .find_map(|(idx, e)| (e.index == sel_index).then_some(idx))
-                        .expect("selected item is always in entries"),
-                )
-            })
-        });
+        let previous_selection = self
+            .entries
+            .iter()
+            .enumerate()
+            .find(|(_, entry)| Some(entry.index) == self.navigation().selected)
+            .map(|(position, entry)| (entry.name.clone(), position))
+            .or_else(|| {
+                self.clean_hub
+                    .as_ref()?
+                    .selected_path()
+                    .map(|path| (path.to_owned(), 0))
+            });
 
         // If we are displaying the root of the glob search results then cancel the search.
         if let Some(glob_tree_root) = tree.glob_tree_root
@@ -784,87 +865,103 @@ impl AppState {
             self.quit_glob_mode(tree, window);
         }
 
-        let (paths, remove_root_node, skip_root, use_root_path, index, parent_index) = match what {
-            Refresh::Selected => {
-                let Some(selected) = self.navigation().selected else {
-                    return Ok(());
-                };
-                let parent_index = tree
-                    .fs_parent_of(selected)
-                    .expect("there is always a parent to a selection");
-
-                let mut path = tree.path_of(selected);
-                if path.to_str() == Some("") {
-                    path = PathBuf::from(".");
-                }
-
-                let (paths, use_root_path, skip_root) = if self.navigation().view_root
-                    == tree.traversal.root_index
-                    && self.root_paths.len() > 1
-                {
-                    (vec![path], true, false)
-                } else {
-                    (vec![path], false, false)
-                };
-
+        let previous_cleanup_view = (self.clean_hub.is_some()
+            && self.navigation().view_root != tree.traversal.root_index)
+            .then(|| {
                 (
-                    paths,
-                    true,
-                    skip_root,
-                    use_root_path,
-                    selected,
-                    parent_index,
+                    tree.path_of(self.navigation.view_root),
+                    tree.path_of(self.navigation().view_root),
                 )
-            }
-            Refresh::AllInView => {
-                let (paths, use_root_path, skip_root) = if self.navigation().view_root
-                    == tree.traversal.root_index
-                    && self.root_paths.len() > 1
-                {
-                    (self.root_paths.clone(), true, false)
+            });
+        let remove_root_node = matches!(what, Refresh::Selected);
+        let index = if remove_root_node {
+            let Some(selected) = self
+                .clean_hub
+                .as_ref()
+                .filter(|hub| hub.root.is_none())
+                .and_then(|hub| hub.selected_members().first().copied())
+                .or(self.navigation().selected)
+            else {
+                return Ok(());
+            };
+            selected
+        } else {
+            self.navigation().view_root
+        };
+        let (indices, parent_index, active_traversal) = if self.clean_hub.is_some() {
+            let (indices, traversal) = self.clean_refresh(tree, index)?;
+            (indices, tree.traversal.root_index, traversal)
+        } else {
+            let parent = if remove_root_node {
+                tree.fs_parent_of(index).expect("selection has a parent")
+            } else {
+                index
+            };
+            let multi_root = self.navigation().view_root == tree.traversal.root_index
+                && self.root_paths.len() > 1;
+            let paths = if multi_root && !remove_root_node {
+                self.root_paths.clone()
+            } else {
+                let path = tree.path_of(index);
+                vec![if path.as_os_str().is_empty() {
+                    PathBuf::from(".")
                 } else {
-                    let mut path = tree.path_of(self.navigation().view_root);
-                    if path.to_str() == Some("") {
-                        path = PathBuf::from(".");
-                    }
-                    (vec![path], false, true)
-                };
-
-                (
+                    path
+                }]
+            };
+            (
+                if remove_root_node {
+                    vec![index]
+                } else {
+                    tree.tree().children(index).collect()
+                },
+                parent,
+                BackgroundTraversal::start(
+                    parent,
+                    &self.walk_options,
                     paths,
-                    false,
-                    skip_root,
-                    use_root_path,
-                    self.navigation().view_root,
-                    self.navigation().view_root,
-                )
-            }
+                    self.walk_options
+                        .ignore_patterns
+                        .as_ref()
+                        .map(|_| self.root_paths.as_slice()),
+                    !remove_root_node && !multi_root,
+                    multi_root,
+                )?,
+            )
         };
 
-        tree.remove_entries(index, remove_root_node);
+        // Tree slots are reused: old marks and bookmarks must not target replacement entries.
+        window.mark = None;
+        self.navigation.bookmarks.clear();
+        tree.traversal
+            .remove_children(parent_index, &indices.into_iter().collect());
         tree.recompute_sizes_recursively(parent_index);
+        if let Some(navigation) = self.glob_navigation.as_mut() {
+            navigation.bookmarks.clear();
+            navigation.matches = navigation
+                .matches
+                .iter()
+                .copied()
+                .filter(|index| tree.exists(*index))
+                .collect();
+            tree.glob_matches = Some(Arc::clone(&navigation.matches));
+        }
+        for navigation in
+            std::iter::once(&mut self.navigation).chain(self.glob_navigation.iter_mut())
+        {
+            if !tree.exists(navigation.view_root) {
+                navigation.view_root = navigation.tree_root;
+            }
+            navigation.selected = navigation.selected.filter(|index| tree.exists(*index));
+        }
 
-        self.entries = tree.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(tree);
-        self.navigation_mut().selected = self.entries.first().map(|e| e.index);
+        self.sync_clean_hub(tree);
+        self.update_entries(tree);
 
         self.scan = Some(FilesystemScan {
-            active_traversal: BackgroundTraversal::start(
-                parent_index,
-                &self.walk_options,
-                paths,
-                self.walk_options
-                    .ignore_patterns
-                    .as_ref()
-                    .map(|_| self.root_paths.as_slice()),
-                skip_root,
-                use_root_path,
-            )?,
+            active_traversal,
             previous_selection,
+            previous_cleanup_view,
             snapshot_export: None,
         });
 
@@ -872,15 +969,18 @@ impl AppState {
         Ok(())
     }
 
-    fn tree_view<'a>(&mut self, traversal: &'a mut Traversal) -> TreeView<'a> {
-        TreeView {
+    pub(super) fn tree_view<'a>(&mut self, traversal: &'a mut Traversal) -> TreeView<'a> {
+        let mut tree = TreeView {
             traversal,
+            scope: None,
             glob_tree_root: self.glob_navigation.as_ref().map(|n| n.tree_root),
             glob_matches: self
                 .glob_navigation
                 .as_ref()
                 .map(|navigation| Arc::clone(&navigation.matches)),
-        }
+        };
+        self.sync_clean_hub(&mut tree);
+        tree
     }
 
     fn search_glob_pattern(
@@ -890,13 +990,15 @@ impl AppState {
         case: gix::glob::pattern::Case,
     ) {
         use FocussedPane::Main;
-        match glob_search(
-            tree_view.tree(),
-            self.navigation.view_root,
-            glob_pattern,
-            case,
-            self.language,
-        ) {
+        let entries = tree_view
+            .children(self.navigation.view_root)
+            .into_iter()
+            .filter_map(|index| {
+                tree_view
+                    .name_in(self.navigation.view_root, index)
+                    .map(|name| (index, name))
+            });
+        match glob_search(tree_view.tree(), entries, glob_pattern, case, self.language) {
             Ok(matches) if matches.is_empty() => {
                 self.message = Some(self.language.ui_text().no_match.into());
             }
@@ -919,6 +1021,7 @@ impl AppState {
 
                 let glob_tree_view = TreeView {
                     traversal: tree_view.traversal,
+                    scope: tree_view.scope.clone(),
                     glob_tree_root: Some(tree_root),
                     glob_matches: Some(matches),
                 };
@@ -982,16 +1085,11 @@ impl AppState {
         window.glob = None;
 
         tree_view.glob_tree_root.take();
-        self.entries = tree_view.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(tree_view);
+        self.update_entries(tree_view);
     }
 }
 
-enum Refresh {
+pub(super) enum Refresh {
     /// Refresh the directory currently in view
     AllInView,
     /// Refresh only the selected item

--- a/src/interactive/app/gitignore.rs
+++ b/src/interactive/app/gitignore.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeSet;
+use std::path::Path;
 
 use dua::traverse::TreeIndex;
 use gix::ignore::Kind;
@@ -7,7 +8,7 @@ use super::{EntryDataBundle, tree_view::TreeView};
 
 pub fn gitignored_entries(
     tree_view: &TreeView<'_>,
-    view_root: TreeIndex,
+    current_path: &Path,
     entries: &[EntryDataBundle],
 ) -> BTreeSet<TreeIndex> {
     use std::path::{Path, PathBuf};
@@ -35,19 +36,12 @@ pub fn gitignored_entries(
             .config_overrides(["gitoxide.parsePrecious=true"])
     }
 
-    let current_path = tree_view.path_of(view_root);
-    let current_path = if current_path.as_os_str().is_empty() {
-        Path::new(".").to_owned()
-    } else {
-        current_path
-    };
-
     let trust_map = gix::sec::trust::Mapping {
         full: open_options(gix::sec::Trust::Full),
         reduced: open_options(gix::sec::Trust::Reduced),
     };
     let Ok(repo) = gix::ThreadSafeRepository::discover_opts(
-        &current_path,
+        current_path,
         gix::discover::upwards::Options::default(),
         trust_map,
     ) else {
@@ -61,6 +55,8 @@ pub fn gitignored_entries(
         return BTreeSet::new();
     };
     let workdir = absolute_path(workdir.to_owned(), &cwd);
+    // Discovery can simplify the Windows verbatim prefix retained by canonical entry paths.
+    let canonical_workdir = workdir.canonicalize().ok();
     let Ok(index) = repo.index_or_empty() else {
         return BTreeSet::new();
     };
@@ -76,7 +72,10 @@ pub fn gitignored_entries(
         .iter()
         .filter_map(|entry| {
             let path = absolute_path(tree_view.path_of(entry.index), &cwd);
-            let relative_path = path.strip_prefix(&workdir).ok()?;
+            let relative_path = path
+                .strip_prefix(&workdir)
+                .ok()
+                .or_else(|| path.strip_prefix(canonical_workdir.as_ref()?).ok())?;
             let platform = excludes.at_path(relative_path, Some(mode(entry))).ok()?;
             platform
                 .excluded_kind()

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -1,27 +1,16 @@
 use crate::interactive::{
     DisplayOptions, EntryDataBundle,
     app::tree_view::TreeView,
-    widgets::{Column, GlobPane, HelpPane, MainWindow, MarkMode, MarkPane},
+    widgets::{Column, GlobPane, HelpPane, MainWindow, MarkPane},
 };
 use crossterm::event::KeyEvent;
 use dua::Config;
 use dua::traverse::TreeIndex;
-use std::{
-    collections::BTreeSet,
-    fs, io,
-    path::PathBuf,
-    sync::atomic::{AtomicUsize, Ordering},
-    thread,
-    time::{Duration, Instant},
-};
-use tui::{Terminal, backend::Backend};
+use std::{collections::BTreeSet, path::PathBuf};
 
-use super::{
-    notification,
-    state::{
-        AppState,
-        FocussedPane::{Glob, Help, Main, Mark},
-    },
+use super::state::{
+    AppState,
+    FocussedPane::{Glob, Help, Main, Mark},
 };
 
 #[derive(Copy, Clone)]
@@ -42,27 +31,6 @@ enum AnnotationKind {
     Gitignored,
 }
 
-/// Aggregate outcome of an entire deletion or trash operation.
-///
-/// This combines the results for all selected entries and adds the operation's
-/// wall-clock duration for the completion notification. In contrast,
-/// [`EntryDeletionStats`] describes the lower-level removal of one selected entry.
-struct DeletionStats {
-    entries: usize,
-    bytes: Option<u128>,
-    errors: usize,
-    elapsed: Duration,
-}
-
-/// Outcome of removing one selected entry from the filesystem and traversal.
-#[derive(Default)]
-struct EntryDeletionStats {
-    entries: usize,
-    /// Scanned size, assigned only after the selected entry was completely removed.
-    bytes: u128,
-    errors: usize,
-}
-
 pub enum CursorDirection {
     PageDown,
     Down,
@@ -73,6 +41,19 @@ pub enum CursorDirection {
 }
 
 impl CursorDirection {
+    pub fn from_key(key: KeyEvent, keys: &dua::KeysConfig) -> Option<Self> {
+        [
+            (&keys.move_to_top, Self::ToTop),
+            (&keys.move_to_bottom, Self::ToBottom),
+            (&keys.page_up, Self::PageUp),
+            (&keys.move_up, Self::Up),
+            (&keys.move_down, Self::Down),
+            (&keys.page_down, Self::PageDown),
+        ]
+        .into_iter()
+        .find_map(|(binding, direction)| binding.matches(key).then_some(direction))
+    }
+
     pub fn move_cursor(&self, n: usize) -> usize {
         use CursorDirection::{Down, PageDown, PageUp, ToBottom, ToTop, Up};
         match self {
@@ -87,9 +68,11 @@ impl CursorDirection {
 }
 
 impl AppState {
-    pub fn open_that(&mut self, tree_view: &TreeView<'_>) {
-        if let Some(idx) = self.navigation().selected {
-            let path = tree_view.path_of(idx);
+    pub fn open_path(&mut self, path: Option<PathBuf>) {
+        if self.block_deletion_changes() {
+            return;
+        }
+        if let Some(path) = path {
             let t = self.language.ui_text();
             if self.read_only && !path.exists() {
                 self.message = Some(format!("{}{}", t.snapshot_path_unavailable, path.display()));
@@ -102,44 +85,18 @@ impl AppState {
     }
 
     pub fn exit_node_with_traversal(&mut self, tree_view: &TreeView<'_>, scan_parent_key: &str) {
-        let entries = self.entries_for_exit_node(tree_view);
-        self.exit_node(entries, tree_view, scan_parent_key);
-    }
-
-    fn entries_for_exit_node(
-        &self,
-        tree_view: &TreeView<'_>,
-    ) -> Option<(TreeIndex, Vec<EntryDataBundle>)> {
-        tree_view
-            .view_parent_of(self.navigation().view_root)
-            .map(|parent_idx| {
-                (
-                    parent_idx,
-                    tree_view.sorted_entries(parent_idx, self.sorting, self.entry_check()),
-                )
-            })
-    }
-
-    pub fn exit_node(
-        &mut self,
-        entries: Option<(TreeIndex, Vec<EntryDataBundle>)>,
-        tree_view: &TreeView<'_>,
-        scan_parent_key: &str,
-    ) {
-        match entries {
-            Some((parent_idx, entries)) => {
-                self.navigation_mut().exit_node(parent_idx, &entries);
-                self.entries = entries;
-                self.update_entry_annotations(tree_view);
-                self.reset_message();
-            }
-            None => {
-                self.message = Some(if self.can_scan_parent(tree_view) {
-                    self.language.top_level_with_scan(scan_parent_key)
-                } else {
-                    self.language.ui_text().top_level.into()
-                });
-            }
+        if let Some(parent) = tree_view.view_parent_of(self.navigation().view_root) {
+            let navigation = self.navigation_mut();
+            navigation.view_root = parent;
+            navigation.selected = navigation.bookmarks.get(&parent).copied();
+            self.update_entries(tree_view);
+            self.reset_message();
+        } else {
+            self.message = Some(if self.can_scan_parent(tree_view) {
+                self.language.top_level_with_scan(scan_parent_key)
+            } else {
+                self.language.ui_text().top_level.into()
+            });
         }
     }
 
@@ -191,52 +148,28 @@ impl AppState {
 
     pub fn cycle_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_size();
-        self.entries = tree_view.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(tree_view);
+        self.update_entries(tree_view);
     }
 
     pub fn cycle_mtime_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_mtime();
-        self.entries = tree_view.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(tree_view);
+        self.update_entries(tree_view);
     }
 
     pub fn cycle_count_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_count();
-        self.entries = tree_view.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(tree_view);
+        self.update_entries(tree_view);
     }
 
     pub fn cycle_name_sorting(&mut self, tree_view: &TreeView<'_>) {
         self.sorting.toggle_name();
-        self.entries = tree_view.sorted_entries(
-            self.navigation().view_root,
-            self.sorting,
-            self.entry_check(),
-        );
-        self.update_entry_annotations(tree_view);
+        self.update_entries(tree_view);
     }
 
     pub fn cycle_mtime_sort_mode(&mut self, tree_view: &TreeView<'_>) {
         if self.sorting.mtime_sort().is_some() {
             self.sorting.cycle_mtime_sort();
-            self.entries = tree_view.sorted_entries(
-                self.navigation().view_root,
-                self.sorting,
-                self.entry_check(),
-            );
+            self.update_entries(tree_view);
         } else {
             self.toggle_column(Column::MTime);
         }
@@ -286,8 +219,14 @@ impl AppState {
     }
 
     pub fn reset_message(&mut self) {
-        if self.scan.is_some() {
+        if let Some(deletion) = &self.deletion {
+            self.message = Some(deletion.message(self.language));
+        } else if self.scan.is_some() {
             self.message = Some(self.language.ui_text().scanning.into());
+        } else if let Some(hub) = self.clean_hub.as_ref().filter(|hub| hub.root.is_none()) {
+            self.message = hub
+                .is_empty()
+                .then(|| self.language.ui_text().no_cleanup_candidates.into());
         } else {
             self.message = self.language.annotation_message(
                 self.cleanup_candidates.as_ref().map_or(0, BTreeSet::len),
@@ -357,234 +296,32 @@ impl AppState {
         };
     }
 
-    pub fn dispatch_to_mark_pane<B>(
+    pub fn dispatch_to_mark_pane(
         &mut self,
         key: KeyEvent,
         window: &mut MainWindow,
         tree_view: &mut TreeView<'_>,
         display: DisplayOptions,
-        terminal: &mut Terminal<B>,
         config: &Config,
-    ) where
-        B: Backend,
-    {
+    ) {
         if window.right_panes_minimized {
             return;
         }
         let res = window
             .mark
             .take()
-            .and_then(|p| p.process_events(key, &config.keys));
-        window.mark = match res {
-            Some((pane, Some(_))) if self.read_only => {
-                self.message = Some(self.language.ui_text().snapshots_read_only.into());
-                Some(pane)
+            .and_then(|pane| pane.process_events(key, &config.keys, !self.is_deleting()));
+        if let Some((pane, mode)) = res {
+            window.mark = Some(pane);
+            if let Some(mode) = mode
+                && let Err(err) = self.start_deletion(window, tree_view, display, mode)
+            {
+                self.message = Some(err.to_string());
             }
-            Some((pane, Some(_))) if self.scan.is_some() => {
-                self.message = Some(self.language.ui_text().traversal_running.into());
-                Some(pane)
-            }
-            Some((pane, mode)) => match mode {
-                Some(MarkMode::Delete) => {
-                    self.message = Some(self.language.ui_text().deleting_items.into());
-                    let start = Instant::now();
-                    let mut entries_deleted = 0;
-                    let mut bytes_deleted = 0;
-                    let mut errors = 0;
-                    let res = pane.iterate_deletable_items(|mut pane, entry_to_delete| {
-                        window.mark = Some(pane);
-                        self.draw(window, tree_view, display, terminal, config).ok();
-                        pane = window.mark.take().expect("option to be filled");
-                        match self.delete_entry(entry_to_delete, tree_view) {
-                            Ok(stats) => {
-                                entries_deleted += stats.entries;
-                                bytes_deleted += stats.bytes;
-                                self.message =
-                                    Some(self.language.deletion_progress(entries_deleted, false));
-                                Ok(pane)
-                            }
-                            Err(stats) => {
-                                entries_deleted += stats.entries;
-                                bytes_deleted += stats.bytes;
-                                errors += stats.errors;
-                                Err((pane, stats.errors))
-                            }
-                        }
-                    });
-                    self.message = None;
-                    self.notify_deletion_finished(
-                        self.language.ui_text().notification_deletion,
-                        DeletionStats {
-                            entries: entries_deleted,
-                            bytes: (errors == 0).then_some(bytes_deleted),
-                            elapsed: start.elapsed(),
-                            errors,
-                        },
-                        display,
-                        config,
-                    );
-                    res
-                }
-                #[cfg(feature = "trash-move")]
-                Some(MarkMode::Trash) => {
-                    self.message = Some(self.language.ui_text().trashing_items.into());
-                    let start = Instant::now();
-                    let mut entries_trashed = 0;
-                    let mut bytes_trashed = 0;
-                    let mut errors = 0;
-                    let res = pane.iterate_deletable_items(|mut pane, entry_to_trash| {
-                        window.mark = Some(pane);
-                        self.draw(window, tree_view, display, terminal, config).ok();
-                        pane = window.mark.take().expect("option to be filled");
-                        let entry_size = tree_view
-                            .tree()
-                            .data(entry_to_trash)
-                            .map_or(0, |entry| entry.size);
-                        match self.trash_entry(entry_to_trash, tree_view) {
-                            Ok(ed) => {
-                                entries_trashed += ed;
-                                bytes_trashed += entry_size;
-                                self.message =
-                                    Some(self.language.deletion_progress(entries_trashed, true));
-                                Ok(pane)
-                            }
-                            Err(c) => {
-                                errors += c;
-                                Err((pane, c))
-                            }
-                        }
-                    });
-                    self.message = None;
-                    self.notify_deletion_finished(
-                        self.language.ui_text().notification_trash,
-                        DeletionStats {
-                            entries: entries_trashed,
-                            bytes: Some(bytes_trashed),
-                            elapsed: start.elapsed(),
-                            errors,
-                        },
-                        display,
-                        config,
-                    );
-                    res
-                }
-                None => Some(pane),
-            },
-            None => None,
-        };
-        if window.mark.is_none() {
+        }
+        if window.mark.is_none() && self.focussed == Mark {
             self.focussed = Main;
         }
-    }
-
-    fn notify_deletion_finished(
-        &self,
-        action: &str,
-        stats: DeletionStats,
-        display: DisplayOptions,
-        config: &Config,
-    ) {
-        let message = notification::deletion_finished(
-            self.language,
-            action,
-            stats.entries,
-            stats.bytes,
-            stats.elapsed,
-            stats.errors,
-            display.byte_format,
-        );
-        if let Err(err) = notification::emit_if_unfocused(
-            config.notifications.delete_finished,
-            self.terminal_focus.is_focussed(),
-            &message,
-        ) {
-            log::debug!("Could not emit terminal notification: {err}");
-        }
-    }
-
-    fn delete_entry(
-        &mut self,
-        index: TreeIndex,
-        tree_view: &mut TreeView<'_>,
-    ) -> Result<EntryDeletionStats, EntryDeletionStats> {
-        if !tree_view.exists(index) {
-            return Ok(EntryDeletionStats::default());
-        }
-        let path_to_delete = tree_view.path_of(index);
-        let bytes = tree_view.tree().data(index).map_or(0, |entry| entry.size);
-        let mut stats = delete_directory_recursively(path_to_delete, self.walk_options.threads);
-        if stats.errors == 0 {
-            stats.entries = self.delete_entries_in_traversal(index, tree_view);
-            stats.bytes = bytes;
-            Ok(stats)
-        } else {
-            Err(stats)
-        }
-    }
-
-    #[cfg(feature = "trash-move")]
-    pub fn trash_entry(
-        &mut self,
-        index: TreeIndex,
-        tree_view: &mut TreeView<'_>,
-    ) -> Result<usize, usize> {
-        let mut entries_deleted = 0;
-        if tree_view.exists(index) {
-            let path_to_delete = tree_view.path_of(index);
-            if trash::delete(path_to_delete).is_err() {
-                return Err(1);
-            }
-            entries_deleted = self.delete_entries_in_traversal(index, tree_view);
-        }
-        Ok(entries_deleted)
-    }
-
-    pub fn delete_entries_in_traversal(
-        &mut self,
-        index: TreeIndex,
-        tree_view: &mut TreeView<'_>,
-    ) -> usize {
-        let parent_idx = tree_view
-            .fs_parent_of(index)
-            .expect("us being unable to delete the root index");
-        let entries_deleted =
-            tree_view.remove_entries(index, true /* remove node at `index` */);
-
-        if tree_view.exists(self.navigation().view_root) {
-            self.entries = tree_view.sorted_entries(
-                self.navigation().view_root,
-                self.sorting,
-                self.entry_check(),
-            );
-        } else {
-            self.go_to_root(tree_view);
-        }
-        self.update_entry_annotations(tree_view);
-
-        if self
-            .navigation()
-            .selected
-            .and_then(|selected| self.entries.iter().find(|e| e.index == selected))
-            .is_none()
-        {
-            let idx = self.entries.first().map(|e| e.index);
-            self.navigation_mut().select(idx);
-        }
-        tree_view.recompute_sizes_recursively(parent_idx);
-
-        entries_deleted
-    }
-
-    pub fn go_to_root(&mut self, tree_view: &TreeView<'_>) {
-        let root = self.navigation().tree_root;
-        let entries = tree_view.sorted_entries(root, self.sorting, self.entry_check());
-        self.navigation_mut().exit_node(root, &entries);
-        self.entries = entries;
-        self.update_entry_annotations(tree_view);
-    }
-
-    pub fn glob_root(&self) -> Option<TreeIndex> {
-        self.glob_navigation.as_ref().map(|e| e.tree_root)
     }
 
     fn mark_entry_by_index(
@@ -594,21 +331,23 @@ impl AppState {
         window: &mut MainWindow,
         tree_view: &TreeView<'_>,
     ) {
+        if self.block_deletion_changes() {
+            return;
+        }
+        let Some(data) = tree_view.tree().data(index) else {
+            return;
+        };
         let is_dir = self
             .entries
             .iter()
-            .find(|e| e.index == index)
-            .unwrap()
-            .is_dir;
-        let should_toggle = match mode {
-            MarkEntryMode::Toggle => true,
-            MarkEntryMode::MarkForDeletion => false,
-        };
-        if let Some(pane) = window.mark.take() {
-            window.mark = pane.toggle_index(index, tree_view, is_dir, should_toggle);
-        } else {
-            window.mark = MarkPane::default().toggle_index(index, tree_view, is_dir, should_toggle);
-        }
+            .find(|entry| entry.index == index)
+            .map_or(data.is_dir, |entry| entry.is_dir);
+        window.mark = window.mark.take().unwrap_or_default().toggle_index(
+            index,
+            tree_view,
+            is_dir,
+            matches!(mode, MarkEntryMode::Toggle),
+        );
     }
 
     pub fn mark_entry(
@@ -618,6 +357,9 @@ impl AppState {
         window: &mut MainWindow,
         tree_view: &TreeView<'_>,
     ) {
+        if self.block_deletion_changes() {
+            return;
+        }
         if let Some(index) = self.navigation().selected {
             self.mark_entry_by_index(index, mode, window, tree_view);
         }
@@ -632,12 +374,18 @@ impl AppState {
         window: &mut MainWindow,
         tree_view: &TreeView<'_>,
     ) {
+        if self.block_deletion_changes() {
+            return;
+        }
         for index in self.entries.iter().map(|e| e.index).collect::<Vec<_>>() {
             self.mark_entry_by_index(index, mode, window, tree_view);
         }
     }
 
     pub fn mark_cleanup_candidates(&mut self, window: &mut MainWindow, tree_view: &TreeView<'_>) {
+        if self.block_deletion_changes() {
+            return;
+        }
         match self.cleanup_candidates.clone() {
             Some(cleanup_candidates) => self.mark_annotation_candidates(
                 cleanup_candidates,
@@ -652,6 +400,9 @@ impl AppState {
     }
 
     pub fn mark_gitignored_entries(&mut self, window: &mut MainWindow, tree_view: &TreeView<'_>) {
+        if self.block_deletion_changes() {
+            return;
+        }
         match self.gitignored_entries.clone() {
             Some(gitignored_entries) => self.mark_annotation_candidates(
                 gitignored_entries,
@@ -708,6 +459,29 @@ impl AppState {
         }
     }
 
+    pub(super) fn update_entries(&mut self, tree: &TreeView<'_>) {
+        if self
+            .clean_hub
+            .as_ref()
+            .is_some_and(|hub| hub.root.is_none())
+        {
+            self.entries.clear();
+            return;
+        }
+        self.entries = tree.sorted_entries(
+            self.navigation().view_root,
+            self.sorting,
+            self.entry_check(),
+        );
+        let selected = self
+            .navigation()
+            .selected
+            .filter(|selected| self.entries.iter().any(|entry| entry.index == *selected))
+            .or_else(|| self.entries.first().map(|entry| entry.index));
+        self.navigation_mut().selected = selected;
+        self.update_entry_annotations(tree);
+    }
+
     pub fn update_entry_annotations(&mut self, tree_view: &TreeView<'_>) {
         if self.glob_navigation.is_some() {
             if self.cleanup_candidates.is_some() {
@@ -720,198 +494,24 @@ impl AppState {
             if self.cleanup_candidates.is_some() {
                 self.cleanup_candidates = Some(super::cleanup::cleanup_candidates(&self.entries));
             }
-            if self.gitignored_entries.is_some() {
+            if self.is_deleting() {
+                // Progress and navigation must not reread a potentially large Git index.
+                // Retain known annotations until completion can check the current view again.
+                if let Some(known) = &self.gitignored_entries {
+                    self.gitignored_entries = Some(
+                        self.entries
+                            .iter()
+                            .filter_map(|entry| known.contains(&entry.index).then_some(entry.index))
+                            .collect(),
+                    );
+                }
+            } else if self.gitignored_entries.is_some() {
                 self.gitignored_entries = Some(super::gitignore::gitignored_entries(
                     tree_view,
-                    self.navigation().view_root,
+                    &self.display_path(tree_view),
                     &self.entries,
                 ));
             }
         }
-    }
-}
-
-fn io_err_to_usize(err: io::Error) -> usize {
-    usize::from(err.kind() != io::ErrorKind::NotFound)
-}
-
-/// Remove `path` and everything beneath it, returning deletion statistics.
-///
-/// Uses the work-stealing walker for a parallel traversal that does **not** follow symlinks.
-/// Files and symlinks are removed in parallel;
-/// directories are collected and removed deepest-first so each `remove_dir`
-/// sees an empty directory.
-fn delete_directory_recursively(path: PathBuf, threads: usize) -> EntryDeletionStats {
-    let mut stats = EntryDeletionStats::default();
-    let mut dirs: Vec<(PathBuf, usize)> = Vec::new();
-    let mut files: Vec<PathBuf> = Vec::new();
-
-    for entry in dua_core::walk(
-        &path,
-        threads,
-        dua_core::Order::Completion,
-        dua_core::Options::default().skip_metadata(),
-        |_| true,
-    ) {
-        match entry {
-            Ok(entry) => {
-                let entry_path = entry.path();
-                if entry.file_type.is_dir() {
-                    // Real directory (symlinks to dirs report is_symlink, not
-                    // is_dir, when follow_links is false): remove after children.
-                    dirs.push((entry_path, entry.depth));
-                } else {
-                    // Regular file or symlink — remove without following.
-                    files.push(entry_path);
-                }
-            }
-            Err(_) => stats.errors += 1,
-        }
-    }
-
-    let next_file = AtomicUsize::new(0);
-    let file_stats = thread::scope(|scope| {
-        let handles = (0..threads.max(1).min(files.len()))
-            .map(|_| {
-                scope.spawn(|| {
-                    let mut total = EntryDeletionStats::default();
-                    while let Some(path) = files.get(next_file.fetch_add(1, Ordering::Relaxed)) {
-                        let result = fs::remove_file(path);
-                        // Windows directory symlinks and junctions require RemoveDirectory.
-                        #[cfg(windows)]
-                        let result = result.or_else(|_| fs::remove_dir(path));
-                        record_removal(result, &mut total);
-                    }
-                    total
-                })
-            })
-            .collect::<Vec<_>>();
-
-        handles
-            .into_iter()
-            .map(|handle| handle.join().expect("deletion worker does not panic"))
-            .fold(EntryDeletionStats::default(), |mut total, stats| {
-                total.entries += stats.entries;
-                total.errors += stats.errors;
-                total
-            })
-    });
-    stats.entries += file_stats.entries;
-    stats.errors += file_stats.errors;
-
-    // Remove directories deepest-first so parents are empty when removed.
-    dirs.sort_by(|(_, a_depth), (_, b_depth)| a_depth.cmp(b_depth).reverse());
-    for (dir, _) in dirs {
-        record_removal(
-            fs::remove_dir(&dir).or_else(|_| fs::remove_file(dir)),
-            &mut stats,
-        );
-    }
-
-    stats
-}
-
-fn record_removal(result: io::Result<()>, stats: &mut EntryDeletionStats) {
-    match result {
-        Ok(()) => stats.entries += 1,
-        Err(err) => stats.errors += io_err_to_usize(err),
-    }
-}
-
-#[cfg(test)]
-mod deletion_notification_tests {
-    use super::*;
-
-    #[test]
-    fn retains_partial_success_statistics_alongside_errors() {
-        let mut stats = EntryDeletionStats::default();
-        record_removal(Ok(()), &mut stats);
-        record_removal(
-            Err(io::Error::new(io::ErrorKind::PermissionDenied, "denied")),
-            &mut stats,
-        );
-
-        assert_eq!(stats.entries, 1);
-        assert_eq!(stats.errors, 1);
-    }
-}
-
-#[cfg(test)]
-mod delete_directory_recursively_tests {
-    use super::*;
-
-    #[test]
-    fn removes_a_single_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let file = dir.path().join("a.txt");
-        fs::write(&file, b"hello").unwrap();
-
-        let stats = delete_directory_recursively(file.clone(), 1);
-
-        assert_eq!(stats.errors, 0);
-        assert_eq!(stats.entries, 1);
-        assert!(!file.exists());
-    }
-
-    #[test]
-    fn removes_a_nested_tree() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path().join("root");
-        let nested = root.join("nested");
-        fs::create_dir_all(&nested).unwrap();
-        fs::write(root.join("top.txt"), b"12345").unwrap();
-        fs::write(nested.join("deep.txt"), b"abc").unwrap();
-
-        let stats = delete_directory_recursively(root.clone(), 1);
-
-        assert_eq!(stats.errors, 0);
-        // top.txt + deep.txt + nested dir + root dir
-        assert_eq!(stats.entries, 4);
-        assert!(!root.exists());
-    }
-
-    #[cfg(any(unix, windows))]
-    #[test]
-    fn removes_symlink_without_following_it() {
-        for delete_parent in [false, true] {
-            let dir = tempfile::tempdir().unwrap();
-            let target = dir.path().join("target");
-            fs::create_dir(&target).unwrap();
-            fs::write(target.join("keep.txt"), b"keep").unwrap();
-
-            let root = dir.path().join("root");
-            fs::create_dir(&root).unwrap();
-            let link = root.join("link");
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(&target, &link).unwrap();
-            #[cfg(windows)]
-            match std::os::windows::fs::symlink_dir(&target, &link) {
-                Ok(()) => {}
-                Err(err) if err.kind() == io::ErrorKind::PermissionDenied => return,
-                Err(err) => panic!("directory symlink can be created: {err}"),
-            }
-
-            let stats =
-                delete_directory_recursively(if delete_parent { root } else { link.clone() }, 2);
-
-            assert_eq!(stats.errors, 0);
-            assert_eq!(stats.entries, if delete_parent { 2 } else { 1 });
-            assert!(!link.exists(), "the symlink itself should be gone");
-            assert!(
-                target.join("keep.txt").exists(),
-                "the symlink target must not be deleted"
-            );
-        }
-    }
-
-    #[test]
-    fn reports_an_error_for_a_missing_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let missing = dir.path().join("does-not-exist");
-
-        let stats = delete_directory_recursively(missing, 1);
-
-        assert_eq!(stats.entries, 0);
-        assert!(stats.errors > 0);
     }
 }

--- a/src/interactive/app/input.rs
+++ b/src/interactive/app/input.rs
@@ -56,8 +56,8 @@ fn forward_event(
 }
 
 pub fn input_channel(focus: TerminalFocus) -> Receiver<Event> {
-    // Keep reading while the event loop performs synchronous deletion or trash work so the
-    // shared focus state stays current, without allowing user input to grow without bound.
+    // Keep the shared focus state current even during a busy frame, without allowing user
+    // input to grow without bound.
     let (key_send, key_receive) = crossbeam::channel::bounded(32);
     std::thread::spawn(move || -> Result<(), std::io::Error> {
         loop {

--- a/src/interactive/app/mod.rs
+++ b/src/interactive/app/mod.rs
@@ -1,6 +1,9 @@
 mod bytevis;
+pub mod clean_hub;
 mod cleanup;
 mod common;
+mod deletion;
+mod deletion_progress;
 mod eventloop;
 mod gitignore;
 mod handlers;

--- a/src/interactive/app/navigation.rs
+++ b/src/interactive/app/navigation.rs
@@ -11,6 +11,7 @@ pub struct Navigation {
     pub view_root: TreeIndex,
     pub selected: Option<TreeIndex>,
     pub bookmarks: BTreeMap<TreeIndex, TreeIndex>,
+    /// Real entries exposed by a scoped root or glob search; empty for ordinary tree roots.
     pub matches: Arc<[TreeIndex]>,
 }
 
@@ -38,15 +39,6 @@ impl Navigation {
         self.bookmarks.insert(view_root, previously_selected);
         self.view_root = previously_selected;
         self.selected = Some(new_selected);
-    }
-
-    pub fn exit_node(&mut self, parent_idx: TreeIndex, entries: &[EntryDataBundle]) {
-        self.view_root = parent_idx;
-        self.selected = self
-            .bookmarks
-            .get(&parent_idx)
-            .copied()
-            .or_else(|| entries.first().map(|b| b.index));
     }
 
     pub fn next_index(

--- a/src/interactive/app/state.rs
+++ b/src/interactive/app/state.rs
@@ -7,6 +7,7 @@ use dua::traverse::{BackgroundTraversal, TraversalStats};
 use crate::interactive::widgets::{Column, Language};
 
 use super::{EntryDataBundle, SortMode, input::TerminalFocus, navigation::Navigation};
+use super::{clean_hub::CleanHub, deletion_progress::FilesystemDeletion};
 
 #[derive(Default, Copy, Clone, PartialEq)]
 pub enum FocussedPane {
@@ -28,6 +29,8 @@ pub struct FilesystemScan {
     pub active_traversal: BackgroundTraversal,
     /// The selected item prior to starting the traversal, if available, based on its name or index into [`AppState::entries`].
     pub previous_selection: Option<(PathBuf, usize)>,
+    /// Paths of the normal and active views before refreshing cleanup candidates.
+    pub previous_cleanup_view: Option<(PathBuf, PathBuf)>,
     /// Snapshot destination for the initial scan, if requested.
     pub snapshot_export: Option<(PathBuf, Option<i32>)>,
 }
@@ -63,12 +66,16 @@ pub struct AppState {
     pub received_events: bool,
     /// Active background filesystem traversal, if a scan or refresh is running.
     pub scan: Option<FilesystemScan>,
+    /// The frozen deletion batch, kept alive until all workers have stopped.
+    pub(super) deletion: Option<FilesystemDeletion>,
     /// Latest traversal progress and error counters.
     pub stats: TraversalStats,
     /// Options used when starting filesystem walks.
     pub walk_options: WalkOptions,
     /// The paths used in the initial traversal, at least 1.
     pub root_paths: Vec<PathBuf>,
+    /// Clean discovery hub and the currently open candidate scope.
+    pub clean_hub: Option<CleanHub>,
     /// Filesystem directory completely represented by the traversal root, if one exists.
     ///
     /// `Some(path)` means the root contains the complete, walk-option-filtered contents of
@@ -105,9 +112,11 @@ impl AppState {
             terminal_focus: TerminalFocus::default(),
             received_events: false,
             scan: None,
+            deletion: None,
             stats: TraversalStats::default(),
             walk_options,
             root_paths: input,
+            clean_hub: None,
             root_path,
             allow_entry_check: !read_only,
             read_only,

--- a/src/interactive/app/terminal.rs
+++ b/src/interactive/app/terminal.rs
@@ -7,7 +7,6 @@ use std::{
 #[cfg(unix)]
 use std::io;
 
-use crate::interactive::EntryCheck;
 use anyhow::{Context, Result};
 use crossbeam::channel::Receiver;
 use crossterm::event::Event;
@@ -28,7 +27,7 @@ use tui::{Terminal, backend::Backend};
 
 use crate::interactive::widgets::{Language, MainWindow};
 
-use super::{DisplayOptions, sorted_entries, state::AppState};
+use super::{DisplayOptions, state::AppState};
 
 /// Restores the user's terminal, suspends the process, and reinitializes the TUI after resume.
 ///
@@ -86,7 +85,7 @@ impl TerminalApp {
         input: Vec<PathBuf>,
         root_path: Option<PathBuf>,
         config: Config,
-        traversal: Traversal,
+        mut traversal: Traversal,
         snapshot_load_duration: Option<Duration>,
     ) -> Result<TerminalApp>
     where
@@ -141,16 +140,11 @@ impl TerminalApp {
         }
 
         state.navigation_mut().view_root = traversal.root_index;
-        state.entries = sorted_entries(
-            &traversal.tree,
-            state.navigation().view_root,
+        let tree_view = state.tree_view(&mut traversal);
+        state.entries = tree_view.sorted_entries(
+            tree_view.traversal.root_index,
             state.sorting,
-            state.glob_root(),
-            state
-                .glob_navigation
-                .as_ref()
-                .map(|navigation| navigation.matches.as_ref()),
-            EntryCheck::new(state.scan.is_some(), state.allow_entry_check),
+            state.entry_check(),
         );
         state.navigation_mut().selected = state.entries.first().map(|b| b.index);
 
@@ -176,6 +170,16 @@ impl TerminalApp {
         Ok(())
     }
 
+    pub fn traverse_clean(&mut self, depth: Option<usize>) -> Result<()> {
+        self.state.clean_hub = Some(super::clean_hub::CleanHub::new(
+            self.state.root_paths.clone(),
+            depth,
+        ));
+        self.state.entries.clear();
+        self.state.root_path = None;
+        self.traverse()
+    }
+
     pub fn traverse_and_export(
         &mut self,
         path: PathBuf,
@@ -194,14 +198,18 @@ impl TerminalApp {
     where
         B: Backend,
     {
-        self.state.process_events(
+        let result = self.state.process_events(
             &mut self.window,
             &mut self.traversal,
             &mut self.display,
             terminal,
             events,
             &self.config,
-        )
+        );
+        if result.is_err() {
+            self.state.deletion = None;
+        }
+        result
     }
 
     pub fn process_events_once<B>(
@@ -212,14 +220,18 @@ impl TerminalApp {
     where
         B: Backend,
     {
-        self.state.process_events_once(
+        let result = self.state.process_events_once(
             &mut self.window,
             &mut self.traversal,
             &mut self.display,
             terminal,
             events,
             &self.config,
-        )
+        );
+        if result.is_err() {
+            self.state.deletion = None;
+        }
+        result
     }
 }
 

--- a/src/interactive/app/tests/journeys_clean.rs
+++ b/src/interactive/app/tests/journeys_clean.rs
@@ -1,0 +1,645 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Result;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use tui::{Terminal, backend::TestBackend, buffer::Buffer, layout::Rect};
+
+use super::utils::{into_codes, into_events, into_keys, untraversed_app_and_terminal_with_closure};
+use crate::interactive::{
+    SortMode,
+    app::{clean_hub::CleanHub, state::Cursor},
+    widgets::{COLOR_MARKED, MainWindowProps},
+};
+
+fn hub(app: &crate::TerminalApp) -> &CleanHub {
+    app.state.clean_hub.as_ref().unwrap()
+}
+
+fn entry_names(app: &crate::TerminalApp) -> BTreeSet<PathBuf> {
+    if let Some(hub) = &app.state.clean_hub
+        && hub.root.is_none()
+    {
+        return hub.rows.iter().map(|row| row.entry.name.clone()).collect();
+    }
+    app.state
+        .entries
+        .iter()
+        .map(|entry| entry.name.clone())
+        .collect()
+}
+
+fn select_hub_entry(
+    app: &mut crate::TerminalApp,
+    terminal: &mut Terminal<TestBackend>,
+    path: &Path,
+) -> Result<()> {
+    let position = hub(app)
+        .rows
+        .iter()
+        .position(|row| row.entry.name == path)
+        .unwrap();
+    app.process_events_once(
+        terminal,
+        into_keys(
+            [KeyCode::Home]
+                .into_iter()
+                .chain(std::iter::repeat_n(KeyCode::Down, position)),
+        ),
+    )?;
+    assert_eq!(hub(app).selected_path(), Some(path));
+    Ok(())
+}
+
+#[test]
+fn clean_hub_titles_show_search_inputs_without_changing_browser_titles() -> Result<()> {
+    let fixture = tempfile::tempdir()?;
+    let root = fixture.path().canonicalize()?;
+    let first = root.join("first-search");
+    let second = root.join("second-search");
+    for path in [&first, &second] {
+        fs::create_dir_all(path.join("__pycache__"))?;
+        fs::write(path.join("__pycache__/cache"), b"cache")?;
+    }
+    let title = |terminal: &Terminal<TestBackend>| {
+        let buffer = terminal.backend().buffer();
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, 1)].symbol())
+            .collect::<String>()
+    };
+    for inputs in [vec![first.clone()], vec![first.clone(), second]] {
+        let (_, mut app) = untraversed_app_and_terminal_with_closure(&inputs, Path::to_path_buf)?;
+        let mut terminal = Terminal::new(TestBackend::new(512, 20))?;
+        let cwd = std::env::current_dir()?;
+        assert!(inputs.iter().all(|path| !path.starts_with(&cwd)));
+        app.traverse_clean(None)?;
+        app.process_events_once(&mut terminal, into_events([]))?;
+        let expected = inputs
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let rendered = title(&terminal);
+        assert!(rendered.contains(&format!(" {expected} ")), "{rendered}");
+        assert!(!rendered.contains(&cwd.display().to_string()));
+    }
+
+    let (_, mut app) =
+        untraversed_app_and_terminal_with_closure(std::slice::from_ref(&first), Path::to_path_buf)?;
+    let mut terminal = Terminal::new(TestBackend::new(512, 20))?;
+    app.traverse()?;
+    app.process_events_once(&mut terminal, into_events([]))?;
+    assert!(app.state.clean_hub.is_none());
+    assert!(title(&terminal).contains(&format!(
+        " {} ",
+        std::env::current_dir()?.canonicalize()?.display()
+    )));
+    app.process_events_once(&mut terminal, into_codes("o"))?;
+    assert!(title(&terminal).contains(&format!(" {} ", first.display())));
+    Ok(())
+}
+
+#[test]
+fn clean_groups_siblings_and_marks_only_candidates() -> Result<()> {
+    let fixture = tempfile::tempdir()?;
+    let root = fixture.path().canonicalize()?;
+    gix::init(&root)?;
+    fs::write(root.join(".gitignore"), b".*_cache/\n__pycache__/\n")?;
+    let project = root.join("project");
+    let candidates = [
+        project.join(".mypy_cache"),
+        project.join(".pytest_cache"),
+        project.join("git/__pycache__"),
+        project.join("git/.ruff_cache"),
+        project.join("test/__pycache__"),
+    ];
+    let singleton = root.join("project.v4-breaking/test/__pycache__");
+    for (index, path) in candidates.iter().chain([&singleton]).enumerate() {
+        fs::create_dir_all(path.join("cache"))?;
+        fs::write(path.join("cache/payload"), vec![b'x'; 100 * (index + 1)])?;
+    }
+    fs::write(singleton.join("cache/payload"), vec![b'x'; 10_000])?;
+    fs::write(project.join("source.py"), b"keep this source")?;
+    let (mut terminal, mut app) =
+        untraversed_app_and_terminal_with_closure(std::slice::from_ref(&root), Path::to_path_buf)?;
+    app.traverse_clean(None)?;
+    app.process_events_once(&mut terminal, into_events([]))?;
+
+    assert!(hub(&app).root.is_none());
+    assert!(app.state.entries.is_empty(), "the hub owns its rows");
+    assert_eq!(hub(&app).rows.len(), 2, "siblings share a hub row");
+    assert_eq!(
+        app.traversal
+            .tree
+            .children(app.traversal.root_index)
+            .count(),
+        6
+    );
+    let group = hub(&app)
+        .rows
+        .iter()
+        .find(|row| row.entry.name == project)
+        .unwrap();
+    let members = &group.members;
+    assert_eq!(members.len(), 5);
+    assert_eq!(
+        group.entry.size,
+        members
+            .iter()
+            .map(|index| app.traversal.tree.data(*index).unwrap().size)
+            .sum::<u128>()
+    );
+    let order = hub(&app)
+        .rows
+        .iter()
+        .map(|row| row.entry.name.clone())
+        .collect::<Vec<_>>();
+    app.process_events_once(&mut terminal, into_codes("smnc/"))?;
+    assert_eq!(app.state.sorting, SortMode::SizeDescending);
+    assert_eq!(
+        hub(&app)
+            .rows
+            .iter()
+            .map(|row| row.entry.name.clone())
+            .collect::<Vec<_>>(),
+        order,
+        "ordinary sorting keys do not reorder hub rows"
+    );
+    assert!(app.window.glob.is_none(), "the hub has no search");
+    select_hub_entry(&mut app, &mut terminal, &project)?;
+    app.process_events_once(&mut terminal, into_codes(" "))?;
+    let marked_paths = |app: &crate::TerminalApp| {
+        app.window
+            .mark
+            .as_ref()
+            .unwrap()
+            .marked()
+            .values()
+            .map(|entry| entry.path.clone())
+            .collect::<BTreeSet<_>>()
+    };
+    assert_eq!(marked_paths(&app), BTreeSet::from(candidates.clone()));
+    // Render before the terminal's NO_COLOR postprocessing.
+    let group_color = |app: &mut crate::TerminalApp| {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 512, 20));
+        let props = MainWindowProps {
+            current_path: hub(app).title(),
+            entries_traversed: app.state.stats.entries_traversed,
+            total_bytes: app.state.stats.total_bytes.unwrap_or_default(),
+            start: app.state.stats.start,
+            elapsed: app.state.stats.elapsed,
+            display: app.display,
+            state: &app.state,
+            config: &app.config,
+        };
+        app.window
+            .render(props, buffer.area, &mut buffer, &mut Cursor::default());
+        let y = 2 + hub(app)
+            .rows
+            .iter()
+            .position(|row| row.entry.name == project)
+            .expect("group row") as u16;
+        let x = (1..256)
+            .find(|&x| buffer[(x, y)].symbol() == "/")
+            .expect("group path");
+        buffer[(x, y)].fg
+    };
+    assert_eq!(group_color(&mut app), COLOR_MARKED);
+    app.process_events_once(&mut terminal, into_codes(" "))?;
+    assert!(
+        app.window.mark.is_none(),
+        "a fully marked group toggles off"
+    );
+
+    app.process_events_once(&mut terminal, into_codes("o"))?;
+    assert_eq!(hub(&app).root, Some(app.state.navigation.tree_root));
+    assert_ne!(app.state.navigation.tree_root, app.traversal.root_index);
+    assert_eq!(
+        entry_names(&app),
+        candidates
+            .iter()
+            .map(|path| path.strip_prefix(&project).unwrap().to_owned())
+            .collect(),
+        "a group lists its five real candidates directly"
+    );
+    assert_eq!(
+        app.state.gitignored_entries,
+        Some(app.state.entries.iter().map(|entry| entry.index).collect())
+    );
+    app.process_events_once(&mut terminal, into_codes("n/__pycache__"))?;
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Enter]))?;
+    assert_eq!(app.state.sorting, SortMode::NameAscending);
+    assert!(app.state.glob_navigation.is_some());
+    assert_eq!(
+        entry_names(&app),
+        BTreeSet::from([candidates[2].clone(), candidates[4].clone()])
+    );
+    app.process_events_once(&mut terminal, into_codes("oR"))?;
+    assert_eq!(entry_names(&app), BTreeSet::from([PathBuf::from("cache")]));
+    app.process_events_once(&mut terminal, into_codes("u"))?;
+    assert_eq!(
+        entry_names(&app),
+        BTreeSet::from([candidates[2].clone(), candidates[4].clone()])
+    );
+    app.process_events_once(&mut terminal, into_codes("q"))?;
+    assert!(app.state.glob_navigation.is_none());
+    assert_eq!(hub(&app).root, Some(app.state.navigation.tree_root));
+    let selected = app
+        .state
+        .entries
+        .iter()
+        .find(|entry| entry.name == Path::new(".mypy_cache"))
+        .unwrap()
+        .index;
+    app.state.navigation.select(Some(selected));
+    app.process_events_once(&mut terminal, into_codes("o/cache"))?;
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Enter]))?;
+    app.process_events_once(&mut terminal, into_codes("oR"))?;
+    app.process_events_once(&mut terminal, into_codes("u"))?;
+    assert_eq!(
+        entry_names(&app),
+        BTreeSet::from([candidates[0].join("cache")])
+    );
+    app.process_events_once(&mut terminal, into_codes("qu"))?;
+    app.process_events_once(&mut terminal, into_codes(" u"))?;
+    assert!(hub(&app).root.is_none());
+    assert_eq!(
+        app.state.message, None,
+        "hub clears browser annotation counts"
+    );
+    assert_eq!(app.window.mark.as_ref().unwrap().marked().len(), 1);
+    assert_ne!(group_color(&mut app), COLOR_MARKED);
+    app.process_events_once(&mut terminal, into_codes(" "))?;
+    assert_eq!(
+        marked_paths(&app),
+        BTreeSet::from(candidates.clone()),
+        "partial marks are completed, not inverted"
+    );
+    app.process_events_once(&mut terminal, into_codes(" "))?;
+    let delete = [
+        Event::Key(KeyCode::Tab.into()),
+        Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+    ];
+    for remaining in (1..candidates.len()).rev() {
+        // Keep the direct siblings until last so their group persists down to one survivor.
+        let target = hub(&app)
+            .selected_members()
+            .iter()
+            .copied()
+            .find(|&index| app.traversal.tree.path_of(index) == candidates[remaining])
+            .unwrap();
+        app.process_events_once(&mut terminal, into_codes("o"))?;
+        app.state.navigation.select(Some(target));
+        if remaining == candidates.len() - 1 {
+            app.process_events_once(&mut terminal, into_codes(" /*"))?;
+            app.process_events_once(&mut terminal, into_keys([KeyCode::Enter]))?;
+            app.state.navigation_mut().select(Some(target));
+            app.process_events_once(&mut terminal, into_codes("o"))?;
+        } else {
+            app.process_events_once(&mut terminal, into_codes(" u"))?;
+        }
+        app.process_events_once(&mut terminal, into_events(delete.clone()))?;
+        if let Some(glob) = &app.state.glob_navigation {
+            assert_eq!(
+                glob.view_root, glob.tree_root,
+                "deleting a viewed match returns to the scoped results"
+            );
+            assert_eq!(app.state.entries.len(), remaining);
+            app.process_events_once(&mut terminal, into_codes("qu"))?;
+        }
+        let selected = hub(&app)
+            .rows
+            .iter()
+            .find(|row| Some(row.entry.name.as_path()) == hub(&app).selected_path())
+            .unwrap();
+        assert!(
+            selected.entry.name.starts_with(&project),
+            "selection follows the group and its final survivor"
+        );
+        assert_eq!(selected.members.len(), remaining);
+        assert_eq!(
+            selected
+                .members
+                .iter()
+                .map(|&index| app.traversal.tree.path_of(index))
+                .collect::<BTreeSet<_>>(),
+            candidates[..remaining].iter().cloned().collect()
+        );
+        assert!(
+            hub(&app).rows.iter().any(|row| row.entry.name == singleton),
+            "the unrelated row stays visible"
+        );
+    }
+    app.process_events_once(&mut terminal, into_codes(" "))?;
+    app.process_events_once(&mut terminal, into_events(delete))?;
+    assert!(project.is_dir());
+    assert_eq!(fs::read(project.join("source.py"))?, b"keep this source");
+    assert!(candidates.iter().all(|path| !path.exists()));
+    assert!(singleton.is_dir());
+    assert_eq!(hub(&app).rows.len(), 1, "empty groups disappear");
+    assert_eq!(hub(&app).rows[0].entry.name, singleton);
+    Ok(())
+}
+
+#[test]
+fn clean_group_refresh_revalidates_members_without_widening_scope() -> Result<()> {
+    let fixture = tempfile::tempdir()?;
+    let root = fixture.path().canonicalize()?;
+    let project = root.join("project");
+    let kept = project.join(".mypy_cache");
+    let rejected = project.join(".pytest_cache");
+    for path in [&kept, &rejected] {
+        fs::create_dir_all(path)?;
+        fs::write(path.join("cache"), b"cache")?;
+    }
+    fs::write(project.join("source.py"), b"source")?;
+    let ignore = root.join("ignore");
+    fs::write(&ignore, b"/project/.pytest_cache/excluded\n")?;
+    let (mut terminal, mut app) = untraversed_app_and_terminal_with_closure(
+        &[root.clone(), project.clone()],
+        Path::to_path_buf,
+    )?;
+    app.state.walk_options.ignore_patterns = dua::IgnorePatterns::from_files(&[ignore])?;
+    app.traverse_clean(None)?;
+    app.process_events_once(&mut terminal, into_events([]))?;
+    assert_eq!(hub(&app).rows.len(), 1);
+    assert_eq!(hub(&app).rows[0].entry.name, project);
+
+    fs::write(rejected.join("excluded"), b"keep")?;
+    let added = project.join(".ruff_cache");
+    fs::create_dir(&added)?;
+    fs::write(added.join("cache"), b"new")?;
+    app.process_events_once(&mut terminal, into_codes("xr"))?;
+    assert!(app.window.mark.is_none(), "refresh clears stale marks");
+    assert_eq!(hub(&app).rows.len(), 1);
+    assert_eq!(
+        hub(&app).rows[0].entry.name,
+        kept,
+        "a singleton is flattened"
+    );
+    assert_eq!(hub(&app).inputs, [root, project.clone()]);
+
+    app.process_events_once(&mut terminal, into_codes("R"))?;
+    assert_eq!(hub(&app).rows.len(), 1);
+    assert_eq!(hub(&app).rows[0].entry.name, project);
+    app.process_events_once(&mut terminal, into_codes("oR"))?;
+    assert_eq!(
+        entry_names(&app),
+        BTreeSet::from([
+            Path::new(".mypy_cache").to_owned(),
+            Path::new(".ruff_cache").to_owned()
+        ]),
+    );
+    assert_eq!(fs::read(project.join("source.py"))?, b"source");
+    assert!(rejected.is_dir());
+    fs::write(added.join(".git"), b"gitdir: elsewhere")?;
+    app.process_events_once(&mut terminal, into_codes("/.ruff_cache"))?;
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Enter]))?;
+    app.process_events_once(&mut terminal, into_codes("oR"))?;
+    assert!(
+        app.state.entries.is_empty(),
+        "rejected glob roots leave no stale view"
+    );
+    app.process_events_once(&mut terminal, into_codes("q"))?;
+    assert_eq!(
+        entry_names(&app),
+        BTreeSet::from([PathBuf::from(".mypy_cache")])
+    );
+    Ok(())
+}
+
+#[test]
+fn clean_publishes_sized_candidates_and_refreshes_the_original_scope() -> Result<()> {
+    let fixture = tempfile::tempdir()?;
+    let root = fixture.path().canonicalize()?;
+    let candidate = root.join("project/node_modules");
+    fs::create_dir_all(candidate.join("__pycache__"))?;
+    fs::write(candidate.join("data"), b"payload")?;
+    fs::write(root.join("source"), b"keep")?;
+    let expected_size = u128::from(candidate.metadata()?.len())
+        + u128::from(candidate.join("__pycache__").metadata()?.len())
+        + 7;
+
+    let (mut terminal, mut app) =
+        untraversed_app_and_terminal_with_closure(std::slice::from_ref(&root), Path::to_path_buf)?;
+    app.traverse_clean(None)?;
+    let (_keep_alive, events) = crossbeam::channel::bounded(0);
+    while app.state.scan.is_some() {
+        app.state.process_event(
+            &mut app.window,
+            &mut app.traversal,
+            &mut app.display,
+            &mut terminal,
+            &events,
+            &app.config,
+        )?;
+        for index in app.traversal.tree.children(app.traversal.root_index) {
+            assert_eq!(
+                app.traversal.tree.name(index).as_deref(),
+                Some(candidate.as_path())
+            );
+            assert_eq!(app.traversal.tree.data(index).unwrap().size, expected_size);
+        }
+    }
+    assert_eq!(hub(&app).rows.len(), 1);
+    assert_eq!(hub(&app).rows[0].entry.name, candidate);
+    assert_eq!(hub(&app).inputs, std::slice::from_ref(&root));
+    assert!(app.state.root_path.is_none());
+
+    app.process_events_once(&mut terminal, into_codes("U"))?;
+    assert_eq!(hub(&app).rows.len(), 1, "parent scanning stays disabled");
+    assert_eq!(hub(&app).inputs, std::slice::from_ref(&root));
+    app.process_events_once(&mut terminal, into_codes("our"))?;
+    assert_eq!(
+        hub(&app).rows[0].entry.name,
+        candidate,
+        "refresh keeps the full root path"
+    );
+
+    let second = root.join("another/__pycache__");
+    fs::create_dir_all(&second)?;
+    fs::write(second.join("cache"), b"new")?;
+    app.process_events_once(&mut terminal, into_codes("xR"))?;
+    assert!(
+        app.window.mark.is_none(),
+        "refresh discards marks with recycled node indices"
+    );
+    assert_eq!(
+        entry_names(&app),
+        BTreeSet::from([candidate.clone(), second.clone()]),
+    );
+    assert_eq!(hub(&app).inputs, std::slice::from_ref(&root));
+
+    select_hub_entry(&mut app, &mut terminal, &candidate)?;
+    app.process_events_once(
+        &mut terminal,
+        into_events([
+            Event::Key(KeyCode::Char('x').into()),
+            Event::Key(KeyCode::Tab.into()),
+            Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+        ]),
+    )?;
+    assert!(!candidate.exists());
+    assert!(second.exists());
+    assert_eq!(fs::read(root.join("source"))?, b"keep");
+    Ok(())
+}
+
+#[test]
+fn clean_refresh_handles_empty_results_depth_zero_and_rejected_candidates() -> Result<()> {
+    let fixture = tempfile::tempdir()?;
+    let root = fixture.path().canonicalize()?;
+    let (mut terminal, mut app) =
+        untraversed_app_and_terminal_with_closure(std::slice::from_ref(&root), Path::to_path_buf)?;
+    app.traverse_clean(Some(1))?;
+    app.process_events_once(&mut terminal, into_events([]))?;
+    assert!(hub(&app).is_empty());
+    assert_eq!(
+        app.state.message.as_deref(),
+        Some(app.state.language.ui_text().no_cleanup_candidates)
+    );
+
+    let candidate = root.join("node_modules");
+    fs::create_dir(&candidate)?;
+    fs::write(candidate.join("data"), b"cache")?;
+    app.process_events_once(&mut terminal, into_codes("R"))?;
+    assert_eq!(hub(&app).rows.len(), 1);
+
+    let (mut direct_terminal, mut direct_app) = untraversed_app_and_terminal_with_closure(
+        std::slice::from_ref(&candidate),
+        Path::to_path_buf,
+    )?;
+    direct_app.traverse_clean(Some(0))?;
+    direct_app.process_events_once(&mut direct_terminal, into_events([]))?;
+    assert_eq!(hub(&direct_app).rows[0].entry.name, candidate);
+
+    fs::write(candidate.join(".git"), b"gitdir: elsewhere")?;
+    app.process_events_once(&mut terminal, into_codes("xr"))?;
+    assert!(
+        hub(&app).is_empty(),
+        "selected refresh revalidates the candidate"
+    );
+    assert!(app.window.mark.is_none());
+    assert!(hub(&app).selected_path().is_none());
+    assert_eq!(hub(&app).inputs, std::slice::from_ref(&root));
+
+    fs::create_dir(root.join("__pycache__"))?;
+    app.process_events_once(&mut terminal, into_codes("R"))?;
+    assert_eq!(hub(&app).rows.len(), 1);
+    assert_eq!(hub(&app).rows[0].entry.name, root.join("__pycache__"));
+    Ok(())
+}
+
+#[test]
+fn clean_refresh_revalidates_the_owner_from_inside_a_candidate() -> Result<()> {
+    for enter in ["o", "oo"] {
+        for refresh in ["r", "R"] {
+            let fixture = tempfile::tempdir()?;
+            let root = fixture.path().canonicalize()?;
+            let candidate = root.join("project/node_modules");
+            fs::create_dir_all(candidate.join("nested"))?;
+            fs::write(candidate.join("nested/cache"), b"cache")?;
+            let (mut terminal, mut app) = untraversed_app_and_terminal_with_closure(
+                std::slice::from_ref(&root),
+                Path::to_path_buf,
+            )?;
+            app.traverse_clean(Some(2))?;
+            app.process_events_once(&mut terminal, into_codes(enter))?;
+            let view_path = crate::interactive::path_of(
+                &app.traversal.tree,
+                app.state.navigation.view_root,
+                None,
+            );
+
+            app.process_events_once(&mut terminal, into_codes(refresh))?;
+            assert_eq!(
+                crate::interactive::path_of(
+                    &app.traversal.tree,
+                    app.state.navigation.view_root,
+                    None,
+                ),
+                view_path,
+                "a safe {enter}/{refresh} refresh restores the current directory"
+            );
+
+            // This lies outside the selected subtree when the view is inside `nested`.
+            fs::create_dir(candidate.join(".git"))?;
+            app.process_events_once(&mut terminal, into_codes("x"))?;
+            app.process_events_once(&mut terminal, into_codes(refresh))?;
+            assert!(
+                app.traversal.clean_search_roots.is_empty(),
+                "{enter}/{refresh} must reject the entire candidate"
+            );
+            assert!(app.state.entries.is_empty());
+            assert!(app.window.mark.is_none());
+            assert_eq!(fs::read(candidate.join("nested/cache"))?, b"cache");
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn clean_selected_refresh_preserves_ignore_pattern_roots() -> Result<()> {
+    let fixture = tempfile::tempdir()?;
+    let root = fixture.path().canonicalize()?;
+    let candidate = root.join("project/node_modules");
+    fs::create_dir_all(&candidate)?;
+    fs::write(candidate.join("kept"), b"cache")?;
+    let ignore = root.join("ignore");
+    fs::write(&ignore, b"/project/node_modules/excluded\n")?;
+    let (mut terminal, mut app) =
+        untraversed_app_and_terminal_with_closure(std::slice::from_ref(&root), Path::to_path_buf)?;
+    app.state.walk_options.ignore_patterns = dua::IgnorePatterns::from_files(&[ignore])?;
+    app.traverse_clean(None)?;
+    app.process_events_once(&mut terminal, into_events([]))?;
+    assert_eq!(hub(&app).rows.len(), 1);
+    fs::write(candidate.join("excluded"), b"ignored")?;
+    app.process_events_once(&mut terminal, into_codes("r"))?;
+    assert!(
+        hub(&app).is_empty(),
+        "refresh vetoes excluded descendants using the original pattern root"
+    );
+    Ok(())
+}
+
+#[test]
+fn clean_refresh_preserves_discovery_roots_with_overlapping_inputs() -> Result<()> {
+    for (depth, artifact, pattern) in [
+        (None, "project/node_modules", "/node_modules/\n"),
+        (Some(2), "project/node_modules", "/node_modules/\n"),
+        (Some(1), "project/__pycache__", "/project/__pycache__/\n"),
+    ] {
+        let fixture = tempfile::tempdir()?;
+        let root = fixture.path().canonicalize()?;
+        let candidate = root.join(artifact);
+        fs::create_dir_all(&candidate)?;
+        fs::write(candidate.join("kept"), b"cache")?;
+        let ignore = root.join("ignore");
+        fs::write(&ignore, pattern)?;
+        let (mut terminal, mut app) = untraversed_app_and_terminal_with_closure(
+            &[root.clone(), root.join("project")],
+            Path::to_path_buf,
+        )?;
+        app.state.walk_options.ignore_patterns = dua::IgnorePatterns::from_files(&[ignore])?;
+        app.traverse_clean(depth)?;
+        app.process_events_once(&mut terminal, into_events([]))?;
+        assert_eq!(hub(&app).rows.len(), 1, "initial discovery at {depth:?}");
+        for key in ["r", "R", "r"] {
+            app.process_events_once(&mut terminal, into_codes(key))?;
+            assert_eq!(hub(&app).rows.len(), 1, "{key} refresh at {depth:?}");
+            assert_eq!(hub(&app).rows[0].entry.name, candidate);
+        }
+        app.process_events_once(&mut terminal, into_codes("o"))?;
+        app.process_events_once(&mut terminal, into_codes("R"))?;
+        assert_eq!(
+            app.state.entries.len(),
+            1,
+            "refresh inside candidate at {depth:?}"
+        );
+        assert_eq!(app.state.entries[0].name, Path::new("kept"));
+    }
+    Ok(())
+}

--- a/src/interactive/app/tests/journeys_deletion.rs
+++ b/src/interactive/app/tests/journeys_deletion.rs
@@ -1,0 +1,376 @@
+use std::{fs, sync::atomic::Ordering, time::Instant};
+
+use anyhow::Result;
+use crossbeam::channel::{Receiver, Sender, never, unbounded};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use dua::{WalkResult, traverse::TreeIndex};
+use tempfile::TempDir;
+use tui::{Terminal, backend::TestBackend};
+
+use super::utils::{
+    index_by_name, initialized_app_and_terminal_from_paths, into_codes, into_events,
+};
+use crate::interactive::app::{
+    deletion::DeletionEvent, deletion_progress::FilesystemDeletion, state::FocussedPane,
+    terminal::TerminalApp,
+};
+
+fn prepared() -> Result<(TempDir, Terminal<TestBackend>, TerminalApp)> {
+    let fixture = TempDir::new()?;
+    fs::create_dir(fixture.path().join("delete"))?;
+    fs::write(fixture.path().join("delete/remove.bin"), [0; 64])?;
+    fs::write(fixture.path().join("delete/zero.bin"), [])?;
+    fs::create_dir(fixture.path().join("keep"))?;
+    fs::write(fixture.path().join("keep/keep.bin"), [0; 32])?;
+    let (mut terminal, mut app) =
+        initialized_app_and_terminal_from_paths(&[fixture.path().canonicalize()?])?;
+    app.process_events_once(&mut terminal, into_codes("o"))?;
+    let target = index_by_name(&app, "delete");
+    app.state.navigation.select(Some(target));
+    app.process_events_once(&mut terminal, into_codes(" "))?;
+    assert!(
+        app.window
+            .mark
+            .as_ref()
+            .unwrap()
+            .marked()
+            .contains_key(&target)
+    );
+    Ok((fixture, terminal, app))
+}
+
+fn inject(app: &mut TerminalApp, target: TreeIndex) -> (Sender<DeletionEvent>, Sender<Instant>) {
+    let (send, events) = unbounded();
+    let (tick, ticks) = unbounded();
+    let tree = app.state.tree_view(&mut app.traversal);
+    let mut deletion = FilesystemDeletion::for_test(&tree, vec![target], events);
+    deletion.tick = ticks;
+    app.state.deletion = Some(deletion);
+    app.state.reset_message();
+    (send, tick)
+}
+
+fn step(
+    app: &mut TerminalApp,
+    terminal: &mut Terminal<TestBackend>,
+    input: &Receiver<Event>,
+) -> Result<Option<WalkResult>> {
+    app.state.process_event(
+        &mut app.window,
+        &mut app.traversal,
+        &mut app.display,
+        terminal,
+        input,
+        &app.config,
+    )
+}
+
+fn key(app: &mut TerminalApp, terminal: &mut Terminal<TestBackend>, key: KeyEvent) -> Result<()> {
+    assert!(step(app, terminal, &into_events([Event::Key(key)]))?.is_none());
+    Ok(())
+}
+
+#[test]
+fn deletion_ticks_update_remaining_bytes_without_input_and_keep_failed_marks() -> Result<()> {
+    let (fixture, mut terminal, mut app) = prepared()?;
+    let target = index_by_name(&app, "delete");
+    let file = index_by_name(&app, "remove.bin");
+    let zero = index_by_name(&app, "zero.bin");
+    // Give the directory itself a known size on every platform. Removing its files must
+    // preserve these bytes, including when a hardlink/APFS-deduplicated entry has size zero.
+    let scanned = app.traversal.tree.data(target).unwrap().size;
+    let mut ancestor = Some(target);
+    while let Some(index) = ancestor {
+        app.traversal
+            .tree
+            .update(index, |entry| entry.size = entry.size - scanned + 81);
+        ancestor = app.traversal.tree.parent(index);
+    }
+    app.state.stats.total_bytes = app.state.stats.total_bytes.map(|size| size - scanned + 81);
+    let tree = app.state.tree_view(&mut app.traversal);
+    app.window.mark.as_mut().unwrap().reconcile(&tree);
+    let total = tree.total_size();
+    let count = tree.tree().data(target).unwrap().entry_count.unwrap();
+    let (send, tick) = inject(&mut app, target);
+    let no_input = never();
+    let before = terminal.backend().buffer().clone();
+
+    fs::remove_file(fixture.path().join("delete/remove.bin"))?;
+    send.send(DeletionEvent::Removed {
+        target: 0,
+        path: fixture.path().canonicalize()?.join("delete/remove.bin"),
+    })?;
+    assert!(step(&mut app, &mut terminal, &no_input)?.is_none());
+    assert!(
+        app.traversal.tree.contains(file),
+        "results wait for a redraw batch"
+    );
+    tick.send(Instant::now())?;
+    assert!(step(&mut app, &mut terminal, &no_input)?.is_none());
+    assert!(!app.traversal.tree.contains(file));
+    assert_eq!(app.traversal.tree.data(target).unwrap().size, 17);
+    assert_eq!(app.window.mark.as_ref().unwrap().total_size(), 17);
+    assert_eq!(app.state.stats.total_bytes, Some(total - 64));
+    assert!(app.state.message.as_ref().unwrap().contains("remaining"));
+    assert_ne!(terminal.backend().buffer(), &before);
+    assert!(app.state.is_deleting());
+
+    fs::remove_file(fixture.path().join("delete/zero.bin"))?;
+    send.send(DeletionEvent::Removed {
+        target: 0,
+        path: fixture.path().canonicalize()?.join("delete/zero.bin"),
+    })?;
+    step(&mut app, &mut terminal, &no_input)?;
+    tick.send(Instant::now())?;
+    step(&mut app, &mut terminal, &no_input)?;
+    assert!(!app.traversal.tree.contains(zero));
+    assert_eq!(app.traversal.tree.data(target).unwrap().size, 17);
+    assert_eq!(
+        app.traversal.tree.data(target).unwrap().entry_count,
+        Some(count - 2)
+    );
+
+    send.send(DeletionEvent::TargetFinished {
+        target: 0,
+        errors: 1,
+    })?;
+    send.send(DeletionEvent::Finished {
+        entries: 2,
+        errors: 1,
+        cancelled: false,
+    })?;
+    assert!(step(&mut app, &mut terminal, &no_input)?.is_none());
+    assert!(!app.state.is_deleting());
+    let pane = app.window.mark.as_ref().unwrap();
+    assert_eq!(pane.total_size(), 17);
+    assert_eq!(pane.marked()[&target].num_errors_during_deletion, 1);
+    key(&mut app, &mut terminal, KeyCode::Char(' ').into())?;
+    assert!(
+        app.window.mark.is_none(),
+        "completion releases the mutation lock"
+    );
+    Ok(())
+}
+
+#[test]
+fn deletion_allows_navigation_and_pane_controls_but_blocks_changes() -> Result<()> {
+    let (_fixture, mut terminal, mut app) = prepared()?;
+    let target = index_by_name(&app, "delete");
+    let root = app.state.navigation.view_root;
+    let nodes = app.traversal.tree.len();
+    let (_send, _tick) = inject(&mut app, target);
+    let cancel = app.state.deletion.as_ref().unwrap().task.cancel.clone();
+
+    key(&mut app, &mut terminal, KeyCode::Char('o').into())?;
+    assert_eq!(app.state.navigation.view_root, target);
+    key(&mut app, &mut terminal, KeyCode::Char('j').into())?;
+    assert!(app.state.navigation.selected.is_some());
+    key(&mut app, &mut terminal, KeyCode::Char('u').into())?;
+    assert_eq!(app.state.navigation.view_root, root);
+    for action in [' ', 'x', 'd', 'a', 'X', 'I', 'r', 'R', 'U'] {
+        key(&mut app, &mut terminal, KeyCode::Char(action).into())?;
+        assert!(app.state.scan.is_none());
+        assert_eq!(app.traversal.tree.len(), nodes);
+        assert_eq!(
+            app.window
+                .mark
+                .as_ref()
+                .unwrap()
+                .marked()
+                .keys()
+                .copied()
+                .collect::<Vec<_>>(),
+            [target]
+        );
+        assert_eq!(
+            app.state.message.as_deref(),
+            Some(app.state.language.ui_text().deletion_running)
+        );
+    }
+    key(&mut app, &mut terminal, KeyCode::Tab.into())?;
+    assert!(app.state.focussed == FocussedPane::Mark);
+    for action in [
+        KeyCode::Char('x').into(),
+        KeyCode::Char('a').into(),
+        KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+        KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+    ] {
+        key(&mut app, &mut terminal, action)?;
+        assert_eq!(app.window.mark.as_ref().unwrap().marked().len(), 1);
+    }
+    key(&mut app, &mut terminal, KeyCode::Esc.into())?;
+    assert!(app.state.focussed == FocussedPane::Main);
+    key(&mut app, &mut terminal, KeyCode::Char('?').into())?;
+    assert!(app.window.help.is_some());
+    key(&mut app, &mut terminal, KeyCode::Esc.into())?;
+    assert!(app.window.help.is_none());
+    key(&mut app, &mut terminal, KeyCode::Char(']').into())?;
+    assert!(app.window.right_panes_minimized);
+    key(&mut app, &mut terminal, KeyCode::Char('n').into())?;
+    assert!(
+        !cancel.load(Ordering::Relaxed),
+        "closing panes does not cancel deletion"
+    );
+    assert!(app.state.is_deleting());
+    Ok(())
+}
+
+#[test]
+fn deleting_the_view_repairs_normal_and_glob_navigation_without_double_counting() -> Result<()> {
+    for glob in [false, true] {
+        let (fixture, mut terminal, mut app) = prepared()?;
+        let target = index_by_name(&app, "delete");
+        let file = index_by_name(&app, "remove.bin");
+        let total = app.state.stats.total_bytes.unwrap();
+        let size = app.traversal.tree.data(target).unwrap().size;
+        let (send, tick) = inject(&mut app, target);
+        if glob {
+            for action in "/delete".chars() {
+                key(&mut app, &mut terminal, KeyCode::Char(action).into())?;
+            }
+            key(&mut app, &mut terminal, KeyCode::Enter.into())?;
+            assert!(app.state.glob_navigation.is_some());
+        }
+        key(&mut app, &mut terminal, KeyCode::Char('o').into())?;
+        assert_eq!(app.state.navigation().view_root, target);
+
+        let path = fixture.path().canonicalize()?.join("delete");
+        fs::remove_dir_all(&path)?;
+        send.send(DeletionEvent::Removed {
+            target: 0,
+            path: path.join("remove.bin"),
+        })?;
+        send.send(DeletionEvent::Removed { target: 0, path })?;
+        step(&mut app, &mut terminal, &never())?;
+        tick.send(Instant::now())?;
+        step(&mut app, &mut terminal, &never())?;
+        assert!(!app.traversal.tree.contains(target));
+        assert!(!app.traversal.tree.contains(file));
+        assert_eq!(app.state.stats.total_bytes, Some(total - size));
+        assert!(app.window.mark.is_none());
+        assert!(
+            app.traversal
+                .tree
+                .contains(app.state.navigation().view_root)
+        );
+        assert!(
+            app.state
+                .entries
+                .iter()
+                .all(|entry| app.traversal.tree.contains(entry.index))
+        );
+        if let Some(navigation) = &app.state.glob_navigation {
+            assert_eq!(navigation.view_root, navigation.tree_root);
+            assert!(navigation.matches.is_empty());
+            assert!(app.state.entries.is_empty());
+            assert!(!navigation.bookmarks.contains_key(&target));
+        }
+        assert!(
+            app.state.is_deleting(),
+            "a removed root does not end the worker batch"
+        );
+        send.send(DeletionEvent::Finished {
+            entries: 3,
+            errors: 0,
+            cancelled: false,
+        })?;
+        assert!(step(&mut app, &mut terminal, &never())?.is_none());
+        assert!(!app.state.is_deleting());
+    }
+    Ok(())
+}
+
+#[test]
+fn quit_cancels_pending_deletion_and_waits_for_inflight_results() -> Result<()> {
+    let (fixture, mut terminal, mut app) = prepared()?;
+    let target = index_by_name(&app, "delete");
+    let file = index_by_name(&app, "remove.bin");
+    let (send, _tick) = inject(&mut app, target);
+    let quit = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+    key(&mut app, &mut terminal, quit)?;
+    assert!(
+        app.state
+            .deletion
+            .as_ref()
+            .unwrap()
+            .task
+            .cancel
+            .load(Ordering::Relaxed)
+    );
+    assert_eq!(
+        app.state.message.as_deref(),
+        Some(app.state.language.ui_text().cancelling_deletion)
+    );
+
+    fs::remove_file(fixture.path().join("delete/remove.bin"))?;
+    send.send(DeletionEvent::Removed {
+        target: 0,
+        path: fixture.path().canonicalize()?.join("delete/remove.bin"),
+    })?;
+    step(&mut app, &mut terminal, &never())?;
+    key(&mut app, &mut terminal, quit)?;
+    assert!(
+        app.state.is_deleting(),
+        "repeated quit still waits for the worker"
+    );
+    assert!(
+        !app.traversal.tree.contains(file),
+        "in-flight successes are retained"
+    );
+    send.send(DeletionEvent::Finished {
+        entries: 1,
+        errors: 0,
+        cancelled: true,
+    })?;
+    assert!(step(&mut app, &mut terminal, &never())?.is_some());
+    assert!(!app.state.is_deleting());
+    assert!(fixture.path().join("delete/zero.bin").exists());
+    Ok(())
+}
+
+#[test]
+fn exhausted_input_drains_deletion_without_cancelling() -> Result<()> {
+    let (fixture, mut terminal, mut app) = prepared()?;
+    let target = index_by_name(&app, "delete");
+    let file = index_by_name(&app, "remove.bin");
+    let (send, _tick) = inject(&mut app, target);
+    let input = into_events([]);
+    assert!(step(&mut app, &mut terminal, &input)?.is_none());
+    let deletion = app.state.deletion.as_ref().unwrap();
+    assert!(deletion.input_closed);
+    assert!(!deletion.task.cancel.load(Ordering::Relaxed));
+    fs::remove_file(fixture.path().join("delete/remove.bin"))?;
+    send.send(DeletionEvent::Removed {
+        target: 0,
+        path: fixture.path().canonicalize()?.join("delete/remove.bin"),
+    })?;
+    send.send(DeletionEvent::Finished {
+        entries: 1,
+        errors: 0,
+        cancelled: false,
+    })?;
+    assert!(step(&mut app, &mut terminal, &input)?.is_some());
+    assert!(!app.state.is_deleting());
+    assert!(!app.traversal.tree.contains(file));
+    Ok(())
+}
+
+#[test]
+fn event_loop_errors_stop_deletion_before_the_app_can_be_leaked() -> Result<()> {
+    for once in [false, true] {
+        let (_fixture, mut terminal, mut app) = prepared()?;
+        let target = index_by_name(&app, "delete");
+        let (send, _tick) = inject(&mut app, target);
+        let cancel = app.state.deletion.as_ref().unwrap().task.cancel.clone();
+        drop(send);
+        let result = if once {
+            app.process_events_once(&mut terminal, never())
+        } else {
+            app.process_events(&mut terminal, never())
+        };
+        assert!(result.is_err());
+        assert!(cancel.load(Ordering::Relaxed));
+        assert!(!app.state.is_deleting());
+    }
+    Ok(())
+}

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -728,6 +728,66 @@ fn once_finishes_traversal_without_user_events() -> Result<()> {
 }
 
 #[test]
+fn scanning_redraws_while_waiting_for_filesystem_events() -> Result<()> {
+    let (mut terminal, mut app) = untraversed_app_and_terminal_from_fixture(&["sample-01"])?;
+    app.traverse()?;
+    let (_scan_sender, scan_receiver) = crossbeam::channel::bounded(0);
+    let active = &mut app.state.scan.as_mut().unwrap().active_traversal;
+    active.event_rx = scan_receiver;
+    active.stats.entries_traversed = 42;
+    let visible = app.traversal.tree.add_child(
+        app.traversal.root_index,
+        "visible",
+        dua::traverse::EntryData {
+            size: 42,
+            ..Default::default()
+        },
+    );
+    let before = terminal.backend().buffer().clone();
+
+    // A focus event does not redraw; it only lets a broken event loop fail instead of hanging.
+    let (wake, events) = crossbeam::channel::bounded(0);
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(5));
+        let _ = wake.send(Event::FocusGained);
+    });
+    app.state.process_event(
+        &mut app.window,
+        &mut app.traversal,
+        &mut app.display,
+        &mut terminal,
+        &events,
+        &app.config,
+    )?;
+
+    assert!(app.state.scan.is_some(), "the scan is still running");
+    assert!(!app.state.received_events, "no user interaction is needed");
+    assert_eq!(app.state.stats.entries_traversed, 42);
+    assert_eq!(app.state.entries[0].index, visible);
+    assert_ne!(terminal.backend().buffer(), &before);
+    Ok(())
+}
+
+#[test]
+fn disconnected_traversal_reports_an_error_instead_of_waiting_forever() -> Result<()> {
+    let (mut terminal, mut app) = untraversed_app_and_terminal_from_fixture(&["sample-01"])?;
+    app.traverse()?;
+    let (sender, receiver) = crossbeam::channel::bounded(0);
+    drop(sender);
+    app.state.scan.as_mut().unwrap().active_traversal.event_rx = receiver;
+
+    let Err(error) = app.process_events_once(&mut terminal, into_events([])) else {
+        panic!("a disconnected traversal must report an error");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("Filesystem traversal stopped unexpectedly")
+    );
+    Ok(())
+}
+
+#[test]
 fn tracks_terminal_focus_events() -> Result<()> {
     let (mut terminal, mut app) = initialized_app_and_terminal_from_fixture(&["sample-01"])?;
 

--- a/src/interactive/app/tests/journeys_with_writes.rs
+++ b/src/interactive/app/tests/journeys_with_writes.rs
@@ -30,6 +30,38 @@ fn marked_file_names(app: &TerminalApp, message: &str) -> BTreeSet<String> {
 }
 
 #[test]
+fn refresh_discards_marks_before_reusing_tree_indices() -> Result<()> {
+    let fixture = TempDir::new()?;
+    let root = fixture.path().canonicalize()?;
+    let removed = root.join("old");
+    fs::create_dir(&removed)?;
+    fs::write(removed.join("data"), b"old")?;
+    let (mut terminal, mut app) =
+        initialized_app_and_terminal_from_paths(std::slice::from_ref(&root))?;
+    app.process_events_once(&mut terminal, into_codes("ox"))?;
+    assert!(app.window.mark.is_some());
+
+    fs::remove_dir_all(removed)?;
+    let replacement = root.join("precious");
+    fs::create_dir(&replacement)?;
+    fs::write(replacement.join("data"), b"keep")?;
+    app.process_events_once(&mut terminal, into_codes("R"))?;
+    assert!(
+        app.window.mark.is_none(),
+        "stale marks must not follow recycled indices"
+    );
+    app.process_events_once(
+        &mut terminal,
+        into_events([
+            Event::Key(KeyCode::Tab.into()),
+            Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+        ]),
+    )?;
+    assert_eq!(fs::read(replacement.join("data"))?, b"keep");
+    Ok(())
+}
+
+#[test]
 fn deletion_and_trash_are_blocked_until_scan_finishes() -> Result<()> {
     use crate::interactive::app::{state::FilesystemScan, tree_view::TreeView};
     use dua::traverse::BackgroundTraversal;
@@ -61,6 +93,7 @@ fn deletion_and_trash_are_blocked_until_scan_finishes() -> Result<()> {
             false,
         )?,
         previous_selection: None,
+        previous_cleanup_view: None,
         snapshot_export: None,
     });
     let delete_key = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL);
@@ -74,11 +107,11 @@ fn deletion_and_trash_are_blocked_until_scan_finishes() -> Result<()> {
             &mut app.window,
             &mut TreeView {
                 traversal: &mut app.traversal,
+                scope: None,
                 glob_tree_root: None,
                 glob_matches: None,
             },
             app.display,
-            &mut terminal,
             &app.config,
         );
         assert_eq!(

--- a/src/interactive/app/tests/mod.rs
+++ b/src/interactive/app/tests/mod.rs
@@ -1,5 +1,7 @@
 pub const FIXTURE_PATH: &str = "tests/fixtures";
 
+mod journeys_clean;
+mod journeys_deletion;
 mod journeys_readonly;
 mod journeys_with_writes;
 mod unit;

--- a/src/interactive/app/tests/unit.rs
+++ b/src/interactive/app/tests/unit.rs
@@ -64,7 +64,8 @@ fn it_can_do_a_glob_search() {
     let (tree, root_index) = sample_02_tree(false);
     let result = glob_search(
         &tree,
-        root_index,
+        tree.children(root_index)
+            .map(|index| (index, tree.name(index).unwrap().into_owned())),
         "tests/fixtures/sample-02",
         Case::Fold,
         Language::English,
@@ -79,7 +80,8 @@ fn it_can_do_a_case_sensitive_glob_search() {
     let (tree, root_index) = sample_02_tree(false);
     let result_insensitive = glob_search(
         &tree,
-        root_index,
+        tree.children(root_index)
+            .map(|index| (index, tree.name(index).unwrap().into_owned())),
         "TESTS/FIXTURES/SAMPLE-02",
         Case::Fold,
         Language::English,
@@ -89,7 +91,8 @@ fn it_can_do_a_case_sensitive_glob_search() {
 
     let result_sensitive = glob_search(
         &tree,
-        root_index,
+        tree.children(root_index)
+            .map(|index| (index, tree.name(index).unwrap().into_owned())),
         "TESTS/FIXTURES/SAMPLE-02",
         Case::Sensitive,
         Language::English,
@@ -135,10 +138,9 @@ fn it_can_sort_directory_mtimes_by_recursive_entries() {
 
     let recursive = sorted_entries(
         &tree,
-        root,
+        tree.children(root),
         SortMode::MTimeDescending(MTimeSort::RecursiveChildrenNewest),
-        None,
-        None,
+        false,
         EntryCheck::Disabled,
     );
     assert_eq!(
@@ -164,10 +166,9 @@ fn it_can_sort_directory_mtimes_by_recursive_entries() {
 
     let recursive_oldest = sorted_entries(
         &tree,
-        root,
+        tree.children(root),
         SortMode::MTimeDescending(MTimeSort::RecursiveChildrenOldest),
-        None,
-        None,
+        false,
         EntryCheck::Disabled,
     );
     assert_eq!(
@@ -194,6 +195,7 @@ fn it_can_sort_directory_mtimes_by_recursive_entries() {
     let mut traversal = Traversal {
         tree,
         root_index: root,
+        clean_search_roots: std::collections::HashMap::new(),
         start_time: Instant::now(),
         cost: None,
     };
@@ -215,15 +217,15 @@ fn it_can_sort_directory_mtimes_by_recursive_entries() {
     state.sorting = SortMode::MTimeDescending(MTimeSort::Entry);
     state.entries = sorted_entries(
         &traversal.tree,
-        root,
+        traversal.tree.children(root),
         state.sorting,
-        None,
-        None,
+        false,
         EntryCheck::Disabled,
     );
 
     let tree_view = TreeView {
         traversal: &mut traversal,
+        scope: None,
         glob_tree_root: None,
         glob_matches: None,
     };

--- a/src/interactive/app/tree_view.rs
+++ b/src/interactive/app/tree_view.rs
@@ -8,6 +8,8 @@ use std::{
 
 pub struct TreeView<'a> {
     pub traversal: &'a mut Traversal,
+    /// Detached browser root and its visible real nodes, independent of glob results.
+    pub scope: Option<(TreeIndex, Arc<[TreeIndex]>)>,
     pub glob_tree_root: Option<TreeIndex>,
     pub glob_matches: Option<Arc<[TreeIndex]>>,
 }
@@ -26,14 +28,68 @@ impl TreeView<'_> {
     }
 
     pub fn view_parent_of(&self, idx: TreeIndex) -> Option<TreeIndex> {
-        match self.glob_tree_root.zip(self.glob_matches.as_deref()) {
-            Some((glob_root, matches)) if matches.binary_search(&idx).is_ok() => Some(glob_root),
-            _ => self.traversal.tree.parent(idx),
+        if let Some((root, matches)) = self.glob_tree_root.zip(self.glob_matches.as_deref())
+            && matches.binary_search(&idx).is_ok()
+        {
+            return Some(root);
+        }
+        self.scope
+            .as_ref()
+            .filter(|(_, members)| members.binary_search(&idx).is_ok())
+            .map(|(root, _)| *root)
+            .or_else(|| self.fs_parent_of(idx))
+    }
+
+    pub fn children(&self, root: TreeIndex) -> Vec<TreeIndex> {
+        if self.glob_tree_root == Some(root) {
+            self.glob_matches.as_deref().unwrap_or_default().to_vec()
+        } else if let Some((scope, members)) = &self.scope
+            && *scope == root
+        {
+            members.to_vec()
+        } else {
+            self.tree().children(root).collect()
+        }
+    }
+
+    pub fn name_in(&self, root: TreeIndex, index: TreeIndex) -> Option<PathBuf> {
+        if self.glob_tree_root == Some(root) {
+            return self.exists(index).then(|| self.path_of(index));
+        }
+        let name = self.tree().name(index)?;
+        if self.scope.as_ref().is_some_and(|(scope, _)| *scope == root) {
+            Some(
+                self.path_of(index)
+                    .strip_prefix(self.tree().name(root)?)
+                    .ok()?
+                    .to_owned(),
+            )
+        } else {
+            Some(name.into_owned())
         }
     }
 
     pub fn path_of(&self, node_idx: TreeIndex) -> PathBuf {
         path_of(&self.traversal.tree, node_idx, self.glob_tree_root)
+    }
+
+    /// Find a filesystem directory after a refresh replaced its tree index.
+    pub fn index_at_path(&self, path: &Path) -> Option<TreeIndex> {
+        if let Some((root, _)) = &self.scope
+            && self.tree().name(*root).as_deref() == Some(path)
+        {
+            return Some(*root);
+        }
+        let mut index = self.traversal.root_index;
+        loop {
+            if self.path_of(index) == path {
+                return Some(index);
+            }
+            index = self.tree().children(index).find(|&child| {
+                self.tree().data(child).is_some_and(|entry| entry.is_dir)
+                    && path.starts_with(self.path_of(child))
+            })?;
+        }
     }
 
     pub fn sorted_entries(
@@ -42,29 +98,27 @@ impl TreeView<'_> {
         sorting: SortMode,
         check: EntryCheck,
     ) -> Vec<EntryDataBundle> {
-        sorted_entries(
-            &self.traversal.tree,
-            view_root,
-            sorting,
-            self.glob_tree_root,
-            self.glob_matches.as_deref(),
-            check,
-        )
+        let use_full_path = self.glob_tree_root == Some(view_root);
+        let scoped = self
+            .scope
+            .as_ref()
+            .is_some_and(|(root, _)| *root == view_root);
+        let indices = self
+            .children(view_root)
+            .into_iter()
+            .filter(|&index| !scoped || self.name_in(view_root, index).is_some());
+        let mut entries =
+            sorted_entries(&self.traversal.tree, indices, sorting, use_full_path, check);
+        if scoped {
+            for entry in &mut entries {
+                entry.name = self.name_in(view_root, entry.index).expect("scope member");
+            }
+        }
+        entries
     }
 
     pub fn current_path(&self, view_root: TreeIndex) -> PathBuf {
         current_path(&self.traversal.tree, view_root, self.glob_tree_root)
-    }
-
-    pub fn remove_entries(&mut self, root_index: TreeIndex, remove_root_node: bool) -> usize {
-        if remove_root_node {
-            return self.tree_mut().remove_subtree(root_index);
-        }
-        let children = self.tree().children(root_index).collect::<Vec<_>>();
-        children
-            .into_iter()
-            .map(|child| self.tree_mut().remove_subtree(child))
-            .sum()
     }
 
     pub fn exists(&self, idx: TreeIndex) -> bool {

--- a/src/interactive/mod.rs
+++ b/src/interactive/mod.rs
@@ -3,33 +3,9 @@ pub use app::*;
 
 pub mod widgets;
 
-mod utils {
-    use dua::traverse::{Tree, TreeIndex};
-    use std::path::PathBuf;
+use dua::traverse::{Tree, TreeIndex};
+use std::path::PathBuf;
 
-    pub fn path_of(tree: &Tree, mut node_idx: TreeIndex, _glob_root: Option<TreeIndex>) -> PathBuf {
-        let mut entries = Vec::new();
-
-        while let Some(parent_idx) = tree.parent(node_idx) {
-            entries.push(
-                tree.name(node_idx)
-                    .expect("node should always be retrievable with valid index"),
-            );
-            node_idx = parent_idx;
-        }
-        entries.push(
-            tree.name(node_idx)
-                .expect("node should always be retrievable with valid index"),
-        );
-        entries
-            .iter()
-            .rev()
-            .filter(|name| !name.as_os_str().is_empty())
-            .fold(PathBuf::new(), |mut acc, entry| {
-                acc.push(entry);
-                acc
-            })
-    }
+pub fn path_of(tree: &Tree, node_idx: TreeIndex, _glob_root: Option<TreeIndex>) -> PathBuf {
+    tree.path_of(node_idx)
 }
-
-pub use utils::path_of;

--- a/src/interactive/widgets/entries.rs
+++ b/src/interactive/widgets/entries.rs
@@ -6,13 +6,11 @@ use crate::interactive::widgets::tui_ext::{
 };
 use crate::interactive::{
     DisplayOptions, EntryDataBundle, SortMode,
-    widgets::{EntryMarkMap, Language, entry_color},
+    widgets::{Language, entry_color},
 };
 use chrono::DateTime;
-use dua::traverse::TreeIndex;
-use itertools::Itertools;
 use std::borrow::{Borrow, Cow};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 use std::time::SystemTime;
 use tui::{
@@ -25,6 +23,15 @@ use tui::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+/// Borrowed entry data and its presentation in the current list.
+pub struct EntryRow<'a> {
+    pub entry: &'a EntryDataBundle,
+    pub marked: bool,
+    pub cleanup: bool,
+    pub gitignored: bool,
+    pub suffix: Option<String>,
+}
+
 /// Inputs used to render the entries pane.
 pub struct EntriesProps<'a> {
     /// Path shown in the entries pane title.
@@ -33,20 +40,14 @@ pub struct EntriesProps<'a> {
     pub display: DisplayOptions,
     /// Whether directories are shown as `dir/` instead of `/dir`.
     pub directory_suffix: bool,
-    /// Currently selected tree entry, if one is selected.
-    pub selected: Option<TreeIndex>,
-    /// Entries to display in the pane, already sorted for the current view.
-    pub entries: &'a [EntryDataBundle],
-    /// Entries currently marked for action, if marking is active.
-    pub marked: Option<&'a EntryMarkMap>,
-    /// Entry indices that match known cleanup-directory names, if enabled.
-    pub cleanup_candidates: Option<&'a BTreeSet<TreeIndex>>,
-    /// Entry indices ignored by the current git repository, if enabled.
-    pub gitignored_entries: Option<&'a BTreeSet<TreeIndex>>,
+    /// Position of the currently selected row, if one is selected.
+    pub selected: Option<usize>,
     /// Border style for the entries pane.
     pub border_style: Style,
     /// Whether this pane currently owns keyboard focus.
     pub is_focussed: bool,
+    /// Whether to advertise ordinary browser actions.
+    pub show_hints: bool,
     /// Active sort mode, used for column visibility and highlighting.
     pub sort_mode: SortMode,
     /// Columns explicitly enabled in addition to columns implied by sorting.
@@ -66,6 +67,7 @@ impl Entries {
     pub fn render<'a>(
         &mut self,
         props: impl Borrow<EntriesProps<'a>>,
+        entries: impl Clone + ExactSizeIterator<Item = EntryRow<'a>>,
         area: Rect,
         buf: &mut Buffer,
     ) {
@@ -73,13 +75,10 @@ impl Entries {
             current_path,
             display,
             directory_suffix,
-            entries,
             selected,
-            marked,
-            cleanup_candidates,
-            gitignored_entries,
             border_style,
             is_focussed,
+            show_hints,
             sort_mode,
             show_columns,
             keys,
@@ -87,10 +86,9 @@ impl Entries {
         } = props.borrow();
         let list = &mut self.list;
 
-        let total: u128 = entries.iter().map(|b| b.size).sum();
         let (recursive_item_count, item_size): (u64, u128) = entries
-            .iter()
-            .map(|f| (f.entry_count.unwrap_or(1), f.size))
+            .clone()
+            .map(|row| (row.entry.entry_count.unwrap_or(1), row.entry.size))
             .reduce(|a, b| (a.0 + b.0, a.1 + b.1))
             .unwrap_or_default();
         let title_width_inside_borders = area.width.saturating_sub(2) as usize;
@@ -105,27 +103,18 @@ impl Entries {
         );
         let title_block = title_block(&title, *border_style);
         let inner_area = title_block.inner(area);
-        let entry_in_view = entry_in_view(*selected, entries);
-
         let props = ListProps {
             block: Some(title_block),
-            entry_in_view,
+            entry_in_view: *selected,
         };
-        let mut scroll_offset = None;
-        let lines = entries.iter().enumerate().map(|(idx, bundle)| {
-            let node_idx = &bundle.index;
+        let lines = entries.enumerate().map(|(idx, row)| {
+            let bundle = row.entry;
             let is_dir = &bundle.is_dir;
             let exists = &bundle.exists;
             let name = bundle.name.as_path();
 
-            let is_marked = marked.is_some_and(|m| m.contains_key(node_idx));
-            let is_cleanup_candidate = cleanup_candidates.is_some_and(|c| c.contains(node_idx));
-            let is_gitignored = gitignored_entries.is_some_and(|g| g.contains(node_idx));
-            let is_selected = selected == &Some(*node_idx);
-            if is_selected {
-                scroll_offset = Some(idx);
-            }
-            let fraction = bundle.size as f32 / total as f32;
+            let is_selected = *selected == Some(idx);
+            let fraction = bundle.size as f32 / item_size as f32;
             let text_style = style(is_selected, *is_focussed);
             let percentage_style = percentage_style(fraction, text_style);
 
@@ -156,14 +145,17 @@ impl Entries {
                     .sum(),
             ) as usize;
 
-            let name = shorten_input(
-                name_with_directory_marker(name.to_string_lossy(), *is_dir, *directory_suffix),
-                available_width,
-            );
+            let mut name =
+                name_with_directory_marker(name.to_string_lossy(), *is_dir, *directory_suffix);
+            if let Some(suffix) = &row.suffix {
+                name.to_mut().push(' ');
+                name.to_mut().push_str(suffix);
+            }
+            let name = shorten_input(name, available_width);
             let style = name_style(
-                is_marked,
-                is_cleanup_candidate,
-                is_gitignored,
+                row.marked,
+                row.cleanup,
+                row.gitignored,
                 *exists,
                 *is_dir,
                 text_style,
@@ -181,24 +173,15 @@ impl Entries {
             .begin_symbol(None)
             .end_symbol(None);
         let mut scrollbar_state =
-            ScrollbarState::new(line_count).position(scroll_offset.unwrap_or(list.offset));
+            ScrollbarState::new(line_count).position(selected.unwrap_or(list.offset));
 
         scrollbar.render(area.inner(Margin::new(0, 1)), buf, &mut scrollbar_state);
 
-        if *is_focussed {
+        if *is_focussed && *show_hints {
             let bound = draw_top_right_help(area, &title, buf, keys);
             draw_bottom_right_help(bound, buf, keys, *language);
         }
     }
-}
-
-fn entry_in_view(selected: Option<TreeIndex>, entries: &[EntryDataBundle]) -> Option<usize> {
-    selected.map(|selected| {
-        entries
-            .iter()
-            .find_position(|b| b.index == selected)
-            .map_or(0, |(idx, _)| idx)
-    })
 }
 
 fn title_block(title: &str, border_style: Style) -> Block<'_> {

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -4,14 +4,14 @@ use crate::interactive::widgets::tui_ext::{
     util::{block_width, rect},
 };
 use anyhow::{Context, Result, anyhow};
-use bstr::BString;
+use bstr::{BString, ByteSlice};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind};
 use dua::{
     KeysConfig,
     traverse::{Tree, TreeIndex},
 };
 use gix::glob::pattern::Case;
-use std::borrow::Borrow;
+use std::{borrow::Borrow, path::PathBuf};
 use tui::{
     buffer::Buffer,
     layout::Rect,
@@ -212,43 +212,44 @@ fn margin_left_right(r: Rect, margin: u16) -> Rect {
     }
 }
 
-fn glob_search_neighbours(
+fn glob_search_entry(
     results: &mut Vec<TreeIndex>,
     tree: &Tree,
-    root_index: TreeIndex,
+    entry: (TreeIndex, &std::path::Path),
     glob: &gix::glob::Pattern,
     path: &mut BString,
     case: Case,
 ) {
-    for node_index in tree.children(root_index) {
-        if let Some(node) = tree.entry(node_index) {
-            let previous_len = path.len();
-            let basename_start = if path.is_empty() {
-                None
-            } else {
-                path.push(b'/');
-                Some(previous_len + 1)
-            };
-            path.extend_from_slice(gix::path::into_bstr(node.name.as_ref()).as_ref());
-            if glob.matches_repo_relative_path(
-                path.as_ref(),
-                basename_start,
-                Some(node.is_dir),
-                case,
-                gix::glob::wildmatch::Mode::NO_MATCH_SLASH_LITERAL,
-            ) {
-                results.push(node_index);
-            } else {
-                glob_search_neighbours(results, tree, node_index, glob, path, case);
-            }
-            path.truncate(previous_len);
+    let (index, name) = entry;
+    if let Some(node) = tree.data(index) {
+        let previous_len = path.len();
+        if !path.is_empty() {
+            path.push(b'/');
         }
+        path.extend_from_slice(
+            gix::path::to_unix_separators_on_windows(gix::path::into_bstr(name)).as_ref(),
+        );
+        if glob.matches_repo_relative_path(
+            path.as_ref(),
+            path.rfind_byte(b'/').map(|position| position + 1),
+            Some(node.is_dir),
+            case,
+            gix::glob::wildmatch::Mode::NO_MATCH_SLASH_LITERAL,
+        ) {
+            results.push(index);
+        } else {
+            for child in tree.children(index) {
+                let name = tree.name(child).expect("child exists");
+                glob_search_entry(results, tree, (child, &name), glob, path, case);
+            }
+        }
+        path.truncate(previous_len);
     }
 }
 
 pub fn glob_search(
     tree: &Tree,
-    root_index: TreeIndex,
+    entries: impl IntoIterator<Item = (TreeIndex, PathBuf)>,
     glob: &str,
     case: gix::glob::pattern::Case,
     language: Language,
@@ -257,7 +258,9 @@ pub fn glob_search(
         .with_context(|| anyhow!(language.ui_text().glob_empty))?;
     let mut results = Vec::new();
     let mut path = BString::default();
-    glob_search_neighbours(&mut results, tree, root_index, &glob, &mut path, case);
+    for (index, name) in entries {
+        glob_search_entry(&mut results, tree, (index, &name), &glob, &mut path, case);
+    }
     Ok(results)
 }
 

--- a/src/interactive/widgets/i18n.rs
+++ b/src/interactive/widgets/i18n.rs
@@ -542,9 +542,8 @@ pub struct UiText {
     pub scanning: &'static str,
     pub snapshots_read_only: &'static str,
     pub traversal_running: &'static str,
-    pub deleting_items: &'static str,
-    #[cfg(feature = "trash-move")]
-    pub trashing_items: &'static str,
+    pub deletion_running: &'static str,
+    pub cancelling_deletion: &'static str,
     pub no_cleanup_candidates: &'static str,
     pub cleanup_candidates_already_marked: &'static str,
     pub cleanup_detection_disabled: &'static str,
@@ -561,6 +560,16 @@ pub struct UiText {
 }
 
 impl Language {
+    pub fn cleanup_group_label(self, count: usize) -> String {
+        match self {
+            Language::English => format!("[{count} candidates]"),
+            Language::Japanese => format!("[候補 {count} 件]"),
+            Language::Korean => format!("[후보 {count}개]"),
+            Language::Chinese => format!("[{count} 个候选项]"),
+            Language::German => format!("[{count} Kandidaten]"),
+        }
+    }
+
     pub fn entries_statistics(self, visible: usize, total: &str, size: &str) -> String {
         match self {
             Language::English => format!("({visible} visible, {total} total, {size})"),
@@ -657,23 +666,33 @@ impl Language {
         }
     }
 
-    pub fn deletion_progress(self, count: usize, trash: bool) -> String {
+    pub fn deletion_progress(self, count: usize, remaining: &str, trash: bool) -> String {
         match (self, trash) {
-            (Language::English, false) => format!("Deleted {count} items..."),
-            (Language::English, true) => format!("Trashed {count} items..."),
-            (Language::Japanese, false) => format!("{count} 件を削除..."),
-            (Language::Japanese, true) => format!("{count} 件をゴミ箱へ移動..."),
-            (Language::Korean, false) => format!("{count}개 항목 삭제..."),
-            (Language::Korean, true) => format!("{count}개 항목을 휴지통으로 이동..."),
-            (Language::Chinese, false) => format!("已删除 {count} 个条目..."),
-            (Language::Chinese, true) => format!("已将 {count} 个条目移至回收站..."),
+            (Language::English, false) => {
+                format!("Deleted {count} items; {remaining} remaining...")
+            }
+            (Language::English, true) => {
+                format!("Trashed {count} items; {remaining} remaining...")
+            }
+            (Language::Japanese, false) => format!("{count} 件を削除、残り {remaining}..."),
+            (Language::Japanese, true) => {
+                format!("{count} 件をゴミ箱へ移動、残り {remaining}...")
+            }
+            (Language::Korean, false) => format!("{count}개 항목 삭제, 남은 용량 {remaining}..."),
+            (Language::Korean, true) => {
+                format!("{count}개 항목을 휴지통으로 이동, 남은 용량 {remaining}...")
+            }
+            (Language::Chinese, false) => format!("已删除 {count} 个条目，剩余 {remaining}..."),
+            (Language::Chinese, true) => {
+                format!("已将 {count} 个条目移至回收站，剩余 {remaining}...")
+            }
             (Language::German, false) => format!(
-                "{count} {} gelöscht...",
+                "{count} {} gelöscht; {remaining} verbleibend...",
                 if count == 1 { "Eintrag" } else { "Einträge" }
             ),
             (Language::German, true) => {
                 let label = if count == 1 { "Eintrag" } else { "Einträge" };
-                format!("{count} {label} in den Papierkorb verschoben...")
+                format!("{count} {label} in den Papierkorb verschoben; {remaining} verbleibend...")
             }
         }
     }
@@ -844,9 +863,8 @@ const EN_UI: UiText = UiText {
     scanning: "-> scanning <-",
     snapshots_read_only: "Snapshots are read-only",
     traversal_running: "Traversal already running",
-    deleting_items: "Deleting items...",
-    #[cfg(feature = "trash-move")]
-    trashing_items: "Trashing items...",
+    deletion_running: "Deletion in progress; changes are disabled",
+    cancelling_deletion: "Cancelling deletion...",
     no_cleanup_candidates: "No cleanup candidates in view",
     cleanup_candidates_already_marked: "Cleanup candidates are already marked",
     cleanup_detection_disabled: "Cleanup candidate detection is disabled",
@@ -908,9 +926,8 @@ const JA_UI: UiText = UiText {
     scanning: "-> スキャン中 <-",
     snapshots_read_only: "スナップショットは読み取り専用です",
     traversal_running: "スキャンはすでに実行中です",
-    deleting_items: "項目を削除中...",
-    #[cfg(feature = "trash-move")]
-    trashing_items: "項目をゴミ箱へ移動中...",
+    deletion_running: "削除中のため変更できません",
+    cancelling_deletion: "削除を中止しています...",
     no_cleanup_candidates: "現在の表示にクリーンアップ候補はありません",
     cleanup_candidates_already_marked: "クリーンアップ候補はすでにマーク済みです",
     cleanup_detection_disabled: "クリーンアップ候補の検出は無効です",
@@ -972,9 +989,8 @@ const KO_UI: UiText = UiText {
     scanning: "-> 스캔 중 <-",
     snapshots_read_only: "스냅샷은 읽기 전용입니다",
     traversal_running: "스캔이 이미 실행 중입니다",
-    deleting_items: "항목 삭제 중...",
-    #[cfg(feature = "trash-move")]
-    trashing_items: "항목을 휴지통으로 이동 중...",
+    deletion_running: "삭제 중에는 변경할 수 없습니다",
+    cancelling_deletion: "삭제 취소 중...",
     no_cleanup_candidates: "현재 보기에 정리 후보가 없습니다",
     cleanup_candidates_already_marked: "정리 후보가 이미 표시되어 있습니다",
     cleanup_detection_disabled: "정리 후보 감지가 비활성화되어 있습니다",
@@ -1036,9 +1052,8 @@ const ZH_UI: UiText = UiText {
     scanning: "-> 正在扫描 <-",
     snapshots_read_only: "快照为只读",
     traversal_running: "扫描已在进行",
-    deleting_items: "正在删除条目...",
-    #[cfg(feature = "trash-move")]
-    trashing_items: "正在将条目移至回收站...",
+    deletion_running: "正在删除，暂时无法更改",
+    cancelling_deletion: "正在取消删除...",
     no_cleanup_candidates: "当前视图中没有清理候选项",
     cleanup_candidates_already_marked: "清理候选项已标记",
     cleanup_detection_disabled: "清理候选项检测已禁用",
@@ -1100,9 +1115,8 @@ const DE_UI: UiText = UiText {
     scanning: "-> Scan läuft <-",
     snapshots_read_only: "Snapshots sind schreibgeschützt",
     traversal_running: "Scan läuft bereits",
-    deleting_items: "Einträge werden gelöscht...",
-    #[cfg(feature = "trash-move")]
-    trashing_items: "Einträge werden in den Papierkorb verschoben...",
+    deletion_running: "Löschung läuft; Änderungen sind gesperrt",
+    cancelling_deletion: "Löschung wird abgebrochen...",
     no_cleanup_candidates: "Keine Bereinigungskandidaten in der Ansicht",
     cleanup_candidates_already_marked: "Bereinigungskandidaten sind bereits markiert",
     cleanup_detection_disabled: "Erkennung von Bereinigungskandidaten ist deaktiviert",
@@ -1213,6 +1227,25 @@ mod tests {
         assert_eq!(Language::Korean.ui_text().footer_sort_mode, "정렬");
         assert_eq!(Language::Chinese.ui_text().footer_sort_mode, "排序");
         assert_eq!(Language::German.ui_text().footer_sort_mode, "Sortierung");
+    }
+
+    #[test]
+    fn deletion_progress_includes_remaining_bytes_in_every_language() {
+        for language in [
+            Language::English,
+            Language::Japanese,
+            Language::Korean,
+            Language::Chinese,
+            Language::German,
+        ] {
+            for trash in [false, true] {
+                let progress = language.deletion_progress(42, "123 MB", trash);
+                assert!(progress.contains("42"));
+                assert!(progress.contains("123 MB"));
+            }
+            assert!(!language.ui_text().deletion_running.is_empty());
+            assert!(!language.ui_text().cancelling_deletion.is_empty());
+        }
     }
 
     #[test]

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -6,8 +6,8 @@ use crate::interactive::{
     DisplayOptions,
     state::{AppState, Cursor, FocussedPane},
     widgets::{
-        COLOR_MARKED, Entries, EntriesProps, Footer, FooterProps, GlobPane, GlobPaneProps, Header,
-        HelpPane, HelpPaneProps, Language, MarkPane, MarkPaneProps,
+        COLOR_MARKED, Entries, EntriesProps, EntryRow, Footer, FooterProps, GlobPane,
+        GlobPaneProps, Header, HelpPane, HelpPaneProps, Language, MarkPane, MarkPaneProps,
     },
 };
 use Constraint::{Length, Max, Min, Percentage};
@@ -73,7 +73,8 @@ impl MainWindow {
         let (entries_style, help_style, mark_style, glob_style) = pane_border_style(state.focussed);
         let (header_area, content_area, footer_area) = main_window_layout(area);
 
-        let safety_notice = mark_safety_notice(state.read_only, &config.keys, language);
+        let safety_notice =
+            mark_safety_notice(state.read_only, state.is_deleting(), &config.keys, language);
 
         let header_bg_color =
             header_background_color(self.has_marks() && safety_notice.is_none(), state.focussed);
@@ -123,6 +124,7 @@ impl MainWindow {
                     root_total_size: *total_bytes,
                     keys: &config.keys,
                     safety_notice,
+                    allow_changes: !state.is_deleting(),
                     language,
                 };
                 pane.render(props, mark_area, buffer);
@@ -155,23 +157,47 @@ impl MainWindow {
         }
 
         let marked = self.mark.as_ref().map(|pane| pane.marked());
+        let entries = state.entries.iter().map(|entry| EntryRow {
+            entry,
+            marked: marked.is_some_and(|marks| marks.contains_key(&entry.index)),
+            cleanup: state
+                .cleanup_candidates
+                .as_ref()
+                .is_some_and(|set| set.contains(&entry.index)),
+            gitignored: state
+                .gitignored_entries
+                .as_ref()
+                .is_some_and(|set| set.contains(&entry.index)),
+            suffix: None,
+        });
         let props = EntriesProps {
             current_path: current_path.clone(),
             display: *display,
             directory_suffix: config.directory_suffix,
-            entries: &state.entries,
-            marked,
-            cleanup_candidates: state.cleanup_candidates.as_ref(),
-            gitignored_entries: state.gitignored_entries.as_ref(),
-            selected: state.navigation().selected,
+            selected: state
+                .entries
+                .iter()
+                .position(|entry| Some(entry.index) == state.navigation().selected),
             border_style: entries_style,
             is_focussed: matches!(state.focussed, Main),
+            show_hints: true,
             sort_mode: state.sorting,
             show_columns: &state.show_columns,
             keys: &config.keys,
             language,
         };
-        self.entries.render(props, entries_area, buffer);
+        if let Some(hub) = state.clean_hub.as_ref().filter(|hub| hub.root.is_none()) {
+            hub.render(
+                &mut self.entries,
+                props,
+                marked,
+                state.cleanup_candidates.is_some(),
+                entries_area,
+                buffer,
+            );
+        } else {
+            self.entries.render(props, entries, entries_area, buffer);
+        }
 
         if let Some((glob_area, pane)) = glob_pane {
             let props = GlobPaneProps {
@@ -298,11 +324,14 @@ fn render_collapse_hint(
 
 fn mark_safety_notice(
     read_only: bool,
+    deleting: bool,
     keys: &dua::KeysConfig,
     language: crate::interactive::widgets::Language,
 ) -> Option<&'static str> {
     let t = language.ui_text();
-    if read_only {
+    if deleting {
+        Some(t.deletion_running)
+    } else if read_only {
         Some(t.mark_snapshot_read_only)
     } else if keys.delete_marked.is_empty()
         && (!cfg!(feature = "trash-move") || keys.trash_marked.is_empty())
@@ -566,14 +595,19 @@ mod tests {
     #[test]
     fn marks_are_only_dangerous_when_a_destructive_action_is_available() {
         let config = dua::Config::default();
-        assert!(mark_safety_notice(false, &config.keys, Language::English).is_none());
+        assert!(mark_safety_notice(false, false, &config.keys, Language::English).is_none());
         assert_eq!(header_background_color(true, Mark), Color::LightRed);
 
-        assert!(mark_safety_notice(true, &config.keys, Language::English).is_some());
+        assert!(mark_safety_notice(true, false, &config.keys, Language::English).is_some());
         assert_eq!(header_background_color(false, Mark), Color::White);
+
+        assert_eq!(
+            mark_safety_notice(false, true, &config.keys, Language::English),
+            Some(Language::English.ui_text().deletion_running)
+        );
 
         let config: dua::Config =
             toml::from_str("[keys]\ndelete_marked = []\ntrash_marked = []").expect("valid config");
-        assert!(mark_safety_notice(false, &config.keys, Language::English).is_some());
+        assert!(mark_safety_notice(false, false, &config.keys, Language::English).is_some());
     }
 }

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -29,6 +29,7 @@ use tui::{
 };
 use unicode_segmentation::UnicodeSegmentation;
 
+#[derive(Clone, Copy)]
 pub enum MarkMode {
     Delete,
     #[cfg(feature = "trash-move")]
@@ -64,6 +65,7 @@ pub struct MarkPaneProps<'a> {
     pub root_total_size: u128,
     pub keys: &'a KeysConfig,
     pub safety_notice: Option<&'static str>,
+    pub allow_changes: bool,
     pub language: Language,
 }
 
@@ -117,6 +119,46 @@ impl MarkPane {
     pub fn marked(&self) -> &EntryMarkMap {
         &self.marked
     }
+    pub fn is_empty(&self) -> bool {
+        self.marked.is_empty()
+    }
+    pub fn total_size(&self) -> u128 {
+        self.total_size
+    }
+    pub fn reconcile(&mut self, tree_view: &TreeView<'_>) {
+        let selected_index = self
+            .selected
+            .and_then(|position| self.tree_index_by_list_position(position));
+        self.marked.retain(|index, mark| {
+            let Some(entry) = tree_view.tree().entry(*index) else {
+                return false;
+            };
+            if tree_view.path_of(*index) != mark.path {
+                return false;
+            }
+            mark.size = entry.size;
+            mark.entry_count = entry.entry_count;
+            true
+        });
+        (self.total_size, self.item_count) = calculate_size_and_count(&self.marked);
+        self.selected = self.selected.and_then(|position| {
+            if self.marked.is_empty() {
+                return None;
+            }
+            Some(
+                self.marked_sorted_by_index()
+                    .iter()
+                    .position(|(index, _)| Some(**index) == selected_index)
+                    .unwrap_or_else(|| position.min(self.marked.len() - 1)),
+            )
+        });
+        self.list.offset = self.list.offset.min(self.marked.len().saturating_sub(1));
+    }
+    pub fn set_deletion_error(&mut self, index: TreeIndex, errors: usize) {
+        if let Some(mark) = self.marked.get_mut(&index) {
+            mark.num_errors_during_deletion = errors;
+        }
+    }
     pub fn into_paths(self) -> impl Iterator<Item = PathBuf> {
         self.marked.into_values().map(|v| v.path)
     }
@@ -124,19 +166,20 @@ impl MarkPane {
         mut self,
         key: KeyEvent,
         keys: &KeysConfig,
+        allow_changes: bool,
     ) -> Option<(Self, Option<MarkMode>)> {
         let action = None;
         if key.kind == KeyEventKind::Release {
             return Some((self, action));
         }
-        if keys.delete_marked.matches(key) {
+        if allow_changes && keys.delete_marked.matches(key) {
             return Some(self.prepare_deletion(MarkMode::Delete));
         }
         #[cfg(feature = "trash-move")]
-        if keys.trash_marked.matches(key) {
+        if allow_changes && keys.trash_marked.matches(key) {
             return Some(self.prepare_deletion(MarkMode::Trash));
         }
-        if keys.remove_all_marks.matches(key) {
+        if allow_changes && keys.remove_all_marks.matches(key) {
             return None;
         }
         if keys.move_to_top.matches(key) {
@@ -151,64 +194,12 @@ impl MarkPane {
             self.change_selection(CursorDirection::Up);
         } else if keys.move_down.matches(key) {
             self.change_selection(CursorDirection::Down);
-        } else if keys.remove_mark.matches(key) {
+        } else if allow_changes && keys.remove_mark.matches(key) {
             return self.remove_selected().map(|s| (s, action));
         }
         Some((self, action))
     }
 
-    pub fn iterate_deletable_items(
-        mut self,
-        mut delete_fn: impl FnMut(Self, TreeIndex) -> Result<Self, (Self, usize)>,
-    ) -> Option<Self> {
-        loop {
-            match self.next_entry_for_deletion() {
-                Some(entry_to_delete) => match delete_fn(self, entry_to_delete) {
-                    Ok(pane) => {
-                        self = pane;
-                        self = self.delete_entry()?;
-                    }
-                    Err((pane, num_errors)) => {
-                        self = pane;
-                        self.set_error_on_marked_item(num_errors);
-                    }
-                },
-                None => return Some(self),
-            }
-        }
-    }
-
-    fn next_entry_for_deletion(&mut self) -> Option<TreeIndex> {
-        match self.selected.and_then(|selected| {
-            self.tree_index_by_list_position(selected)
-                .and_then(|idx| self.marked.get(&idx).map(|d| (selected, idx, d)))
-        }) {
-            Some((position, selected_index, data)) => {
-                if data.num_errors_during_deletion == 0 {
-                    Some(selected_index)
-                } else {
-                    self.selected = match position + 1 {
-                        p if p < self.marked.len() => Some(p),
-                        _ => Some(self.marked.len().saturating_sub(1)),
-                    };
-                    self.tree_index_by_list_position(position + 1)
-                }
-            }
-            None => None,
-        }
-    }
-    fn delete_entry(self) -> Option<Self> {
-        self.remove_selected()
-    }
-    fn set_error_on_marked_item(&mut self, num_errors: usize) {
-        if let Some(d) = self
-            .selected
-            .and_then(|s| self.tree_index_by_list_position(s))
-            .and_then(|p| self.marked.get_mut(&p))
-        {
-            d.num_errors_during_deletion = num_errors;
-        }
-    }
     fn prepare_deletion(mut self, mark: MarkMode) -> (Self, Option<MarkMode>) {
         for entry in self.marked.values_mut() {
             entry.num_errors_during_deletion = 0;
@@ -222,6 +213,7 @@ impl MarkPane {
             let se_len = self.marked.len();
             if let Some(idx) = idx {
                 self.marked.remove(&idx);
+                (self.total_size, self.item_count) = calculate_size_and_count(&self.marked);
                 let new_len = se_len.saturating_sub(1);
                 if new_len == 0 {
                     return None;
@@ -235,7 +227,7 @@ impl MarkPane {
         Some(self)
     }
 
-    fn tree_index_by_list_position(&mut self, selected: usize) -> Option<TreeIndex> {
+    fn tree_index_by_list_position(&self, selected: usize) -> Option<TreeIndex> {
         self.marked_sorted_by_index()
             .get(selected)
             .map(|(k, _)| *k.to_owned())
@@ -268,6 +260,7 @@ impl MarkPane {
             root_total_size,
             keys,
             safety_notice,
+            allow_changes,
             language,
         } = props.borrow();
 
@@ -494,7 +487,7 @@ impl MarkPane {
                 t.mark_toggle, keys.remove_mark, t.mark_remove_all, keys.remove_all_marks
             );
             let help_text_block_width = block_width(&help_text);
-            if help_text_block_width <= bound.width {
+            if *allow_changes && help_text_block_width <= bound.width {
                 draw_text_nowrap_fn(
                     rect::snap_to_right(bound, help_text_block_width),
                     buf,
@@ -552,6 +545,7 @@ mod mark_pane_tests {
                 keys: &KeysConfig::default(),
                 root_total_size: 1_000_000_000,
                 safety_notice: None,
+                allow_changes: true,
                 language: Language::English,
             },
             area,
@@ -596,6 +590,7 @@ mod mark_pane_tests {
                 keys: &config.keys,
                 root_total_size: 0,
                 safety_notice: None,
+                allow_changes: true,
                 language: Language::English,
             },
             area,
@@ -666,6 +661,7 @@ mod mark_pane_tests {
                 keys: &KeysConfig::default(),
                 root_total_size: 0,
                 safety_notice: Some(" Snapshot is read-only; marked entries cannot be deleted "),
+                allow_changes: true,
                 language: Language::English,
             },
             area,
@@ -708,6 +704,7 @@ mod mark_pane_tests {
                 keys: &KeysConfig::default(),
                 root_total_size: 0,
                 safety_notice: None,
+                allow_changes: true,
                 language: Language::Korean,
             },
             area,
@@ -734,16 +731,154 @@ mod mark_pane_tests {
         .expect("valid config");
 
         assert!(matches!(
-            MarkPane::default().process_events(KeyCode::Char('z').into(), &config.keys),
+            MarkPane::default().process_events(KeyCode::Char('z').into(), &config.keys, true),
             Some((_, Some(MarkMode::Delete)))
         ));
         assert!(matches!(
             MarkPane::default().process_events(
                 KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
-                &config.keys
+                &config.keys,
+                true
             ),
             Some((_, None))
         ));
+    }
+
+    #[test]
+    fn busy_pane_preserves_marks_and_errors_but_allows_navigation() {
+        let keys = KeysConfig::default();
+        let mut pane = MarkPane {
+            selected: Some(0),
+            has_focus: true,
+            marked: [
+                (
+                    TreeIndex::new(1),
+                    EntryMark {
+                        index: 1,
+                        path: PathBuf::from("one"),
+                        num_errors_during_deletion: 3,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    TreeIndex::new(2),
+                    EntryMark {
+                        index: 2,
+                        path: PathBuf::from("two"),
+                        ..Default::default()
+                    },
+                ),
+            ]
+            .into(),
+            ..Default::default()
+        };
+        for key in [
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            KeyCode::Char('a').into(),
+            KeyCode::Char('x').into(),
+            KeyCode::Char('d').into(),
+            KeyCode::Char(' ').into(),
+        ] {
+            let (next, action) = pane.process_events(key, &keys, false).expect("marks stay");
+            pane = next;
+            assert!(action.is_none());
+            assert_eq!(pane.marked.len(), 2);
+            assert_eq!(pane.selected, Some(0));
+            assert_eq!(
+                pane.marked[&TreeIndex::new(1)].num_errors_during_deletion,
+                3
+            );
+        }
+        let (mut pane, action) = pane
+            .process_events(KeyCode::Char('j').into(), &keys, false)
+            .expect("navigation keeps marks");
+        assert!(action.is_none());
+        assert_eq!(pane.selected, Some(1));
+
+        let area = Rect::new(0, 0, 120, 5);
+        let mut buffer = Buffer::empty(area);
+        pane.render(
+            MarkPaneProps {
+                border_style: Style::default(),
+                format: ByteFormat::Metric,
+                keys: &keys,
+                root_total_size: 0,
+                safety_notice: Some(Language::English.ui_text().deletion_running),
+                allow_changes: false,
+                language: Language::English,
+            },
+            area,
+            &mut buffer,
+        );
+        let rendered: String = buffer.content.iter().map(Cell::symbol).collect();
+        assert!(rendered.contains("Deletion in progress; changes are disabled"));
+        assert!(!rendered.contains("mark-toggle"));
+        assert!(!rendered.contains("remove-all"));
+        assert!(!rendered.contains("to delete without prompt"));
+    }
+
+    #[test]
+    fn reconcile_updates_remaining_sizes_and_preserves_selection_identity() {
+        use dua::traverse::{EntryData, Traversal};
+
+        let mut traversal = Traversal::new();
+        let root = traversal.root_index;
+        let deleted = traversal
+            .tree
+            .add_child(root, "deleted", EntryData::default());
+        let survivor = traversal.tree.add_child(
+            root,
+            "survivor",
+            EntryData {
+                size: 40,
+                entry_count: Some(2),
+                is_dir: true,
+                ..Default::default()
+            },
+        );
+        let stale = traversal
+            .tree
+            .add_child(root, "stale", EntryData::default());
+        let view = TreeView {
+            traversal: &mut traversal,
+            scope: None,
+            glob_tree_root: None,
+            glob_matches: None,
+        };
+        let mut pane = MarkPane::default();
+        for index in [deleted, survivor, stale] {
+            pane = pane
+                .toggle_index(index, &view, index == survivor, true)
+                .unwrap();
+        }
+        pane.selected = Some(1);
+        pane.set_deletion_error(survivor, 2);
+        view.traversal.tree.remove_subtree(deleted);
+        view.traversal.tree.remove_subtree(stale);
+        let replacement = view
+            .traversal
+            .tree
+            .add_child(root, "replacement", EntryData::default());
+        assert_eq!(replacement, stale, "exercise a recycled tree index");
+        view.traversal.tree.update(survivor, |data| {
+            data.size = 28;
+            data.entry_count = Some(1);
+        });
+
+        pane.reconcile(&view);
+        assert_eq!(pane.marked.len(), 1);
+        assert_eq!(pane.selected, Some(0));
+        assert_eq!(pane.tree_index_by_list_position(0), Some(survivor));
+        assert_eq!(pane.total_size(), 28);
+        assert_eq!(pane.item_count, 1);
+        assert_eq!(pane.marked[&survivor].num_errors_during_deletion, 2);
+
+        view.traversal.tree.remove_subtree(survivor);
+        pane.reconcile(&view);
+        assert!(pane.is_empty());
+        assert_eq!(pane.selected, None);
+        assert_eq!((pane.total_size(), pane.item_count), (0, 0));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub(crate) use dua_core as walk;
 pub use dua_core::Options as TraversalOptions;
 
 mod aggregate;
+/// Discovery of directories suitable for interactive cleanup.
+pub mod clean;
 mod common;
 mod config;
 pub use config::{Config, KeyBinding, KeyBindings, KeysConfig};

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn open_snapshot_file(path: &Path) -> Result<fs::File> {
     Ok(file)
 }
 
+#[cfg(feature = "tui-crossplatform")]
 fn read_snapshot_file(path: &Path) -> Result<dua::snapshot::Snapshot> {
     dua::snapshot::read(open_snapshot_file(path)?)
         .with_context(|| format!("Could not read snapshot {}", path.display()))
@@ -92,9 +93,9 @@ fn marked_path_for_output(path: &Path, stdout_is_terminal: bool) -> std::borrow:
 }
 
 fn main() -> Result<()> {
-    #[cfg(feature = "tui-crossplatform")]
-    use options::Command::Interactive;
     use options::Command::{Aggregate, Completions, Config, Diff, Flamegraph, Stacks};
+    #[cfg(feature = "tui-crossplatform")]
+    use options::Command::{Clean, Interactive};
 
     let matches = options::Args::command().get_matches_from(wild::args_os());
     let global_traversal_options_used = traversal_options_on_command_line(&matches);
@@ -137,14 +138,40 @@ fn main() -> Result<()> {
 
     let res = match command {
         #[cfg(feature = "tui-crossplatform")]
-        Some(Interactive {
-            traversal: subcommand_traversal,
-            export,
-            compression,
-            import,
-            no_entry_check,
-            once,
-        }) => {
+        Some(command @ (Interactive { .. } | Clean { .. })) => {
+            let (
+                subcommand_traversal,
+                export,
+                compression,
+                import,
+                no_entry_check,
+                once,
+                clean_depth,
+            ) = match command {
+                Interactive {
+                    traversal,
+                    export,
+                    compression,
+                    import,
+                    no_entry_check,
+                    once,
+                } => (
+                    traversal,
+                    export,
+                    compression,
+                    import,
+                    no_entry_check,
+                    once,
+                    None,
+                ),
+                Clean {
+                    traversal,
+                    depth,
+                    no_entry_check,
+                    once,
+                } => (traversal, None, 0, None, no_entry_check, once, Some(depth)),
+                _ => unreachable!("only terminal commands enter this arm"),
+            };
             if import.is_some() && global_traversal_options_used {
                 bail!("--import cannot be used with traversal options or input paths");
             }
@@ -162,40 +189,47 @@ fn main() -> Result<()> {
             let snapshot = import.as_deref().map(read_snapshot_file).transpose()?;
             let snapshot_load_duration = snapshot_load_start.map(|start| start.elapsed());
             let read_only = snapshot.is_some();
-            let (input_paths, initial_traversal, walk_options, root_path) = if let Some(snapshot) =
-                snapshot
-            {
-                let input_paths = snapshot
-                    .roots
-                    .iter()
-                    .map(|root| {
-                        snapshot
-                            .traversal
-                            .tree
-                            .name(*root)
-                            .expect("snapshot root exists")
-                            .into_owned()
-                    })
-                    .collect();
-                (
-                    input_paths,
-                    snapshot.traversal,
-                    snapshot_walk_options(),
-                    None,
-                )
-            } else {
-                let walk_options = walk_options_from(&traversal.scan)?;
-                let has_complete_root = traversal.scan.input.is_empty()
-                    || traversal.scan.input.len() == 1 && traversal.scan.input[0].is_dir();
-                let input_paths = extract_paths_maybe_set_cwd(traversal.scan.input, &walk_options)?;
-                let root_path = has_complete_root.then(std::env::current_dir).transpose()?;
-                (
-                    input_paths,
-                    dua::traverse::Traversal::new(),
-                    walk_options,
-                    root_path,
-                )
-            };
+            let (input_paths, initial_traversal, walk_options, root_path) =
+                if let Some(snapshot) = snapshot {
+                    let input_paths = snapshot
+                        .roots
+                        .iter()
+                        .map(|root| {
+                            snapshot
+                                .traversal
+                                .tree
+                                .name(*root)
+                                .expect("snapshot root exists")
+                                .into_owned()
+                        })
+                        .collect();
+                    (
+                        input_paths,
+                        snapshot.traversal,
+                        snapshot_walk_options(),
+                        None,
+                    )
+                } else {
+                    let walk_options = walk_options_from(&traversal.scan)?;
+                    let (input_paths, root_path) = if clean_depth.is_some() {
+                        (clean_input_paths(traversal.scan.input)?, None)
+                    } else {
+                        let has_complete_root = traversal.scan.input.is_empty()
+                            || traversal.scan.input.len() == 1 && traversal.scan.input[0].is_dir();
+                        let input_paths =
+                            extract_paths_maybe_set_cwd(traversal.scan.input, &walk_options)?;
+                        (
+                            input_paths,
+                            has_complete_root.then(std::env::current_dir).transpose()?,
+                        )
+                    };
+                    (
+                        input_paths,
+                        dua::traverse::Traversal::new(),
+                        walk_options,
+                        root_path,
+                    )
+                };
 
             let no_tty_msg = "Interactive mode requires a connected terminal";
             if !io::stderr().is_terminal() {
@@ -237,7 +271,9 @@ fn main() -> Result<()> {
                 initial_traversal,
                 snapshot_load_duration,
             )?;
-            if let Some(path) = export {
+            if let Some(depth) = clean_depth {
+                app.traverse_clean(depth)?;
+            } else if let Some(path) = export {
                 app.traverse_and_export(path, (compression != 0).then_some(compression))?;
             } else if !read_only {
                 app.traverse()?;
@@ -801,6 +837,27 @@ fn extract_paths_maybe_set_cwd(
         .collect())
 }
 
+#[cfg(feature = "tui-crossplatform")]
+fn clean_input_paths(mut paths: Vec<PathBuf>) -> Result<Vec<PathBuf>> {
+    if paths.is_empty() {
+        paths.push(PathBuf::from("."));
+    }
+    paths
+        .into_iter()
+        .map(|path| {
+            let path = std::path::absolute(path)?;
+            if !path
+                .symlink_metadata()
+                .with_context(|| format!("Could not read clean input {}", path.display()))?
+                .is_dir()
+            {
+                bail!("Clean input {} is not a directory", path.display());
+            }
+            Ok(path)
+        })
+        .collect()
+}
+
 #[cfg(unix)]
 fn device_id(path: &Path) -> io::Result<u64> {
     use std::os::unix::fs::MetadataExt;
@@ -967,6 +1024,27 @@ mod tests {
             "marked��[31m",
             "TAB and ESC control characters are sanitized for terminal output"
         );
+    }
+
+    #[cfg(feature = "tui-crossplatform")]
+    #[test]
+    fn clean_inputs_keep_the_working_directory_and_reject_files() {
+        let cwd = std::env::current_dir().unwrap();
+        assert_eq!(
+            super::clean_input_paths(vec![]).unwrap(),
+            std::slice::from_ref(&cwd)
+        );
+        let fixture = tempfile::tempdir().unwrap();
+        let directory = fixture.path().join("project");
+        fs::create_dir(&directory).unwrap();
+        assert_eq!(
+            super::clean_input_paths(vec![directory.clone()]).unwrap(),
+            [directory]
+        );
+        let file = fixture.path().join("file");
+        fs::write(&file, b"source").unwrap();
+        assert!(super::clean_input_paths(vec![file]).is_err());
+        assert_eq!(std::env::current_dir().unwrap(), cwd);
     }
 
     #[cfg(feature = "tui-crossplatform")]

--- a/src/options.rs
+++ b/src/options.rs
@@ -232,6 +232,22 @@ pub struct StackArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
+    /// Find disposable directories and inspect them in the terminal user interface.
+    #[cfg(feature = "tui-crossplatform")]
+    #[clap(mut_arg("input", |arg| arg.help("Directories to search. Defaults to the current directory.")))]
+    Clean {
+        #[clap(flatten)]
+        traversal: TraversalArgs,
+        /// Limit discovery depth. Input directories have depth 0; found candidates are always sized completely.
+        #[clap(short = 'd', long, value_name = "DEPTH")]
+        depth: Option<usize>,
+        /// Do not check entries for presence when listing a directory on slow filesystems.
+        #[clap(long, short = 'e')]
+        no_entry_check: bool,
+        /// Exit after discovery and sizing, optionally replaying keys first.
+        #[clap(long, num_args = 0..=1, require_equals = true, default_missing_value = "")]
+        once: Option<String>,
+    },
     /// Launch the terminal user interface
     #[cfg(feature = "tui-crossplatform")]
     #[clap(name = "interactive", visible_alias = "i")]
@@ -435,6 +451,38 @@ mod tests {
     fn traversal_options_are_accepted_by_aggregate() {
         Args::try_parse_from(["dua", "aggregate", "--format", "metric", "--threads", "1"])
             .expect("aggregate accepts traversal options");
+    }
+
+    #[cfg(feature = "tui-crossplatform")]
+    #[test]
+    fn clean_accepts_discovery_and_tui_options_without_snapshots() {
+        let args = Args::try_parse_from([
+            "dua",
+            "clean",
+            "--depth",
+            "0",
+            "--format",
+            "bytes",
+            "--threads",
+            "1",
+            "--no-entry-check",
+            "--once=R",
+            "project",
+        ])
+        .expect("clean accepts zero-depth discovery and interactive traversal options");
+        assert!(matches!(args.command, Some(super::Command::Clean {
+            depth: Some(0), no_entry_check: true, once: Some(keys), ..
+        }) if keys == "R"));
+        assert!(matches!(
+            Args::try_parse_from(["dua", "clean"]).unwrap().command,
+            Some(super::Command::Clean { depth: None, .. })
+        ));
+
+        for option in ["--export", "--import", "--compression"] {
+            let error = Args::try_parse_from(["dua", "clean", option, "file"])
+                .expect_err("clean does not expose snapshot options");
+            assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+        }
     }
 
     #[test]

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -5,11 +5,14 @@ use crossbeam::channel::Receiver;
 use filesize::PathExt;
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt, io,
     num::NonZeroU32,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
@@ -464,6 +467,23 @@ impl Tree {
         }
     }
 
+    /// Return the filesystem path formed by the names of `index` and its ancestors.
+    ///
+    /// # Panics
+    /// Panics if `index` is missing.
+    #[must_use]
+    pub fn path_of(&self, index: TreeIndex) -> PathBuf {
+        let names: Vec<_> = std::iter::successors(Some(index), |index| self.parent(*index))
+            .map(|index| self.name(index).expect("node exists"))
+            .collect();
+        names
+            .iter()
+            .rev()
+            .map(|name| name.as_os_str())
+            .filter(|name| !name.is_empty())
+            .collect()
+    }
+
     /// Replace an entry's name. Old arena bytes remain reserved until the tree is dropped.
     pub fn rename(&mut self, index: TreeIndex, name: impl AsRef<Path>) -> Result<(), TreeError> {
         if !self.contains(index) {
@@ -482,7 +502,39 @@ impl Tree {
             return 0;
         }
         self.detach(index);
-        let mut pending = vec![index];
+        self.remove_detached_subtrees(vec![index])
+    }
+
+    /// Remove selected direct children of `parent` and their descendants in one sibling pass.
+    ///
+    /// Missing indices and indices that are not direct children of `parent` are ignored.
+    /// Returns the total number of removed nodes; parent sizes and counts are unchanged.
+    pub fn remove_children(&mut self, parent: TreeIndex, children: &HashSet<TreeIndex>) -> usize {
+        let Some(node) = self.node(parent) else {
+            return 0;
+        };
+        let mut current = node.first_child;
+        let mut previous = NONE;
+        let mut pending = Vec::new();
+        while current != NONE {
+            let index = TreeIndex::from_raw(current);
+            let next = self.nodes[current as usize].next_sibling;
+            if children.contains(&index) {
+                if previous == NONE {
+                    self.nodes[parent.index()].first_child = next;
+                } else {
+                    self.nodes[previous as usize].next_sibling = next;
+                }
+                pending.push(index);
+            } else {
+                previous = current;
+            }
+            current = next;
+        }
+        self.remove_detached_subtrees(pending)
+    }
+
+    fn remove_detached_subtrees(&mut self, mut pending: Vec<TreeIndex>) -> usize {
         let mut removed = 0;
         while let Some(index) = pending.pop() {
             let mut child = self.nodes[index.index()].first_child;
@@ -649,6 +701,8 @@ pub struct Traversal {
     pub tree: Tree,
     /// The top-level node of the tree.
     pub root_index: TreeIndex,
+    /// Original discovery root for each published cleanup candidate, keyed by absolute path.
+    pub clean_search_roots: HashMap<PathBuf, PathBuf>,
     /// The time at which the instance was created, typically the start of the traversal.
     pub start_time: Instant,
     /// The time it cost to compute the traversal, when done.
@@ -670,6 +724,7 @@ impl Traversal {
         Self {
             tree,
             root_index,
+            clean_search_roots: HashMap::new(),
             start_time: Instant::now(),
             cost: None,
         }
@@ -679,6 +734,20 @@ impl Traversal {
     #[must_use]
     pub fn is_costly(&self) -> bool {
         self.cost.is_none_or(|d| d.as_secs_f32() > 10.0)
+    }
+
+    /// Remove selected children and their cleanup provenance in one sibling pass.
+    pub fn remove_children(&mut self, parent: TreeIndex, children: &HashSet<TreeIndex>) -> usize {
+        if parent == self.root_index && !self.clean_search_roots.is_empty() {
+            for &index in children {
+                if self.tree.parent(index) == Some(parent)
+                    && let Some(name) = self.tree.name(index)
+                {
+                    self.clean_search_roots.remove(name.as_ref());
+                }
+            }
+        }
+        self.tree.remove_children(parent, children)
     }
 }
 
@@ -714,6 +783,17 @@ pub struct TraversalEntry(pub(crate) crate::walk::Entry);
 
 /// Events emitted by a background filesystem traversal.
 pub enum TraversalEvent {
+    /// Lightweight discovery progress, as deltas since the previous update.
+    DiscoveryProgress {
+        /// Number of directory entries inspected.
+        entries: u64,
+        /// Number of I/O errors encountered.
+        io_errors: u64,
+    },
+    /// Begin staging a cleanup candidate, with its stream index and original discovery root.
+    CandidateStarted(usize, PathBuf),
+    /// Finish the indexed candidate; only accepted candidates become visible.
+    CandidateFinished(usize, bool),
     /// A discovered entry and its traversal context:
     ///
     /// 0. The discovered entry, or the I/O error encountered while reading it.
@@ -747,9 +827,162 @@ pub struct BackgroundTraversal {
     preexisting_nodes: HashMap<PathBuf, (TreeIndex, bool)>,
     /// Receiver used to obtain traversal events from the worker thread.
     pub event_rx: Receiver<TraversalEvent>,
+    clean_stages: HashMap<usize, CleanStage>,
+    _cancelled: Option<CancelOnDrop>,
+}
+
+struct CleanStage {
+    staging_root: TreeIndex,
+    search_root: PathBuf,
+    /// Only entries affecting shared inode/clone accounting retain their metadata until acceptance.
+    deferred_inodes: Vec<(TreeIndex, crate::walk::Entry, u128)>,
+    valid: bool,
+}
+
+struct CancelOnDrop(Arc<AtomicBool>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+enum CleanInput {
+    Discover {
+        paths: Vec<PathBuf>,
+        depth: Option<usize>,
+        pattern_root: Option<PathBuf>,
+    },
+    Refresh(Vec<(PathBuf, PathBuf)>),
+}
+
+impl CleanInput {
+    fn discover(
+        self,
+        options: WalkOptions,
+        mut send: impl FnMut(crate::clean::DiscoveryEvent) -> bool,
+    ) {
+        match self {
+            Self::Discover {
+                paths,
+                depth,
+                pattern_root,
+            } => {
+                crate::clean::discover(paths, options, depth, pattern_root, send);
+            }
+            Self::Refresh(candidates) => {
+                let mut keep_going = true;
+                for (path, search_root) in candidates {
+                    if !keep_going {
+                        break;
+                    }
+                    crate::clean::discover(
+                        vec![path],
+                        options.clone(),
+                        Some(0),
+                        Some(search_root),
+                        |event| {
+                            keep_going = send(event);
+                            keep_going
+                        },
+                    );
+                }
+            }
+        }
+    }
 }
 
 impl BackgroundTraversal {
+    /// Discover cleanup candidates and publish each root once its detailed scan is complete.
+    pub fn start_clean(
+        root_idx: TreeIndex,
+        walk_options: &WalkOptions,
+        input: Vec<PathBuf>,
+        depth: Option<usize>,
+        pattern_root: Option<&Path>,
+    ) -> anyhow::Result<Self> {
+        Self::start_clean_inner(
+            root_idx,
+            walk_options,
+            CleanInput::Discover {
+                paths: input,
+                depth,
+                pattern_root: pattern_root.map(Path::to_path_buf),
+            },
+        )
+    }
+
+    /// Revalidate published candidate paths with each candidate's original discovery root.
+    pub fn refresh_clean_candidates(
+        root_idx: TreeIndex,
+        walk_options: &WalkOptions,
+        candidates: Vec<(PathBuf, PathBuf)>,
+    ) -> anyhow::Result<Self> {
+        Self::start_clean_inner(root_idx, walk_options, CleanInput::Refresh(candidates))
+    }
+
+    fn start_clean_inner(
+        root_idx: TreeIndex,
+        walk_options: &WalkOptions,
+        input: CleanInput,
+    ) -> anyhow::Result<Self> {
+        let (entry_tx, event_rx) = crossbeam::channel::bounded(100);
+        let cancelled = Arc::new(AtomicBool::new(false));
+        std::thread::Builder::new()
+            .name("dua-clean-dispatcher".into())
+            .spawn({
+                let walk_options = walk_options.clone();
+                let cancelled = Arc::clone(&cancelled);
+                move || {
+                    use crate::clean::DiscoveryEvent;
+                    if walk_options.threads <= 1 {
+                        let mut index = 0;
+                        input.discover(walk_options.clone(), |event| {
+                            if cancelled.load(Ordering::Relaxed) {
+                                return false;
+                            }
+                            match event {
+                                DiscoveryEvent::Candidate { path, search_root } => {
+                                    let keep_going = walk_clean_candidate(
+                                        &walk_options,
+                                        path,
+                                        search_root,
+                                        index,
+                                        &entry_tx,
+                                        &cancelled,
+                                    );
+                                    index += 1;
+                                    keep_going
+                                }
+                                DiscoveryEvent::Progress { entries, io_errors } => entry_tx
+                                    .send(TraversalEvent::DiscoveryProgress { entries, io_errors })
+                                    .is_ok(),
+                            }
+                        });
+                    } else {
+                        walk_clean_candidates(input, &walk_options, &entry_tx, &cancelled);
+                    }
+                    let _ = entry_tx.send(TraversalEvent::Finished);
+                }
+            })?;
+        Ok(Self {
+            walk_options: walk_options.clone(),
+            root_idx,
+            stats: TraversalStats::default(),
+            root_nodes: Vec::new(),
+            nodes_by_directory: Vec::new(),
+            inodes: InodeFilter::default(),
+            throttle: Some(Throttle::new(Duration::from_millis(250), None)),
+            skip_root: false,
+            use_root_path: true,
+            retained_depth: None,
+            preexisting_nodes: HashMap::new(),
+            event_rx,
+            clean_stages: HashMap::new(),
+            _cancelled: Some(CancelOnDrop(cancelled)),
+        })
+    }
+
     /// Start a background thread to perform the actual tree walk, and dispatch the results
     /// as events to be received on [`BackgroundTraversal::event_rx`].
     pub fn start(
@@ -908,6 +1141,8 @@ impl BackgroundTraversal {
             retained_depth: None,
             preexisting_nodes,
             event_rx: entry_rx,
+            clean_stages: HashMap::new(),
+            _cancelled: None,
         })
     }
 
@@ -950,7 +1185,7 @@ impl BackgroundTraversal {
                 .into()
         };
         let node = traversal.tree.add_child(
-            self.root_idx,
+            self.integration_root(root_idx),
             name,
             EntryData {
                 metadata_io_error: true,
@@ -958,9 +1193,11 @@ impl BackgroundTraversal {
                 ..EntryData::default()
             },
         );
-        traversal.tree.update(self.root_idx, |entry| {
-            *entry.entry_count.get_or_insert(0) += 1;
-        });
+        traversal
+            .tree
+            .update(self.integration_root(root_idx), |entry| {
+                *entry.entry_count.get_or_insert(0) += 1;
+            });
         self.root_nodes[root_idx] = Some(node);
     }
 
@@ -969,6 +1206,53 @@ impl BackgroundTraversal {
             self.nodes_by_directory.resize(directory_id + 1, None);
         }
         self.nodes_by_directory[directory_id] = Some(node);
+    }
+
+    fn integration_root(&self, index: usize) -> TreeIndex {
+        self.clean_stages
+            .get(&index)
+            .map_or(self.root_idx, |stage| stage.staging_root)
+    }
+
+    fn commit_clean_inodes(
+        &mut self,
+        traversal: &mut Traversal,
+        entries: Vec<(TreeIndex, crate::walk::Entry, u128)>,
+    ) {
+        for (node, entry, original_size) in entries {
+            let metadata = entry
+                .metadata
+                .as_ref()
+                .and_then(|m| m.as_ref().ok())
+                .expect("accepted metadata");
+            let counted = self.walk_options.count_hard_links || self.inodes.add(&entry, metadata);
+            let size = if counted { original_size } else { 0 };
+            #[cfg(target_os = "macos")]
+            let size = if counted
+                && !self.walk_options.apparent_size
+                && self.walk_options.metadata_options.apfs_clone_metadata
+            {
+                u128::from(self.inodes.allocated_size(metadata))
+            } else {
+                size
+            };
+            let removed_bytes = original_size - size;
+            let removed_entry = u64::from(!counted && !entry.file_type.is_dir());
+            traversal.tree.update(node, |data| {
+                data.size -= removed_bytes;
+                if removed_entry != 0 {
+                    data.entry_count = Some(0);
+                }
+            });
+            let mut ancestor = traversal.tree.parent(node);
+            while let Some(index) = ancestor {
+                traversal.tree.update(index, |data| {
+                    data.size -= removed_bytes;
+                    *data.entry_count.get_or_insert(0) -= removed_entry;
+                });
+                ancestor = traversal.tree.parent(index);
+            }
+        }
     }
 
     /// Integrate `event` into traversal `t` so its information is represented by it.
@@ -993,10 +1277,76 @@ impl BackgroundTraversal {
         event: TraversalEvent,
     ) -> Option<bool> {
         match event {
+            TraversalEvent::DiscoveryProgress { entries, io_errors } => {
+                self.stats.entries_traversed += entries;
+                self.stats.io_errors += io_errors;
+                return self
+                    .throttle
+                    .as_ref()
+                    .is_some_and(|t| t.can_update())
+                    .then_some(false);
+            }
+            TraversalEvent::CandidateStarted(candidate_index, search_root) => {
+                if self.clean_stages.is_empty() {
+                    self.nodes_by_directory.clear();
+                }
+                self.root_nodes
+                    .resize(self.root_nodes.len().max(candidate_index + 1), None);
+                let staging_root = traversal.tree.add_root("", EntryData::default());
+                assert!(
+                    self.clean_stages
+                        .insert(
+                            candidate_index,
+                            CleanStage {
+                                staging_root,
+                                search_root,
+                                deferred_inodes: Vec::new(),
+                                valid: true,
+                            }
+                        )
+                        .is_none()
+                );
+            }
+            TraversalEvent::CandidateFinished(candidate_index, accepted) => {
+                let stage = self
+                    .clean_stages
+                    .remove(&candidate_index)
+                    .expect("candidate has started");
+                let candidate = self.root_nodes[candidate_index];
+                if let Some(candidate) = candidate.filter(|_| accepted && stage.valid) {
+                    self.commit_clean_inodes(traversal, stage.deferred_inodes);
+                    traversal.clean_search_roots.insert(
+                        traversal
+                            .tree
+                            .name(candidate)
+                            .expect("staged root exists")
+                            .into_owned(),
+                        stage.search_root,
+                    );
+                    traversal.tree.detach(candidate);
+                    traversal
+                        .tree
+                        .attach(traversal.root_index, candidate)
+                        .expect("staged root is detached");
+                    let data = traversal.tree.data(candidate).expect("staged root exists");
+                    traversal.tree.update(traversal.root_index, |root| {
+                        root.size += data.size;
+                        *root.entry_count.get_or_insert(0) += data.entry_count.unwrap_or(0);
+                    });
+                } else {
+                    self.root_nodes[candidate_index] = None;
+                }
+                traversal.tree.remove_subtree(stage.staging_root);
+                return Some(false);
+            }
             TraversalEvent::Entry(entry, root_path, device_id, root_idx) => {
                 self.stats.entries_traversed += 1;
+                let is_clean = self.clean_stages.contains_key(&root_idx);
                 let mut data = EntryData::default();
                 let Ok(TraversalEntry(entry)) = entry else {
+                    if let Some(stage) = self.clean_stages.get_mut(&root_idx) {
+                        stage.valid = false;
+                    }
                     self.stats.io_errors += 1;
                     self.record_error_on_root(traversal, root_idx, &root_path);
                     return self
@@ -1018,7 +1368,7 @@ impl BackgroundTraversal {
                 data.is_dir = entry.file_type.is_dir();
                 if let Some(Ok(m)) = &entry.metadata {
                     if self.walk_options.count_hard_links
-                        || self.inodes.add(&entry, m)
+                        || (is_clean || self.inodes.add(&entry, m))
                             && (self.walk_options.cross_filesystems
                                 || crossdev::is_same_device(device_id, m))
                     {
@@ -1032,7 +1382,7 @@ impl BackgroundTraversal {
                                     m,
                                     data.is_dir,
                                     &self.walk_options,
-                                    &mut self.inodes,
+                                    (!is_clean).then_some(&mut self.inodes),
                                 )
                                 .unwrap_or_else(|_| {
                                     self.stats.io_errors += 1;
@@ -1059,6 +1409,11 @@ impl BackgroundTraversal {
 
                 data.mtime = mtime;
                 data.size = file_size;
+                if data.metadata_io_error
+                    && let Some(stage) = self.clean_stages.get_mut(&root_idx)
+                {
+                    stage.valid = false;
+                }
                 if data.is_dir {
                     data.entry_count = Some(1);
                 }
@@ -1101,7 +1456,7 @@ impl BackgroundTraversal {
                 let retain_entry = self.retained_depth.is_none_or(|depth| walk_depth <= depth);
 
                 let parent_index = if walk_depth == 0 {
-                    self.root_idx
+                    self.integration_root(root_idx)
                 } else {
                     let parent_id = entry
                         .parent_directory_id
@@ -1139,11 +1494,25 @@ impl BackgroundTraversal {
                     });
                 }
 
+                if is_clean && InodeFilter::needs_tracking(&entry, &self.walk_options) {
+                    self.clean_stages
+                        .get_mut(&root_idx)
+                        .expect("candidate has started")
+                        .deferred_inodes
+                        .push((
+                            retained_node.expect("clean retains all entries"),
+                            entry,
+                            file_size,
+                        ));
+                }
                 if self.throttle.as_ref().is_some_and(|t| t.can_update()) {
                     return Some(false);
                 }
             }
             TraversalEvent::RootError(root_path, root_idx) => {
+                if let Some(stage) = self.clean_stages.get_mut(&root_idx) {
+                    stage.valid = false;
+                }
                 self.stats.io_errors += 1;
                 self.record_error_on_root(traversal, root_idx, &root_path);
             }
@@ -1165,6 +1534,301 @@ impl BackgroundTraversal {
     }
 }
 
+struct CleanCandidate {
+    path: Arc<PathBuf>,
+    search_root: PathBuf,
+    device: u64,
+    accepted: Arc<AtomicBool>,
+}
+
+impl CleanCandidate {
+    fn new(options: &WalkOptions, path: PathBuf, search_root: PathBuf) -> io::Result<Self> {
+        let device = if options.cross_filesystems {
+            0
+        } else {
+            crossdev::init(&search_root)?
+        };
+        Ok(Self {
+            path: Arc::new(path),
+            search_root,
+            device,
+            accepted: Arc::new(AtomicBool::new(true)),
+        })
+    }
+
+    fn forward_entry(
+        &self,
+        options: &WalkOptions,
+        cwd: &Path,
+        index: usize,
+        entry: io::Result<crate::walk::Entry>,
+        tx: &crossbeam::channel::Sender<TraversalEvent>,
+    ) -> bool {
+        if self.accepted.load(Ordering::Relaxed) {
+            if let Ok(entry) = &entry {
+                let entry_path = entry.path();
+                let excluded = options.ignore_dirs.contains(entry_path.as_path())
+                    || options.ignore_patterns.as_ref().is_some_and(|patterns| {
+                        crate::pattern_relative_path(&entry_path, cwd, &self.search_root)
+                            .is_some_and(|relative| {
+                                patterns.is_excluded(relative, entry.file_type.is_dir())
+                            })
+                    });
+                let boundary = !options.cross_filesystems
+                    && entry
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.as_ref().ok())
+                        .is_some_and(|m| !crossdev::is_same_device(self.device, m));
+                let git_marker = crate::clean::is_git_dir_name(&entry.file_name)
+                    || (entry
+                        .file_name
+                        .as_encoded_bytes()
+                        .eq_ignore_ascii_case(b"HEAD")
+                        && gix::discover::is_git(entry.parent_path.as_ref()).is_ok());
+                if git_marker
+                    || excluded
+                    || boundary
+                    || (entry.depth == 0 && !entry.file_type.is_dir())
+                {
+                    log::debug!(
+                        "Skipping cleanup candidate {} because of {}",
+                        self.path.display(),
+                        entry_path.display()
+                    );
+                    self.accepted.store(false, Ordering::Relaxed);
+                }
+            }
+            if self.accepted.load(Ordering::Relaxed) {
+                let failed = entry
+                    .as_ref()
+                    .map_or(true, |entry| !matches!(&entry.metadata, Some(Ok(_))));
+                if failed {
+                    self.accepted.store(false, Ordering::Relaxed);
+                }
+                return tx
+                    .send(TraversalEvent::Entry(
+                        entry.map(TraversalEntry),
+                        Arc::clone(&self.path),
+                        self.device,
+                        index,
+                    ))
+                    .is_ok();
+            }
+        }
+        // Rejected candidates can still have jobs in flight. Count them while those jobs drain.
+        tx.send(TraversalEvent::DiscoveryProgress {
+            entries: 1,
+            io_errors: 0,
+        })
+        .is_ok()
+    }
+}
+
+fn walk_clean_candidates(
+    input: CleanInput,
+    options: &WalkOptions,
+    tx: &crossbeam::channel::Sender<TraversalEvent>,
+    cancelled: &Arc<AtomicBool>,
+) {
+    std::thread::scope(|scope| {
+        // One discovery reader and a shared sizing pool, within the existing I/O thread budget.
+        let (mut roots, walk) = crate::walk::stream_roots(
+            options.threads - 1,
+            crate::walk::Order::ParentFirst,
+            options.metadata_options,
+        );
+        let (candidate_tx, candidate_rx) = crossbeam::channel::bounded(32);
+        // Bound active candidate staging, not just the queue waiting to reach the walker.
+        let (slot_tx, slot_rx) = crossbeam::channel::bounded(32);
+        for _ in 0..32 {
+            slot_tx.send(()).expect("slots fit");
+        }
+        let discovery = std::thread::Builder::new()
+            .name("dua-clean-discovery".into())
+            .spawn_scoped(scope, move || {
+                let mut index = 0;
+                input.discover(options.clone(), |event| {
+                    if cancelled.load(Ordering::Relaxed) {
+                        return false;
+                    }
+                    match event {
+                        crate::clean::DiscoveryEvent::Progress { entries, io_errors } => tx
+                            .send(TraversalEvent::DiscoveryProgress { entries, io_errors })
+                            .is_ok(),
+                        crate::clean::DiscoveryEvent::Candidate { path, search_root } => {
+                            let candidate =
+                                match CleanCandidate::new(options, path.clone(), search_root) {
+                                    Ok(candidate) => candidate,
+                                    Err(err) => {
+                                        log::debug!(
+                                            "Could not inspect cleanup root {}: {err}",
+                                            path.display()
+                                        );
+                                        return tx
+                                            .send(TraversalEvent::DiscoveryProgress {
+                                                entries: 0,
+                                                io_errors: 1,
+                                            })
+                                            .is_ok();
+                                    }
+                                };
+                            if slot_rx.recv().is_err() {
+                                return false;
+                            }
+                            let device = candidate.device;
+                            let accepted = Arc::clone(&candidate.accepted);
+                            let cancelled = Arc::clone(cancelled);
+                            let cross_filesystems = options.cross_filesystems;
+                            if candidate_tx.send((index, candidate)).is_err() {
+                                return false;
+                            }
+                            let submitted = roots
+                                .add_root(index, path, move |entry| {
+                                    accepted.load(Ordering::Relaxed)
+                                        && !cancelled.load(Ordering::Relaxed)
+                                        && (cross_filesystems
+                                            || entry
+                                                .metadata
+                                                .as_ref()
+                                                .and_then(|m| m.as_ref().ok())
+                                                .is_none_or(|m| {
+                                                    crossdev::is_same_device(device, m)
+                                                }))
+                                })
+                                .is_ok();
+                            index += 1;
+                            submitted
+                        }
+                    }
+                });
+            });
+        if let Err(err) = discovery {
+            log::error!("Could not start cleanup discovery: {err}");
+            let _ = tx.send(TraversalEvent::DiscoveryProgress {
+                entries: 0,
+                io_errors: 1,
+            });
+            return;
+        }
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let mut candidates = HashMap::new();
+        for (index, event) in walk {
+            if cancelled.load(Ordering::Relaxed) {
+                break;
+            }
+            // Discovery queues context before submitting a root, so it is available even when
+            // another root's metadata finishes first.
+            while !candidates.contains_key(&index) {
+                let (candidate_index, candidate) =
+                    candidate_rx.recv().expect("submitted root has context");
+                if tx
+                    .send(TraversalEvent::CandidateStarted(
+                        candidate_index,
+                        candidate.search_root.clone(),
+                    ))
+                    .is_err()
+                {
+                    cancelled.store(true, Ordering::Relaxed);
+                    break;
+                }
+                candidates.insert(candidate_index, candidate);
+            }
+            if cancelled.load(Ordering::Relaxed) {
+                break;
+            }
+            let keep_going = match event {
+                crate::walk::RootEvent::Entry(entry) => {
+                    candidates[&index].forward_entry(options, &cwd, index, entry, tx)
+                }
+                crate::walk::RootEvent::Finished => {
+                    let candidate = candidates.remove(&index).expect("root has started");
+                    let sent = tx
+                        .send(TraversalEvent::CandidateFinished(
+                            index,
+                            candidate.accepted.load(Ordering::Relaxed),
+                        ))
+                        .is_ok();
+                    slot_tx.send(()).ok();
+                    sent
+                }
+            };
+            if !keep_going {
+                cancelled.store(true, Ordering::Relaxed);
+                break;
+            }
+        }
+        // Unblock discovery before the scope joins it, including cancellation while at capacity.
+        drop(slot_tx);
+        drop(candidate_rx);
+    });
+}
+
+fn walk_clean_candidate(
+    options: &WalkOptions,
+    path: PathBuf,
+    search_root: PathBuf,
+    index: usize,
+    tx: &crossbeam::channel::Sender<TraversalEvent>,
+    cancelled: &AtomicBool,
+) -> bool {
+    if cancelled.load(Ordering::Relaxed) {
+        return false;
+    }
+    let candidate = match CleanCandidate::new(options, path, search_root) {
+        Ok(candidate) => candidate,
+        Err(err) => {
+            log::debug!("Could not inspect cleanup root: {err}");
+            return tx
+                .send(TraversalEvent::DiscoveryProgress {
+                    entries: 0,
+                    io_errors: 1,
+                })
+                .is_ok();
+        }
+    };
+    if tx
+        .send(TraversalEvent::CandidateStarted(
+            index,
+            candidate.search_root.clone(),
+        ))
+        .is_err()
+    {
+        return false;
+    }
+    // Inspect exclusions as well: deleting their containing candidate would delete them too.
+    let mut unfiltered = options.clone();
+    unfiltered.ignore_dirs.clear();
+    unfiltered.ignore_patterns = None;
+    let roots = vec![WalkRoot {
+        index: 0,
+        path: candidate.path.as_ref().clone(),
+        #[cfg(any(windows, target_os = "macos"))]
+        entry: None,
+        pattern_root: None,
+        device_id: candidate.device,
+    }];
+    let cwd = std::env::current_dir().unwrap_or_default();
+    for (_, event) in unfiltered.iter_from_paths(roots, false, crate::walk::Order::ParentFirst) {
+        if cancelled.load(Ordering::Relaxed) {
+            return false;
+        }
+        if let crate::walk::RootEvent::Entry(entry) = event {
+            if !candidate.forward_entry(options, &cwd, index, entry, tx) {
+                return false;
+            }
+            if !candidate.accepted.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+    }
+    tx.send(TraversalEvent::CandidateFinished(
+        index,
+        candidate.accepted.load(Ordering::Relaxed),
+    ))
+    .is_ok()
+}
+
 #[cfg(not(any(windows, target_os = "macos")))]
 /// Return disk usage for `name` on Unix-like platforms.
 fn size_on_disk(
@@ -1173,7 +1837,7 @@ fn size_on_disk(
     meta: &crate::walk::Metadata,
     _is_dir: bool,
     _options: &WalkOptions,
-    _inodes: &mut InodeFilter,
+    _inodes: Option<&mut InodeFilter>,
 ) -> io::Result<u64> {
     name.size_on_disk_fast(meta)
 }
@@ -1187,13 +1851,14 @@ fn size_on_disk(
     meta: &crate::walk::Metadata,
     _is_dir: bool,
     options: &WalkOptions,
-    inodes: &mut InodeFilter,
+    inodes: Option<&mut InodeFilter>,
 ) -> io::Result<u64> {
-    Ok(if options.metadata_options.apfs_clone_metadata {
-        inodes.allocated_size(meta)
-    } else {
-        meta.allocated_size()
-    })
+    Ok(inodes
+        .filter(|_| options.metadata_options.apfs_clone_metadata)
+        .map_or_else(
+            || meta.allocated_size(),
+            |inodes| inodes.allocated_size(meta),
+        ))
 }
 
 #[cfg(windows)]
@@ -1205,7 +1870,7 @@ fn size_on_disk(
     meta: &crate::walk::Metadata,
     is_dir: bool,
     _options: &WalkOptions,
-    _inodes: &mut InodeFilter,
+    _inodes: Option<&mut InodeFilter>,
 ) -> io::Result<u64> {
     Ok(if is_dir { 0 } else { meta.allocated_size() })
 }
@@ -1213,6 +1878,379 @@ fn size_on_disk(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn clean_walk_options() -> WalkOptions {
+        WalkOptions {
+            threads: 2,
+            count_hard_links: false,
+            apparent_size: true,
+            cross_filesystems: true,
+            ignore_dirs: std::collections::BTreeSet::new(),
+            ignore_patterns: None,
+            metadata_options: crate::TraversalOptions::default(),
+        }
+    }
+
+    #[test]
+    fn clean_candidates_can_finish_out_of_order_without_sharing_unaccepted_inodes() {
+        let directory = tempfile::tempdir().unwrap();
+        let paths = ["slow", "fast", "last"].map(|name| directory.path().join(name));
+        for path in &paths {
+            std::fs::create_dir(path).unwrap();
+        }
+        std::fs::write(paths[0].join("payload"), b"content").unwrap();
+        for path in &paths[1..] {
+            std::fs::hard_link(paths[0].join("payload"), path.join("payload")).unwrap();
+        }
+        let mut traversal = Traversal::new();
+        let options = clean_walk_options();
+        let mut background = BackgroundTraversal::start_clean(
+            traversal.root_index,
+            &options,
+            vec![directory.path().to_owned()],
+            Some(0),
+            None,
+        )
+        .unwrap();
+        while background
+            .integrate_traversal_event(&mut traversal, background.event_rx.recv().unwrap())
+            != Some(true)
+        {}
+
+        for index in 0..2 {
+            background.integrate_traversal_event(
+                &mut traversal,
+                TraversalEvent::CandidateStarted(index, directory.path().to_owned()),
+            );
+        }
+        for (index, path) in paths[..2].iter().enumerate() {
+            for entry in crate::walk::walk(
+                path,
+                1,
+                crate::walk::Order::ParentFirst,
+                options.metadata_options,
+                |_| true,
+            ) {
+                background.integrate_traversal_event(
+                    &mut traversal,
+                    TraversalEvent::Entry(
+                        entry.map(TraversalEntry),
+                        Arc::new(path.clone()),
+                        0,
+                        index,
+                    ),
+                );
+            }
+        }
+        assert_eq!(traversal.tree.children(traversal.root_index).count(), 0);
+        background
+            .integrate_traversal_event(&mut traversal, TraversalEvent::CandidateFinished(1, true));
+        let fast = background.root_nodes[1].unwrap();
+        let payload = traversal.tree.children(fast).next().unwrap();
+        assert_eq!(traversal.tree.data(payload).unwrap().size, 7);
+        assert_eq!(traversal.tree.children(traversal.root_index).count(), 1);
+        background
+            .integrate_traversal_event(&mut traversal, TraversalEvent::CandidateFinished(0, false));
+        background.integrate_traversal_event(
+            &mut traversal,
+            TraversalEvent::CandidateStarted(2, directory.path().to_owned()),
+        );
+        for entry in crate::walk::walk(
+            &paths[2],
+            1,
+            crate::walk::Order::ParentFirst,
+            options.metadata_options,
+            |_| true,
+        ) {
+            background.integrate_traversal_event(
+                &mut traversal,
+                TraversalEvent::Entry(entry.map(TraversalEntry), Arc::new(paths[2].clone()), 0, 2),
+            );
+        }
+        background
+            .integrate_traversal_event(&mut traversal, TraversalEvent::CandidateFinished(2, true));
+        let last = background.root_nodes[2].unwrap();
+        let payload = traversal.tree.children(last).next().unwrap();
+        assert_eq!(
+            traversal.tree.data(payload).unwrap().size,
+            0,
+            "rejecting the slow root must not erase the fast root's accepted accounting"
+        );
+        assert!(background.clean_stages.is_empty());
+        assert!(background.root_nodes[0].is_none());
+    }
+
+    #[test]
+    fn clean_streams_more_candidates_than_its_capacity_with_any_thread_budget() {
+        let directory = tempfile::tempdir().unwrap();
+        for index in 0..40 {
+            let candidate = directory
+                .path()
+                .join(format!("project-{index}/node_modules"));
+            std::fs::create_dir_all(candidate.join("child")).unwrap();
+            std::fs::write(candidate.join("child/payload"), b"content").unwrap();
+            if index % 10 == 0 {
+                std::fs::create_dir(candidate.join("child/.git")).unwrap();
+            }
+        }
+        for threads in [1, 2, 4] {
+            let mut traversal = Traversal::new();
+            let mut options = clean_walk_options();
+            options.threads = threads;
+            let mut background = BackgroundTraversal::start_clean(
+                traversal.root_index,
+                &options,
+                vec![directory.path().to_owned()],
+                None,
+                None,
+            )
+            .unwrap();
+            loop {
+                let event = background
+                    .event_rx
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("scan makes progress");
+                if background.integrate_traversal_event(&mut traversal, event) == Some(true) {
+                    break;
+                }
+            }
+            assert_eq!(traversal.tree.children(traversal.root_index).count(), 36);
+            assert_eq!(background.stats.io_errors, 0);
+            assert!(background.clean_stages.is_empty());
+            for root in traversal.tree.children(traversal.root_index) {
+                let child = traversal.tree.children(root).next().unwrap();
+                let payload = traversal.tree.children(child).next().unwrap();
+                assert_eq!(traversal.tree.data(payload).unwrap().size, 7);
+            }
+        }
+    }
+
+    #[test]
+    fn clean_roots_are_published_only_after_sizing_and_vetting() {
+        let directory = tempfile::tempdir().unwrap();
+        let good = directory.path().join("good/node_modules");
+        let bad = directory.path().join("bad/node_modules");
+        std::fs::create_dir_all(&good).unwrap();
+        std::fs::create_dir_all(bad.join("nested/.git")).unwrap();
+        std::fs::write(good.join("payload"), b"content").unwrap();
+        std::fs::write(bad.join("payload"), b"private").unwrap();
+        let mut traversal = Traversal::new();
+        let mut background = BackgroundTraversal::start_clean(
+            traversal.root_index,
+            &clean_walk_options(),
+            vec![directory.path().to_owned()],
+            None,
+            None,
+        )
+        .unwrap();
+        let mut published = 0;
+        loop {
+            let event = background.event_rx.recv().unwrap();
+            if matches!(&event, TraversalEvent::CandidateFinished(_, true)) {
+                published += 1;
+            }
+            let finished = background.integrate_traversal_event(&mut traversal, event);
+            assert_eq!(
+                traversal.tree.children(traversal.root_index).count(),
+                published,
+                "in-progress and rejected candidates must remain hidden"
+            );
+            if finished == Some(true) {
+                break;
+            }
+        }
+        let roots = traversal
+            .tree
+            .children(traversal.root_index)
+            .collect::<Vec<_>>();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(
+            traversal.tree.name(roots[0]).unwrap(),
+            good.canonicalize().unwrap()
+        );
+        assert_eq!(traversal.tree.children(roots[0]).count(), 1);
+        assert!(traversal.tree.data(roots[0]).unwrap().size >= 7);
+        assert_eq!(
+            traversal.tree.len(),
+            3,
+            "discarded staging trees leave no live nodes"
+        );
+        assert_eq!(background.stats.io_errors, 0);
+        assert_eq!(traversal.clean_search_roots.len(), 1);
+        traversal.remove_children(roots[0], &traversal.tree.children(roots[0]).collect());
+        assert_eq!(traversal.clean_search_roots.len(), 1);
+        traversal.remove_children(traversal.root_index, &HashSet::from([roots[0]]));
+        assert!(traversal.clean_search_roots.is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn concurrent_clean_candidates_deduplicate_only_accepted_apfs_clones() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let directory = tempfile::tempdir().unwrap();
+        let paths =
+            ["bad", "first", "second"].map(|name| directory.path().join(name).join("node_modules"));
+        for path in &paths {
+            std::fs::create_dir_all(path).unwrap();
+        }
+        std::fs::create_dir_all(paths[0].join("nested/.git")).unwrap();
+        let original = paths[0].join("payload");
+        std::fs::write(&original, vec![1; 8192]).unwrap();
+        for path in &paths[1..] {
+            std::fs::copy(&original, path.join("payload")).unwrap();
+        }
+        let allocated = u128::from(std::fs::metadata(&original).unwrap().blocks()) * 512;
+        for deduplicate in [false, true] {
+            let mut options = clean_walk_options();
+            options.threads = 4;
+            options.apparent_size = false;
+            options.metadata_options.apfs_clone_metadata = deduplicate;
+            let mut traversal = Traversal::new();
+            let mut background = BackgroundTraversal::start_clean(
+                traversal.root_index,
+                &options,
+                vec![directory.path().to_owned()],
+                None,
+                None,
+            )
+            .unwrap();
+            while background
+                .integrate_traversal_event(&mut traversal, background.event_rx.recv().unwrap())
+                != Some(true)
+            {}
+            assert_eq!(traversal.clean_search_roots.len(), 2);
+            let total: u128 = traversal
+                .tree
+                .children(traversal.root_index)
+                .map(|root| {
+                    let payload = traversal.tree.children(root).next().unwrap();
+                    traversal.tree.data(payload).unwrap().size
+                })
+                .sum();
+            assert_eq!(total, allocated * if deduplicate { 1 } else { 2 });
+        }
+    }
+
+    #[test]
+    fn clean_rejects_case_variants_of_nested_gitfiles() {
+        for marker in [".git", ".GIT", ".Git"] {
+            let directory = tempfile::tempdir().unwrap();
+            let repo = gix::init(directory.path().join("admin")).unwrap();
+            let search = directory.path().join("scan");
+            let nested = search.join("node_modules/nested");
+            std::fs::create_dir_all(&nested).unwrap();
+            std::fs::write(
+                nested.join(marker),
+                format!("gitdir: {}\n", repo.path().display()),
+            )
+            .unwrap();
+            let mut traversal = Traversal::new();
+            let mut background = BackgroundTraversal::start_clean(
+                traversal.root_index,
+                &clean_walk_options(),
+                vec![search],
+                None,
+                None,
+            )
+            .unwrap();
+            while background
+                .integrate_traversal_event(&mut traversal, background.event_rx.recv().unwrap())
+                != Some(true)
+            {}
+            assert_eq!(traversal.tree.len(), 1, "protect the {marker} worktree");
+            assert!(traversal.clean_search_roots.is_empty());
+        }
+    }
+
+    #[test]
+    fn clean_empty_scan_finishes_without_roots() {
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("ordinary"), b"content").unwrap();
+        let mut traversal = Traversal::new();
+        let mut background = BackgroundTraversal::start_clean(
+            traversal.root_index,
+            &clean_walk_options(),
+            vec![directory.path().to_owned()],
+            None,
+            None,
+        )
+        .unwrap();
+        while background
+            .integrate_traversal_event(&mut traversal, background.event_rx.recv().unwrap())
+            != Some(true)
+        {}
+        assert_eq!(traversal.tree.len(), 1);
+        assert_eq!(background.stats.total_bytes, Some(0));
+        assert!(background.stats.elapsed.is_some());
+    }
+
+    #[test]
+    fn clean_rejection_restores_hardlink_accounting() {
+        let directory = tempfile::tempdir().unwrap();
+        let bad = directory.path().join("a/node_modules");
+        let good = directory.path().join("b/node_modules");
+        std::fs::create_dir_all(bad.join("nested/repo/.git")).unwrap();
+        std::fs::create_dir_all(&good).unwrap();
+        std::fs::write(bad.join("payload"), b"content").unwrap();
+        std::fs::hard_link(bad.join("payload"), good.join("payload")).unwrap();
+        let mut traversal = Traversal::new();
+        let mut background = BackgroundTraversal::start_clean(
+            traversal.root_index,
+            &clean_walk_options(),
+            vec![bad, good.clone()],
+            None,
+            None,
+        )
+        .unwrap();
+        while background
+            .integrate_traversal_event(&mut traversal, background.event_rx.recv().unwrap())
+            != Some(true)
+        {}
+        let roots = traversal
+            .tree
+            .children(traversal.root_index)
+            .collect::<Vec<_>>();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(
+            traversal.tree.name(roots[0]).unwrap(),
+            good.canonicalize().unwrap()
+        );
+        let payload = traversal.tree.children(roots[0]).next().unwrap();
+        assert_eq!(
+            traversal.tree.data(payload).unwrap().size,
+            7,
+            "a rejected root must not consume the accepted root's hardlink accounting"
+        );
+    }
+
+    #[test]
+    fn clean_rejects_containers_of_excluded_entries() {
+        let directory = tempfile::tempdir().unwrap();
+        let candidate = directory.path().join("node_modules");
+        let protected = candidate.join("precious");
+        std::fs::create_dir_all(&protected).unwrap();
+        std::fs::write(protected.join("file"), b"keep").unwrap();
+        let mut options = clean_walk_options();
+        options
+            .ignore_dirs
+            .insert(protected.canonicalize().unwrap());
+        let mut traversal = Traversal::new();
+        let mut background = BackgroundTraversal::start_clean(
+            traversal.root_index,
+            &options,
+            vec![candidate],
+            None,
+            None,
+        )
+        .unwrap();
+        while background
+            .integrate_traversal_event(&mut traversal, background.event_rx.recv().unwrap())
+            != Some(true)
+        {}
+        assert_eq!(traversal.tree.len(), 1);
+        assert_eq!(background.stats.io_errors, 0);
+    }
 
     #[test]
     fn ancestor_sizes_update_before_traversal_finishes() {
@@ -1551,6 +2589,55 @@ mod tests {
         );
         assert_eq!(tree.name(reused).as_deref(), Some(Path::new("reused")));
         assert_eq!(tree.children(root).collect::<Vec<_>>(), [reused, kept]);
+    }
+
+    #[test]
+    fn tree_removes_selected_children_in_one_batch() {
+        let mut tree = Tree::new();
+        let root_data = EntryData {
+            size: 100,
+            entry_count: Some(10),
+            ..EntryData::default()
+        };
+        let root = tree.add_root("root", root_data);
+        let tail = tree.add_child(root, "tail", EntryData::default());
+        let kept = tree.add_child(root, "kept", EntryData::default());
+        let kept_child = tree.add_child(kept, "kept-child", EntryData::default());
+        let middle = tree.add_child(root, "middle", EntryData::default());
+        let nested = tree.add_child(middle, "nested", EntryData::default());
+        let head = tree.add_child(root, "head", EntryData::default());
+        let other_root = tree.add_root("other", EntryData::default());
+        let other_child = tree.add_child(other_root, "other-child", EntryData::default());
+        let missing = TreeIndex::from(100_usize);
+
+        assert_eq!(
+            tree.remove_children(
+                root,
+                &HashSet::from([head, middle, tail, nested, kept_child, other_child, missing]),
+            ),
+            4,
+            "only selected direct children and their subtrees are removed"
+        );
+        assert_eq!(tree.len(), 5);
+        assert_eq!(tree.children(root).collect::<Vec<_>>(), [kept]);
+        assert_eq!(tree.children(kept).collect::<Vec<_>>(), [kept_child]);
+        assert_eq!(tree.children(other_root).collect::<Vec<_>>(), [other_child]);
+        assert_eq!(
+            tree.data(root),
+            Some(root_data),
+            "accounting remains with the caller"
+        );
+        assert_eq!(tree.remove_children(missing, &HashSet::from([kept])), 0);
+        assert_eq!(tree.remove_children(root, &HashSet::new()), 0);
+
+        let reused = tree.add_child(root, "reused", EntryData::default());
+        assert!([head, middle, nested, tail].contains(&reused));
+        assert_eq!(tree.children(root).collect::<Vec<_>>(), [reused, kept]);
+        assert_eq!(
+            tree.remove_children(root, &HashSet::from([reused, kept])),
+            3
+        );
+        assert!(tree.children(root).next().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Tasks

This section is for Byron only. Models continuing this PR must not add, remove, check, uncheck, rename, or reorder checkboxes here.

- [ ] refackiew

----

Everything below this line was generated by `Codex`.

Created by Codex on behalf of Byron. Byron will review before this is ready to merge.

## Changes

`dua clean [DIRECTORY]...` finds disposable directories, sizes them, and opens the existing TUI. Multiple sibling candidates share a virtual parent; deeper candidates join their nearest containing group, keeping a Python project's caches together. Group sizes and counts include only the candidates. Marking or deleting a group operates on its candidates and preserves the parent and ordinary source files. Single candidates outside groups remain separate roots.

Discovery reads directory entries/types before detailed size scans and prunes matched artifacts and Git internals. Supported names cover Node dependencies, Python caches and virtual environments, Cargo build output, and Zig's `.zig-cache`, legacy `zig-cache`, and `zig-out`. Cargo and virtualenv candidates require project markers. Within Git worktrees, candidates must be ignored and wholly untracked, including conflict stages and gitlink/sparse ancestors. Failed Git checks, nested repositories, unreadable contents, traversal exclusions, and filesystem boundaries reject the candidate.

Group refresh revalidates recorded members using their original ignore-pattern roots without discovering siblings or scanning the real parent. Navigation is restored and groups that lose their siblings are flattened. Full refresh repeats discovery in the original search directories. Marks are cleared before indices are reused. The command supports `--depth`, traversal options, `--once`, and `--no-entry-check`; snapshot import/export and parent scanning are unavailable.

Discovery submits new candidates to a running walker that shares the existing thread budget. Candidates are sized concurrently and published independently, allowing a fast cache to appear while an earlier, slower cache is still scanning. Workers check new roots between directory jobs; the pool stays alive through discovery gaps and finishes after submissions close and all roots complete. The single-thread path remains sequential, and at most 32 candidates are active.

Each candidate has a separate staging tree. Shared hardlink/APFS accounting is committed only after validation, so rejected candidates cannot consume or undo another candidate's accounting. Closing submissions does not block on a full output channel, and walker shutdown disconnects that channel before joining workers.

Active scans also redraw once a second during gaps in traversal events, keeping counters and visible rows current without keyboard input. Refreshing from inside a candidate revalidates the whole owning candidate and restores the current directory if it remains safe.

Discovery and candidate scans conservatively protect ASCII case variants of Git markers, including `.GIT` gitfiles pointing outside the search directory. The regression covers lower, upper, and mixed-case spellings. Git reference: `1630431f32`, `t/t0001-init.sh` separate-git-dir cases.

## Validation

- Deterministic regression holds one root blocked while a newly submitted root completes with the same two workers. Further submissions work after the pool becomes idle.
- Scheduling, full-output cancellation, 40 candidates with 1/2/4 threads, and interleaved hardlink/APFS acceptance/rejection regressions pass.
- Linux and Windows cross-compilation pass.
- A regression holds the input and traversal channels quiet and verifies that counters, rows, and the terminal buffer update during the scan. A live terminal scan also produced output in every second without keyboard input.
- Interior refresh regressions cover both `r` and `R` at multiple depths, including a newly added Git marker outside the selected subtree.
- Regression tests first reproduced missing discovery/publication, unsafe tracked candidates, conflict-stage/gitlink gaps, changing ignore scope on refresh, walker shutdown, grouping containment, and missing Zig cache discovery.
- Cleanup journeys cover nested grouping, aggregate sizes, partial/full mark toggles, actual deletion with source preservation, similarly prefixed projects, and refresh without widening scope.
- Zig fixtures cover current and legacy cache names, build output, subtree pruning, ignored caches, unignored directories, and tracked output.
- `make check-pre-push`: feature combinations, workspace tests, formatting, Clippy, and stateless journeys.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
- Read-only PTY smoke: Ghostty's `.zig-cache` and `zig-out` appeared together
  beneath a virtual parent with two candidates.
- Snapshot fixtures initialize the new runtime grouping flag; the wire format is unchanged.

Git behavior reference: `1630431f32` (`v2.55.GIT`), `Documentation/git-clean.adoc`, and `t/t7300-clean.sh` cases for ignored tracked directories, nested worktrees, and submodules. Gitoxide's `gitoxide-core/src/organize.rs` informed repository-boundary pruning. Ghostty's build layout and ignore patterns informed Zig support.

## Reported issue


```text
$issue-full-auto Add a `dua clean` subcommand which similar to https://github.com/ByteAtATime/oweka provides a TUI that offers directories to delete. Re-use the existing TUI for `interactive` mode, but list only directories that were found using heuristics as roots.
To find these roots, consider using a search that is shallow, and uses well-known directory names, with an initial traversal that doesn't query metadata, just directory entries and types. Once a root is found, it's scheduled for a detailed traversal to learn about file-sizes as well and ultimately be added as root to the interactive tree. `--export` should naturally not be included in `clean`.
```

Additional user guidance:

```text
And when Git is compiled in and available, double-check that the candidates aren't actually tracked to avoid proposing the deletion of important directories. Maybe also consider ambiguity, i.e. expect deletable items to be gitignored.
```

