### PR TITLE
feat: minimize right-hand panels with ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ Launch into interactive mode with the `i` or `interactive` subcommand. Get help 
 shortcuts with `?`.
 Use this mode to explore, and/or to delete files and directories to release disk space.
 
+Press `]` to minimize or restore the entire right side. `Tab` cycles through visible panes;
+`?` restores and focuses Help when the right side is minimized.
+
 Please note that great care has been taken to prevent accidental deletions due to a multi-stage
 process, which makes this mode viable for exploration.
 
@@ -291,6 +294,7 @@ For example:
 esc_navigates_back = true
 
 close_pane = "esc"
+toggle_right_panes = "]"
 sort_by_name = "ctrl+n"
 
 # Disable permanent deletion and moving entries to the trash.

--- a/src/config.rs
+++ b/src/config.rs
@@ -443,8 +443,10 @@ pub struct KeysConfig {
     pub suspend: KeyBindings,
     /// Clear and repaint the screen.
     pub repaint: KeyBindings,
-    /// Move focus to the next open pane.
+    /// Move focus to the next visible pane.
     pub cycle_panes: KeyBindings,
+    /// Minimize or restore the entire right side.
+    pub toggle_right_panes: KeyBindings,
     /// Show or hide help.
     pub toggle_help: KeyBindings,
     /// Open the glob-search pane.
@@ -537,6 +539,7 @@ impl Default for KeysConfig {
             suspend: KeyBindings::defaults(&["ctrl+z"]),
             repaint: KeyBindings::defaults(&["ctrl+l"]),
             cycle_panes: KeyBindings::defaults(&["tab"]),
+            toggle_right_panes: KeyBindings::defaults(&["]"]),
             toggle_help: KeyBindings::defaults(&["?"]),
             open_search: KeyBindings::defaults(&["/"]),
             move_down: KeyBindings::defaults(&["j", "down"]),
@@ -655,6 +658,7 @@ impl Config {
             "# suspend = \"ctrl+z\" # Unix only.\n",
             "# repaint = \"ctrl+l\"\n",
             "# cycle_panes = \"tab\"\n",
+            "# toggle_right_panes = \"]\" # Minimize or restore the entire right side.\n",
             "# toggle_help = \"?\"\n",
             "# open_search = \"/\"\n",
             "#\n",
@@ -741,6 +745,7 @@ mod tests {
             "suspend",
             "repaint",
             "cycle_panes",
+            "toggle_right_panes",
             "toggle_help",
             "open_search",
             "move_down",

--- a/src/interactive/app/eventloop.rs
+++ b/src/interactive/app/eventloop.rs
@@ -624,6 +624,9 @@ impl AppState {
                 _ if keys.cycle_panes.matches(key) => {
                     self.cycle_focus(window);
                 }
+                _ if !glob_focussed && keys.toggle_right_panes.matches(key) => {
+                    self.toggle_right_panes(window);
+                }
                 _ if !glob_focussed && keys.open_search.matches(key) => {
                     self.toggle_glob_search(window);
                 }

--- a/src/interactive/app/handlers.rs
+++ b/src/interactive/app/handlers.rs
@@ -296,7 +296,28 @@ impl AppState {
         }
     }
 
+    pub fn toggle_right_panes(&mut self, window: &mut MainWindow) {
+        if window.help.is_none() && window.mark.is_none() {
+            return;
+        }
+        window.right_panes_minimized = !window.right_panes_minimized;
+        if window.right_panes_minimized {
+            if let Some(pane) = window.mark.as_mut() {
+                pane.set_focus(false);
+            }
+            if matches!(self.focussed, Help | Mark) {
+                self.focussed = Main;
+            }
+        }
+    }
+
     pub fn toggle_help_pane(&mut self, window: &mut MainWindow) {
+        if window.right_panes_minimized {
+            window.right_panes_minimized = false;
+            window.help.get_or_insert_with(HelpPane::default);
+            self.focussed = Help;
+            return;
+        }
         self.focussed = match self.focussed {
             Main | Mark | Glob => {
                 window.help = Some(HelpPane::default());
@@ -311,6 +332,14 @@ impl AppState {
     pub fn cycle_focus(&mut self, window: &mut MainWindow) {
         if let Some(p) = window.mark.as_mut() {
             p.set_focus(false);
+        }
+        if window.right_panes_minimized {
+            self.focussed = if self.focussed == Main && window.glob.is_some() {
+                Glob
+            } else {
+                Main
+            };
+            return;
         }
         self.focussed = match (
             self.focussed,
@@ -339,6 +368,9 @@ impl AppState {
     ) where
         B: Backend,
     {
+        if window.right_panes_minimized {
+            return;
+        }
         let res = window
             .mark
             .take()

--- a/src/interactive/app/tests/journeys_readonly.rs
+++ b/src/interactive/app/tests/journeys_readonly.rs
@@ -20,6 +20,121 @@ use crate::interactive::{
 };
 
 #[test]
+fn minimized_right_panes_preserve_state_and_skip_focus() -> Result<()> {
+    use crate::interactive::state::FocussedPane::{Glob, Help, Main, Mark};
+
+    let fixture = tempfile::tempdir()?;
+    let paths = [fixture.path().join("first"), fixture.path().join("second")];
+    for path in &paths {
+        fs::write(path, b"keep")?;
+    }
+    let (mut terminal, mut app) = initialized_app_and_terminal_from_paths(&paths)?;
+    app.process_events_once(&mut terminal, into_codes("x?j"))?;
+    let help_scroll = app.window.help.as_ref().unwrap().scroll;
+    assert!(help_scroll > 0);
+    assert!(app.state.focussed == Help);
+
+    app.process_events_once(&mut terminal, into_codes("]"))?;
+    assert!(
+        app.state.focussed == Main,
+        "minimizing returns focus to the list"
+    );
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(app.state.focussed == Main, "Tab skips minimized panes");
+    app.process_events_once(
+        &mut terminal,
+        into_events(
+            ['r', 't']
+                .map(|key| Event::Key(KeyEvent::new(KeyCode::Char(key), KeyModifiers::CONTROL))),
+        ),
+    )?;
+    for path in &paths {
+        assert_eq!(
+            fs::read(path)?,
+            b"keep",
+            "minimized marks cannot be deleted"
+        );
+    }
+    assert_eq!(app.window.mark.as_ref().unwrap().marked().len(), 1);
+    assert_eq!(terminal.backend().buffer()[(38, 11)].symbol(), "1");
+
+    app.process_events_once(&mut terminal, into_codes("/[abc]"))?;
+    assert!(app.state.focussed == Glob);
+    assert_eq!(app.window.glob.as_ref().unwrap().input, "[abc]");
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(app.state.focussed == Main);
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(app.state.focussed == Glob);
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Esc]))?;
+
+    app.process_events_once(&mut terminal, into_codes("x"))?;
+    assert_eq!(app.window.mark.as_ref().unwrap().marked().len(), 2);
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(
+        app.state.focussed == Main,
+        "adding marks keeps the sidebar minimized"
+    );
+    assert_eq!(terminal.backend().buffer()[(38, 11)].symbol(), "2");
+    app.process_events_once(&mut terminal, into_codes("?"))?;
+    assert!(app.state.focussed == Help);
+    assert_eq!(app.window.help.as_ref().unwrap().scroll, help_scroll);
+
+    app.process_events_once(&mut terminal, into_codes("]]"))?;
+    assert!(app.state.focussed == Main, "restoring does not move focus");
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab, KeyCode::Tab]))?;
+    assert!(app.state.focussed == Mark);
+    assert!(app.window.mark.as_ref().unwrap().has_focus());
+    app.process_events_once(&mut terminal, into_codes("]"))?;
+    assert!(app.state.focussed == Main);
+    assert!(!app.window.mark.as_ref().unwrap().has_focus());
+    assert_eq!(app.window.mark.as_ref().unwrap().marked().len(), 2);
+    Ok(())
+}
+
+#[test]
+fn right_pane_toggle_handles_remapping_disabling_and_empty_panes() -> Result<()> {
+    use crate::interactive::state::FocussedPane::{Help, Main};
+
+    let (mut terminal, mut app) = initialized_app_and_terminal_from_fixture(&["sample-02"])?;
+    app.process_events_once(&mut terminal, into_codes("]"))?;
+    app.process_events_once(&mut terminal, into_codes("x"))?;
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(
+        app.window.mark.as_ref().unwrap().has_focus(),
+        "empty toggle has no effect"
+    );
+    app.process_events_once(&mut terminal, into_codes("]"))?;
+    app.process_events_once(&mut terminal, into_codes("a"))?;
+    assert!(app.window.mark.is_none());
+    app.process_events_once(&mut terminal, into_codes("]x"))?;
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(
+        app.state.focussed == Main,
+        "empty panes retain the minimized preference"
+    );
+
+    app.config.keys = toml::from_str::<dua::Config>("[keys]\ntoggle_right_panes = 'z'\n")?.keys;
+    app.process_events_once(&mut terminal, into_codes("]"))?;
+    app.process_events_once(&mut terminal, into_keys([KeyCode::Tab]))?;
+    assert!(
+        app.state.focussed == Main,
+        "remapping replaces the default binding"
+    );
+    app.process_events_once(&mut terminal, into_codes("z?"))?;
+    assert!(app.state.focussed == Help);
+    app.process_events_once(&mut terminal, into_codes("z"))?;
+    assert!(app.state.focussed == Main);
+
+    app.config.keys = toml::from_str::<dua::Config>("[keys]\ntoggle_right_panes = []\n")?.keys;
+    app.process_events_once(&mut terminal, into_codes("?]"))?;
+    assert!(
+        app.state.focussed == Help,
+        "disabled binding does not minimize"
+    );
+    Ok(())
+}
+
+#[test]
 fn init_from_pdu_results() -> Result<()> {
     use crate::interactive::app::tests::utils::new_test_terminal;
     let _terminal = new_test_terminal()?;

--- a/src/interactive/widgets/glob.rs
+++ b/src/interactive/widgets/glob.rs
@@ -122,6 +122,10 @@ impl GlobPane {
         buffer: &mut Buffer,
         cursor: &mut Cursor,
     ) {
+        if area.width < 4 || area.height < 3 {
+            cursor.show = false;
+            return;
+        }
         let GlobPaneProps {
             border_style,
             has_focus,

--- a/src/interactive/widgets/help.rs
+++ b/src/interactive/widgets/help.rs
@@ -139,6 +139,11 @@ impl HelpPane {
                     );
                 }
                 hotkey(keys.cycle_panes.to_string(), t.pane_tab, Some(t.pane_tab_2));
+                hotkey(
+                    keys.toggle_right_panes.to_string(),
+                    t.pane_toggle_right_panes,
+                    None,
+                );
                 hotkey(keys.toggle_help.to_string(), t.pane_help_toggle, None);
                 spacer();
             }
@@ -313,6 +318,23 @@ mod tests {
     }
 
     #[test]
+    fn right_side_toggle_is_documented() {
+        assert!(
+            rendered(Language::English).contains("] => Minimize or restore the entire right side.")
+        );
+        for (binding, expected) in [("\"alt+]\"", "Alt + ]"), ("[]", "<unmapped>")] {
+            let config: dua::Config =
+                toml::from_str(&format!("[keys]\ntoggle_right_panes = {binding}"))
+                    .expect("valid key configuration");
+            assert!(
+                rendered_with_keys(Language::English, &config.keys).contains(&format!(
+                    "{expected} => Minimize or restore the entire right side."
+                ))
+            );
+        }
+    }
+
+    #[test]
     fn japanese_replaces_the_english_strings() {
         let en = rendered(Language::English);
         let ja = rendered(Language::Japanese);
@@ -341,6 +363,7 @@ mod tests {
         for expected in [
             german.pane_q_quit,
             german.pane_tab_2,
+            german.pane_toggle_right_panes,
             german.disp_sort_mtime,
             german.disp_show_mtime_2,
             german.disp_sort_count,

--- a/src/interactive/widgets/i18n.rs
+++ b/src/interactive/widgets/i18n.rs
@@ -110,6 +110,7 @@ pub struct HelpText {
     pub pane_qesc_close_2: &'static str,
     pub pane_tab: &'static str,
     pub pane_tab_2: &'static str,
+    pub pane_toggle_right_panes: &'static str,
     pub pane_help_toggle: &'static str,
 
     pub nav_title: &'static str,
@@ -172,8 +173,9 @@ const EN: HelpText = HelpText {
     pane_esc_close_2: "In main view, ascend to the parent directory.",
     pane_qesc_close: "Close the current pane.",
     pane_qesc_close_2: "Closes the program if no pane is open.",
-    pane_tab: "Cycle between all open panes.",
+    pane_tab: "Cycle between visible panes.",
     pane_tab_2: "Activate 'Marked Items' pane to delete selected files.",
+    pane_toggle_right_panes: "Minimize or restore the entire right side.",
     pane_help_toggle: "Show or hide this help pane.",
 
     nav_title: "Navigation",
@@ -236,8 +238,9 @@ const JA: HelpText = HelpText {
     pane_esc_close_2: "メイン画面では親ディレクトリへ移動する。",
     pane_qesc_close: "現在のペインを閉じる。",
     pane_qesc_close_2: "開いているペインがなければプログラムを終了する。",
-    pane_tab: "開いているペインを順番に切り替える。",
+    pane_tab: "表示中のペインを順番に切り替える。",
     pane_tab_2: "「マーク済み」ペインを有効化して選択ファイルを削除する。",
+    pane_toggle_right_panes: "右側全体を最小化または元に戻す。",
     pane_help_toggle: "このヘルプペインの表示/非表示を切り替える。",
 
     nav_title: "ナビゲーション",
@@ -300,8 +303,9 @@ const KO: HelpText = HelpText {
     pane_esc_close_2: "기본 화면에서는 상위 디렉터리로 이동합니다.",
     pane_qesc_close: "현재 패널을 닫습니다.",
     pane_qesc_close_2: "열린 패널이 없으면 프로그램을 종료합니다.",
-    pane_tab: "열린 모든 패널을 순환합니다.",
+    pane_tab: "표시된 패널 사이에서 순서대로 전환합니다.",
     pane_tab_2: "'표시된 항목' 패널을 활성화하여 선택한 파일을 삭제합니다.",
+    pane_toggle_right_panes: "오른쪽 전체를 최소화하거나 복원합니다.",
     pane_help_toggle: "이 도움말 패널을 표시하거나 숨깁니다.",
 
     nav_title: "탐색",
@@ -364,8 +368,9 @@ const ZH: HelpText = HelpText {
     pane_esc_close_2: "在主视图中，返回上级目录。",
     pane_qesc_close: "关闭当前面板。",
     pane_qesc_close_2: "如果没有打开的面板，则退出程序。",
-    pane_tab: "在所有打开的面板之间循环切换。",
+    pane_tab: "在可见面板之间循环切换。",
     pane_tab_2: "激活“已标记项目”面板以删除所选文件。",
+    pane_toggle_right_panes: "最小化或还原整个右侧区域。",
     pane_help_toggle: "显示或隐藏此帮助面板。",
 
     nav_title: "导航",
@@ -428,8 +433,9 @@ const DE: HelpText = HelpText {
     pane_esc_close_2: "In der Hauptansicht zum übergeordneten Verzeichnis wechseln.",
     pane_qesc_close: "Aktuellen Bereich schließen.",
     pane_qesc_close_2: "Beendet das Programm, wenn kein Bereich geöffnet ist.",
-    pane_tab: "Zwischen allen geöffneten Bereichen wechseln.",
+    pane_tab: "Zwischen sichtbaren Bereichen wechseln.",
     pane_tab_2: "„Markierte Einträge“ zum Löschen gewählter Dateien öffnen.",
+    pane_toggle_right_panes: "Gesamte rechte Seite minimieren oder wiederherstellen.",
     pane_help_toggle: "Diesen Hilfebereich ein- oder ausblenden.",
 
     nav_title: "Navigation",
@@ -501,6 +507,8 @@ pub struct UiText {
     pub glob_cancel: &'static str,
     pub glob_empty: &'static str,
 
+    pub marked_label: &'static str,
+    pub toggle_collapse: &'static str,
     pub mark_snapshot_read_only: &'static str,
     pub mark_no_destructive_keys: &'static str,
     #[cfg(feature = "trash-move")]
@@ -803,6 +811,8 @@ const EN_UI: UiText = UiText {
     glob_case: "case",
     glob_cancel: "cancel",
     glob_empty: "Glob was empty or only whitespace",
+    marked_label: "Marked",
+    toggle_collapse: "toggle-collapse",
     mark_snapshot_read_only: " Snapshot is read-only; marked entries cannot be deleted ",
     mark_no_destructive_keys: " No destructive keys are mapped; marked entries are safe ",
     #[cfg(feature = "trash-move")]
@@ -865,6 +875,8 @@ const JA_UI: UiText = UiText {
     glob_case: "大小",
     glob_cancel: "取消",
     glob_empty: "glob が空か空白のみです",
+    marked_label: "マーク済み",
+    toggle_collapse: "折りたたみ切替",
     mark_snapshot_read_only: " スナップショットは読み取り専用のため削除できません ",
     mark_no_destructive_keys: " 削除キーは未設定です。マーク済み項目は安全です ",
     #[cfg(feature = "trash-move")]
@@ -927,6 +939,8 @@ const KO_UI: UiText = UiText {
     glob_case: "대소문자",
     glob_cancel: "취소",
     glob_empty: "glob이 비어 있거나 공백뿐입니다",
+    marked_label: "표시됨",
+    toggle_collapse: "접기 전환",
     mark_snapshot_read_only: " 스냅샷은 읽기 전용이므로 표시된 항목을 삭제할 수 없습니다 ",
     mark_no_destructive_keys: " 삭제 키가 지정되지 않아 표시된 항목은 안전합니다 ",
     #[cfg(feature = "trash-move")]
@@ -989,6 +1003,8 @@ const ZH_UI: UiText = UiText {
     glob_case: "大小写",
     glob_cancel: "取消",
     glob_empty: "glob 为空或仅包含空白",
+    marked_label: "已标记",
+    toggle_collapse: "切换折叠",
     mark_snapshot_read_only: " 快照为只读；无法删除已标记条目 ",
     mark_no_destructive_keys: " 未映射破坏性按键；已标记条目是安全的 ",
     #[cfg(feature = "trash-move")]
@@ -1051,6 +1067,8 @@ const DE_UI: UiText = UiText {
     glob_case: "case",
     glob_cancel: "cancel",
     glob_empty: "Glob ist leer oder enthält nur Leerzeichen",
+    marked_label: "Markiert",
+    toggle_collapse: "ein-/ausklappen",
     mark_snapshot_read_only: " Snapshot ist schreibgeschützt; markierte Einträge sind nicht löschbar ",
     mark_no_destructive_keys: " Keine Lösch-Tasten belegt; markierte Einträge sind sicher ",
     #[cfg(feature = "trash-move")]

--- a/src/interactive/widgets/main.rs
+++ b/src/interactive/widgets/main.rs
@@ -1,21 +1,27 @@
+use crate::interactive::widgets::tui_ext::{
+    draw_text_nowrap_fn,
+    util::{block_width, rect},
+};
 use crate::interactive::{
     DisplayOptions,
     state::{AppState, Cursor, FocussedPane},
     widgets::{
         COLOR_MARKED, Entries, EntriesProps, Footer, FooterProps, GlobPane, GlobPaneProps, Header,
-        HelpPane, HelpPaneProps, MarkPane, MarkPaneProps,
+        HelpPane, HelpPaneProps, Language, MarkPane, MarkPaneProps,
     },
 };
-use Constraint::{Length, Max, Percentage};
+use Constraint::{Length, Max, Min, Percentage};
 use FocussedPane::{Glob, Help, Main, Mark};
 use std::borrow::Borrow;
 use std::path::PathBuf;
 use tui::buffer::Buffer;
 use tui::{
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::Modifier,
     style::{Color, Style},
 };
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 pub struct MainWindowProps<'a> {
     pub current_path: PathBuf,
@@ -34,6 +40,8 @@ pub struct MainWindow {
     pub entries: Entries,
     pub mark: Option<MarkPane>,
     pub glob: Option<GlobPane>,
+    /// Keep open right-hand panes as a narrow shared sidebar while retaining their contents.
+    pub right_panes_minimized: bool,
 }
 
 impl MainWindow {
@@ -55,6 +63,12 @@ impl MainWindow {
             config,
         } = props.borrow();
         let language = state.language;
+        if let Some(pane) = self.mark.as_mut() {
+            let has_focus = state.focussed == Mark;
+            if pane.has_focus() != has_focus {
+                pane.set_focus(has_focus);
+            }
+        }
 
         let (entries_style, help_style, mark_style, glob_style) = pane_border_style(state.focussed);
         let (header_area, content_area, footer_area) = main_window_layout(area);
@@ -66,7 +80,8 @@ impl MainWindow {
         Header::render(language, header_bg_color, header_area, buffer);
 
         let (entries_area, help_pane, mark_pane) = {
-            let (left_pane, right_pane) = content_layout(content_area);
+            let (left_pane, right_pane) =
+                content_layout(content_area, self.right_panes_minimized, language);
             match (&mut self.help, &mut self.mark) {
                 (Some(pane), None) => (left_pane, Some((right_pane, pane)), None),
                 (None, Some(pane)) => (left_pane, None, Some((right_pane, pane))),
@@ -90,25 +105,53 @@ impl MainWindow {
         };
 
         if let Some((mark_area, pane)) = mark_pane {
-            let props = MarkPaneProps {
-                border_style: mark_style,
-                format: display.byte_format,
-                root_total_size: *total_bytes,
-                keys: &config.keys,
-                safety_notice,
-                language,
-            };
-            pane.render(props, mark_area, buffer);
+            if self.right_panes_minimized {
+                render_minimized_label(
+                    &format!(
+                        " {} {}",
+                        pane.marked().len(),
+                        language.ui_text().marked_label
+                    ),
+                    mark_area,
+                    buffer,
+                    mark_style,
+                );
+            } else {
+                let props = MarkPaneProps {
+                    border_style: mark_style,
+                    format: display.byte_format,
+                    root_total_size: *total_bytes,
+                    keys: &config.keys,
+                    safety_notice,
+                    language,
+                };
+                pane.render(props, mark_area, buffer);
+                if !matches!(state.focussed, Mark | Glob) {
+                    render_collapse_hint(mark_area, buffer, &config.keys, language);
+                }
+            }
         }
 
         if let Some((help_area, pane)) = help_pane {
-            let props = HelpPaneProps {
-                border_style: help_style,
-                has_focus: matches!(state.focussed, Help),
-                keys: &config.keys,
-                language,
-            };
-            pane.render(props, help_area, buffer);
+            if self.right_panes_minimized {
+                render_minimized_label(
+                    language.help_text().block_title,
+                    help_area,
+                    buffer,
+                    help_style,
+                );
+            } else {
+                let props = HelpPaneProps {
+                    border_style: help_style,
+                    has_focus: matches!(state.focussed, Help),
+                    keys: &config.keys,
+                    language,
+                };
+                pane.render(props, help_area, buffer);
+                if !matches!(state.focussed, Help | Glob) {
+                    render_collapse_hint(help_area, buffer, &config.keys, language);
+                }
+            }
         }
 
         let marked = self.mark.as_ref().map(|pane| pane.marked());
@@ -176,12 +219,81 @@ fn right_pane_layout(right_pane: Rect) -> (Rect, Rect) {
     (regions[0], regions[1])
 }
 
-fn content_layout(content_area: Rect) -> (Rect, Rect) {
+fn content_layout(content_area: Rect, minimized: bool, language: Language) -> (Rect, Rect) {
     let regions = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Percentage(50), Percentage(50)].as_ref())
+        .constraints(if minimized {
+            let label_width = [
+                language.help_text().block_title,
+                language.ui_text().marked_label,
+            ]
+            .into_iter()
+            .flat_map(|label| label.graphemes(true))
+            .map(block_width)
+            .max()
+            .unwrap_or(1);
+            [Min(0), Length(label_width + 2)]
+        } else {
+            [Percentage(50), Percentage(50)]
+        })
         .split(content_area);
     (regions[0], regions[1])
+}
+
+fn render_minimized_label(label: &str, area: Rect, buffer: &mut Buffer, style: Style) {
+    let area = area.intersection(buffer.area).inner(Margin::new(1, 0));
+    if area.is_empty() {
+        return;
+    }
+    let mut graphemes = label.graphemes(true).peekable();
+    for y in area.y..area.bottom() {
+        let Some(grapheme) = graphemes.next() else {
+            break;
+        };
+        let clipped = grapheme.width() > usize::from(area.width)
+            || (y + 1 == area.bottom() && graphemes.peek().is_some());
+        buffer.set_stringn(
+            area.x,
+            y,
+            if clipped { "…" } else { grapheme },
+            usize::from(area.width),
+            style,
+        );
+        if clipped {
+            break;
+        }
+    }
+}
+
+fn render_collapse_hint(
+    area: Rect,
+    buffer: &mut Buffer,
+    keys: &dua::KeysConfig,
+    language: crate::interactive::widgets::Language,
+) {
+    if area.height < 2 || keys.toggle_right_panes.is_empty() {
+        return;
+    }
+    let hint = format!(
+        " {} = {} ",
+        language.ui_text().toggle_collapse,
+        keys.toggle_right_panes.primary(),
+    );
+    let width = block_width(&hint);
+    if width <= area.width.saturating_sub(2) {
+        let bottom = Rect {
+            y: area.bottom() - 1,
+            width: area.width - 1,
+            height: 1,
+            ..area
+        };
+        draw_text_nowrap_fn(
+            rect::snap_to_right(bottom, width),
+            buffer,
+            &hint,
+            |_, _, _| Style::default(),
+        );
+    }
 }
 
 fn mark_safety_notice(
@@ -236,7 +348,220 @@ fn pane_border_style(focused_pane: FocussedPane) -> (Style, Style, Style, Style)
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::interactive::widgets::Language;
+
+    fn render_window(window: &mut MainWindow, area: Rect, language: Language) -> Buffer {
+        render_window_with_focus_and_keys(window, area, language, Main, &dua::Config::default())
+    }
+
+    fn render_window_with_focus_and_keys(
+        window: &mut MainWindow,
+        area: Rect,
+        language: Language,
+        focused: FocussedPane,
+        config: &dua::Config,
+    ) -> Buffer {
+        let mut state = AppState::new(crate::snapshot_walk_options(), Vec::new(), None, false);
+        state.language = language;
+        state.received_events = true;
+        state.focussed = focused;
+        let mut buffer = Buffer::empty(area);
+        window.render(
+            MainWindowProps {
+                current_path: PathBuf::from("."),
+                entries_traversed: 0,
+                total_bytes: 0,
+                start: std::time::Instant::now(),
+                elapsed: None,
+                display: DisplayOptions::new(dua::ByteFormat::Bytes),
+                state: &state,
+                config,
+            },
+            area,
+            &mut buffer,
+            &mut Cursor::default(),
+        );
+        buffer
+    }
+
+    #[test]
+    fn collapse_hints_only_show_on_unfocused_pane_borders() {
+        let mut window = MainWindow {
+            help: Some(HelpPane::default()),
+            mark: Some(MarkPane::default()),
+            ..Default::default()
+        };
+        for focused in [Main, Help, Mark, Help, Glob, Main] {
+            let buffer = render_window_with_focus_and_keys(
+                &mut window,
+                Rect::new(0, 0, 120, 24),
+                Language::English,
+                focused,
+                &dua::Config::default(),
+            );
+            let row = |y| {
+                (60..120)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            };
+            assert_eq!(
+                row(11).contains("toggle-collapse = ]"),
+                !matches!(focused, Help | Glob)
+            );
+            assert_eq!(
+                row(22).contains("toggle-collapse = ]"),
+                !matches!(focused, Mark | Glob)
+            );
+            assert_eq!(window.mark.as_ref().unwrap().has_focus(), focused == Mark);
+        }
+        for (binding, expected) in [("'ctrl+b'", true), ("[]", false)] {
+            let config: dua::Config =
+                toml::from_str(&format!("[keys]\ntoggle_right_panes = {binding}")).unwrap();
+            let buffer = render_window_with_focus_and_keys(
+                &mut window,
+                Rect::new(0, 0, 120, 24),
+                Language::English,
+                Main,
+                &config,
+            );
+            let row: String = (60..120).map(|x| buffer[(x, 22)].symbol()).collect();
+            assert_eq!(row.contains("toggle-collapse = Ctrl + b"), expected);
+            assert!(!row.contains("toggle-collapse = ]"));
+            assert!(!row.contains("<unmapped>"));
+        }
+        let buffer = render_window(&mut window, Rect::new(0, 0, 40, 24), Language::English);
+        let row: String = (20..40).map(|x| buffer[(x, 22)].symbol()).collect();
+        assert!(row.chars().all(|c| matches!(c, '└' | '─' | '┘')));
+        let buffer = render_window(&mut window, Rect::new(0, 0, 120, 24), Language::German);
+        let row: String = (60..120).map(|x| buffer[(x, 22)].symbol()).collect();
+        assert!(row.contains("ein-/ausklappen = ]"));
+    }
+
+    #[test]
+    fn minimized_help_uses_three_column_sidebar_with_padding() {
+        let mut window = MainWindow {
+            help: Some(HelpPane::default()),
+            right_panes_minimized: true,
+            ..Default::default()
+        };
+        let buffer = render_window(&mut window, Rect::new(0, 0, 30, 10), Language::English);
+        for (row, character) in ["H", "e", "l", "p"].into_iter().enumerate() {
+            assert_eq!(buffer[(27, row as u16 + 1)].symbol(), " ");
+            assert_eq!(buffer[(28, row as u16 + 1)].symbol(), character);
+            assert_eq!(buffer[(29, row as u16 + 1)].symbol(), " ");
+        }
+        assert_eq!(
+            buffer[(26, 2)].symbol(),
+            "│",
+            "entries reclaim the released columns"
+        );
+    }
+
+    #[test]
+    fn minimized_marked_and_shared_sidebars_use_available_height() {
+        for help in [false, true] {
+            let mut window = MainWindow {
+                help: help.then(HelpPane::default),
+                mark: Some(MarkPane::default()),
+                right_panes_minimized: true,
+                ..Default::default()
+            };
+            let buffer = render_window(&mut window, Rect::new(0, 0, 30, 10), Language::English);
+            let (start, letters): (u16, &[_]) = if help {
+                (5, &[" ", "0", " ", "…"])
+            } else {
+                (1, &[" ", "0", " ", "M", "a", "r", "k", "…"])
+            };
+            for (row, letter) in letters.iter().enumerate() {
+                assert_eq!(buffer[(27, start + row as u16)].symbol(), " ");
+                assert_eq!(buffer[(28, start + row as u16)].symbol(), *letter);
+                assert_eq!(buffer[(29, start + row as u16)].symbol(), " ");
+            }
+            if help {
+                assert_eq!(buffer[(28, 1)].symbol(), "H");
+                assert_eq!(buffer[(28, 4)].symbol(), "p");
+            }
+        }
+    }
+
+    #[test]
+    fn minimized_labels_render_wide_translations_and_intact_graphemes() {
+        let mut help = MainWindow {
+            help: Some(HelpPane::default()),
+            right_panes_minimized: true,
+            ..Default::default()
+        };
+        let buffer = render_window(&mut help, Rect::new(0, 0, 30, 10), Language::Japanese);
+        for (row, grapheme) in ["ヘ", "ル", "プ"].into_iter().enumerate() {
+            assert_eq!(buffer[(26, row as u16 + 1)].symbol(), " ");
+            assert_eq!(buffer[(27, row as u16 + 1)].symbol(), grapheme);
+            assert_eq!(buffer[(28, row as u16 + 1)].symbol(), " ");
+            assert_eq!(buffer[(29, row as u16 + 1)].symbol(), " ");
+        }
+        let mut marked = MainWindow {
+            mark: Some(MarkPane::default()),
+            right_panes_minimized: true,
+            ..Default::default()
+        };
+        let buffer = render_window(&mut marked, Rect::new(0, 0, 30, 10), Language::Chinese);
+        for (row, grapheme) in [" ", "0", " ", "已", "标", "记"].into_iter().enumerate() {
+            assert_eq!(buffer[(26, row as u16 + 1)].symbol(), " ");
+            assert_eq!(buffer[(27, row as u16 + 1)].symbol(), grapheme);
+            assert_eq!(buffer[(29, row as u16 + 1)].symbol(), " ");
+        }
+
+        let area = Rect::new(3, 4, 4, 3);
+        let mut buffer = Buffer::empty(area);
+        render_minimized_label("e\u{301}界!", area, &mut buffer, Style::default());
+        assert_eq!(buffer[(4, 4)].symbol(), "e\u{301}");
+        assert_eq!(buffer[(4, 5)].symbol(), "界");
+        assert_eq!(buffer[(4, 6)].symbol(), "!");
+        for row in 4..7 {
+            assert_eq!(buffer[(3, row)].symbol(), " ");
+            assert_eq!(buffer[(6, row)].symbol(), " ");
+        }
+    }
+
+    #[test]
+    fn minimized_layout_handles_tiny_and_wide_areas_without_reserving_absent_panes() {
+        let (entries, sidebar) = content_layout(Rect::new(5, 6, 600, 14), true, Language::English);
+        assert_eq!(entries, Rect::new(5, 6, 597, 14));
+        assert_eq!(sidebar, Rect::new(602, 6, 3, 14));
+
+        let mut absent = MainWindow::default();
+        let area = Rect::new(0, 0, 30, 10);
+        let expanded = render_window(&mut absent, area, Language::English);
+        absent.right_panes_minimized = true;
+        assert_eq!(
+            render_window(&mut absent, area, Language::English),
+            expanded
+        );
+
+        for width in 0..=4 {
+            for height in 0..=5 {
+                let mut window = MainWindow {
+                    help: Some(HelpPane::default()),
+                    mark: Some(MarkPane::default()),
+                    glob: Some(GlobPane::default()),
+                    right_panes_minimized: true,
+                    ..Default::default()
+                };
+                render_window(
+                    &mut window,
+                    Rect::new(2, 3, width, height),
+                    Language::Japanese,
+                );
+                assert!(window.help.is_some() && window.mark.is_some() && window.glob.is_some());
+            }
+        }
+
+        let area = Rect::new(3, 4, 3, 2);
+        let mut buffer = Buffer::empty(area);
+        render_minimized_label("帮助", area, &mut buffer, Style::default());
+        assert_eq!(buffer[(3, 4)].symbol(), " ");
+        assert_eq!(buffer[(4, 4)].symbol(), "…");
+        assert_eq!(buffer[(5, 4)].symbol(), " ");
+        assert_eq!(buffer[(4, 5)].symbol(), " ");
+    }
 
     #[test]
     fn marks_are_only_dangerous_when_a_destructive_action_is_available() {

--- a/src/interactive/widgets/mark.rs
+++ b/src/interactive/widgets/mark.rs
@@ -68,7 +68,6 @@ pub struct MarkPaneProps<'a> {
 }
 
 impl MarkPane {
-    #[cfg(test)]
     pub fn has_focus(&self) -> bool {
         self.has_focus
     }


### PR DESCRIPTION
# Tasks

* [x] refackiew

# Codex

## Behavior

Add a configurable `toggle_right_panes` action, defaulting to `]`, that
minimizes or restores the shared Help and Marked sidebar. Minimized panes
display their translated names vertically with a blank column on each side:
three columns for single-width labels and four for double-width labels.
The main list uses the remaining terminal width.

- Keep Help and Marked stacked when both exist, preserving their contents.
- Return focus to the main list on collapse and skip minimized panes with
  Tab. Restoring with `]` keeps focus in the main list; `?` restores and
  focuses Help without resetting its scroll position.
- Keep marks and quit protection intact. Do not dispatch deletion actions
  to a minimized Mark pane, and preserve literal brackets in search input.
- Retain the minimized preference for the session, including while marking
  more entries or temporarily having no right-hand panes. With no panes,
  `]` is a no-op and the sidebar consumes no space.
- Advertise `toggle-collapse = ]` on the bottom border of each unfocused,
  expanded Help or Mark pane, using the configured key and translated label.
  Hide the hint during search input, when disabled, or when it cannot fit
  between the border corners.

## Rendering and configuration

Reuse the existing panel instances, layout, key-binding parser, and Unicode
dependencies. Render one grapheme per row, support double-width translated
characters, and indicate clipped labels with an ellipsis. Skip search-pane
rendering when its margins and cursor cannot fit the available area.

Synchronize Mark's stored focus with the application's current pane only
when they differ. This removes stale Mark controls after leaving that pane
without resetting its selection on ordinary redraws.

Document the shortcut in the default configuration and README, and add
localized labels and help for all five supported languages. The binding can
be remapped or disabled like existing actions.

## Validation

Regression tests first reproduced `]` leaving focus in Help, rendering the
full pane instead of a narrow label, missing collapse hints, and missing
label padding. Passing journeys cover focus, mark preservation, deletion blocking, search input,
remapped and disabled bindings, and empty-pane behavior. Render tests cover
one or both panels, wide and combining graphemes, clipping, hint visibility,
translated labels, and tiny or very wide terminals.

- `make check-pre-push`
- `cargo test --bin dua interactive::widgets::main::tests`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Linux, macOS, and Windows CI passed for this code.
